### PR TITLE
Feat/fcd-interactive-navigation

### DIFF
--- a/scripts/fcd
+++ b/scripts/fcd
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+# fcd - Fuzzy Change Directory
+# Interactive directory navigation using fzf
+# Works with both bash and zsh
+
+fcd() {
+  local current_path="${1:-$(pwd)}"
+  
+  while true; do
+    # Build the directory list as a string
+    local dirs_string=""
+    
+    # Add control options
+    dirs_string="cd\n"
+    
+    # Add parent directory if not at root
+    if [[ "$current_path" != "/" ]]; then
+      dirs_string="${dirs_string}../\n"
+    fi
+    
+    # Add subdirectories
+    if [[ -d "$current_path" ]]; then
+      # Use find for compatibility with both shells
+      while IFS= read -r dir; do
+        local basename="${dir##*/}"
+        dirs_string="${dirs_string}${basename}/\n"
+      done < <(find "$current_path" -maxdepth 1 -type d ! -path "$current_path" 2>/dev/null | sort)
+    fi
+    
+    # Setup preview command
+    local preview_cmd='
+      selected={}
+      current_path="'"$current_path"'"
+      if [[ "$selected" == "cd" ]]; then
+        echo "📁 Current: $current_path"
+        echo ""
+        echo "Press ENTER to change to this directory"
+      elif [[ "$selected" == "../" ]]; then
+        parent="$(dirname "$current_path")"
+        echo "📁 Parent: $parent"
+        echo ""
+        ls -la "$parent" 2>/dev/null | head -20
+      else
+        target="$current_path/${selected%/}"
+        if [[ -d "$target" ]]; then
+          echo "📁 Directory: $target"
+          echo ""
+          ls -la "$target" 2>/dev/null | head -20
+        fi
+      fi
+    '
+    
+    # Show fzf selector with fresh instance
+    local selected
+    selected=$(echo -e "$dirs_string" | sed '/^$/d' | fzf \
+      --height 80% \
+      --reverse \
+      --header "📍 Current: $current_path (ESC to cancel)" \
+      --preview "$preview_cmd" \
+      --preview-window right:50% \
+      --bind "esc:abort" \
+      --prompt "Navigate > ")
+    
+    # Handle selection
+    if [[ -z "$selected" ]]; then
+      # Cancelled
+      return 0
+    elif [[ "$selected" == "cd" ]]; then
+      # Change to the current virtual path
+      cd "$current_path" || return 1
+      echo "Changed directory to: $current_path"
+      return 0
+    elif [[ "$selected" == "../" ]]; then
+      # Navigate to parent
+      current_path=$(dirname "$current_path")
+    else
+      # Navigate to subdirectory
+      current_path="$current_path/${selected%/}"
+      # Resolve symlinks and normalize path
+      current_path=$(cd "$current_path" 2>/dev/null && pwd || echo "$current_path")
+    fi
+  done
+}
+
+# Export function based on shell
+if [[ -n "$BASH_VERSION" ]]; then
+  # Running in bash
+  export -f fcd
+elif [[ -n "$ZSH_VERSION" ]]; then
+  # Running in zsh - no need to export
+  :
+fi

--- a/shell/.bashrc
+++ b/shell/.bashrc
@@ -273,3 +273,8 @@ eval "$(mise activate bash)"
 
 # Initialize starship prompt
 eval "$(starship init bash)"
+
+# Interactive directory navigation with fzf
+if [ -f "$HOME/ghq/github.com/ushironoko/dotfiles/scripts/fcd" ]; then
+  source "$HOME/ghq/github.com/ushironoko/dotfiles/scripts/fcd"
+fi

--- a/shell/.zshrc
+++ b/shell/.zshrc
@@ -198,3 +198,8 @@ export PATH="$HOME/.local/bin:$PATH"
 # Starship prompt
 # Initialize starship after mise is activated
 eval "$(starship init zsh)"
+
+# Interactive directory navigation with fzf
+if [ -f "$HOME/ghq/github.com/ushironoko/dotfiles/scripts/fcd" ]; then
+  source "$HOME/ghq/github.com/ushironoko/dotfiles/scripts/fcd"
+fi


### PR DESCRIPTION
- Add sourcing of fcd script in both .bashrc and .zshrc
- Includes conditional check for script existence before sourcing
- Enables interactive directory navigation in both bash and zsh
- Maintains consistency across shell environments

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>