### PR TITLE
feat: add comprehensive Starship prompt configuration

### DIFF
--- a/config/starship.toml
+++ b/config/starship.toml
@@ -1,2 +1,116 @@
+# Starship prompt configuration
+# Format defines the order of modules from left to right
+format = """
+$os\
+$directory\
+$git_branch\
+$git_status\
+$nodejs\
+$bun\
+$deno\
+$rust\
+$python\
+$direnv\
+$cmd_duration\
+$line_break\
+$character"""
+
+# OS module - displays operating system icon
+[os]
+format = "[$symbol]($style) "
+style = "bold white"
+disabled = false
+
+[os.symbols]
+Linux = "🐧"
+Macos = "🍎"
+Ubuntu = "🎯"
+Unknown = "❓"
+Windows = "🪟"
+
+# Directory module - current working directory
+[directory]
+truncation_length = 3
+truncate_to_repo = false
+format = "[$path]($style) "
+style = "bold cyan"
+read_only = " 🔒"
+
+# Git branch module
+[git_branch]
+symbol = ""
+format = "[$symbol $branch]($style) "
+style = "bold purple"
+
+# Git status module - shows repository status
+[git_status]
+format = '([\[$all_status$ahead_behind\]]($style) )'
+style = "bold yellow"
+conflicted = "=${count}"
+ahead = "⇡${count}"
+behind = "⇣${count}"
+diverged = "⇕⇡${ahead_count}⇣${behind_count}"
+untracked = "?${count}"
+stashed = "\\$${count}"
+modified = "!${count}"
+staged = "+${count}"
+renamed = "»${count}"
+deleted = "✘${count}"
+
+# Node.js module
 [nodejs]
-format = '[$version](bold green) '
+format = "[$symbol$version]($style) "
+symbol = "⬢ "
+style = "bold green"
+detect_extensions = ["js", "mjs", "cjs", "ts", "mts", "cts"]
+detect_files = ["package.json", ".node-version", ".nvmrc"]
+detect_folders = ["node_modules"]
+
+# Bun module
+[bun]
+format = "[$symbol$version]($style) "
+symbol = "🥟 "
+style = "bold yellow"
+detect_files = ["bun.lockb", "bunfig.toml", "bun.lock"]
+
+# Deno module
+[deno]
+format = "[$symbol$version]($style) "
+symbol = "🦕 "
+style = "bold blue"
+detect_files = ["deno.json", "deno.jsonc", "deno.lock", "mod.ts", "deps.ts"]
+
+# Rust module
+[rust]
+format = "[$symbol$version]($style) "
+symbol = "🦀 "
+style = "bold red"
+detect_files = ["Cargo.toml", "Cargo.lock"]
+detect_extensions = ["rs"]
+
+# Python module
+[python]
+format = "[$symbol$version]($style) "
+symbol = "🐍 "
+style = "bold blue"
+detect_extensions = ["py"]
+detect_files = ["requirements.txt", "pyproject.toml", "Pipfile", ".python-version"]
+
+# Direnv module - shows if direnv is active
+[direnv]
+format = "[\\[$symbol$state\\]]($style) "
+symbol = "direnv"
+style = "bold cyan"
+disabled = false
+detect_files = [".envrc"]
+
+# Command duration - shows execution time for long commands
+[cmd_duration]
+min_time = 5000  # Show if command takes more than 5 seconds
+format = "took [$duration]($style) "
+style = "bold yellow"
+
+# Character module - the prompt symbol
+[character]
+success_symbol = "[➜](bold green)"
+error_symbol = "[✗](bold red)"


### PR DESCRIPTION
- Configure display order with left-to-right module arrangement
- Add OS module with platform-specific icons (Linux, macOS, Ubuntu)
- Enhance directory module with truncation and read-only indicators
- Add Git modules for branch display and detailed status indicators
- Configure runtime modules with custom icons:
  - Node.js (⬢) with package.json detection
  - Bun (🥟) with lockfile detection
  - Deno (🦕) with TypeScript module detection
  - Rust (🦀) with Cargo file detection
  - Python (🐍) with requirements/pyproject detection
- Add direnv module for environment variable management
- Configure command duration display for long-running commands
- Customize prompt characters for success/error states
- Fix Git stash escaping and direnv bracket formatting

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>