### PR TITLE
add repairing-bit skill

### DIFF
--- a/claude/.claude/skills/repairing-bit/SKILL.md
+++ b/claude/.claude/skills/repairing-bit/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: repairing-bit
+description: Restore session state (plan, target files, in-flight tasks) from bit issues created by the start-work skill. Use when resuming work after Claude Code restart, when the in-memory task list is empty but bit issues exist for the current branch, or when the user mentions "restore session", "repair session", "pick up where I left off", or references a prior bit-issue-tracked session.
+---
+
+# Overview
+
+Reverse companion of the `start-work` skill. `start-work` writes session state (plan, target files, tasks) into bit issues; `repairing-bit` reads them back and rehydrates the in-memory `TaskList`.
+
+Use when the conversation has lost task context (new session, compacted history) but the underlying bit issues still describe ongoing work.
+
+## When to invoke
+
+- User asks to "resume", "restore", "repair", or "continue" a session.
+- A new conversation starts and you suspect prior task issues exist (e.g., user references work from earlier).
+- After context compaction, before resuming any non-trivial change.
+
+Do **not** invoke when no prior session work exists — `start-work` is the right skill for fresh work.
+
+## Issue title contract (must match `start-work`)
+
+| Kind   | Title prefix                                   |
+| ------ | ---------------------------------------------- |
+| Parent | `[plan:<branch-name>#<seq>] <title>`           |
+| Task   | `[task:<branch-name>#<seq>:<task_id>] <title>` |
+
+Both labelled with `session:<branch-name>`.
+
+## Execution flow
+
+### Phase 1: Verify bit CLI
+
+```bash
+command -v bit >/dev/null 2>&1 && bit --version
+```
+
+If absent: report to user, stop. No restoration possible.
+
+### Phase 2: Determine current branch and list open issues
+
+```bash
+git branch --show-current
+bit issue list --open
+```
+
+Optionally narrow with `--label "session:<branch-name>"` if the branch is known.
+
+### Phase 3: Locate the active parent issue
+
+Scan open issues for titles starting with `[plan:<branch-name>#`. Two outcomes:
+
+**(a) Active parent found** → proceed to Phase 4.
+
+**(b) No active parent** → branch has no in-flight session. Inspect recent activity to characterize state:
+
+```bash
+bit issue list --closed --limit 10
+```
+
+Then view: the **most recent `[plan:...]` closed issue** (1 issue) plus **every closed task issue that references it as parent** (filter by title prefix `[task:<that-branch>#<that-seq>:`). For each selected issue run `bit issue view <id>` and `bit issue comment list <id>`. Skip plans/tasks from other branches/seqs unless the user explicitly asks.
+
+Summarize: what was completed, when it was closed (use the latest comment timestamp if no explicit close date is exposed), any open follow-ups mentioned in comments. Then stop — do not fabricate tasks. Report to the user.
+
+### Phase 4: Load parent issue
+
+```bash
+bit issue view <parent_id>
+```
+
+Extract from the body:
+
+- Branch name, worktree path, main repo path (Session Info section).
+- Plan content (Plan section).
+
+Note `<branch-name>#<seq>` for filtering task issues.
+
+### Phase 5: Load sub-issues (open task issues)
+
+Filter open issues whose titles start with `[task:<branch-name>#<seq>:`. For each:
+
+```bash
+bit issue view <task_id>
+bit issue comment list <task_id>
+```
+
+Extract from each body:
+
+- Parent reference (`parent: #<id>`) — sanity check it matches.
+- Target Files list with operation (modify | create | delete).
+- Task Description.
+
+Comments may record scope adjustments (Target Files added/excluded). Apply the latest body as authoritative; comments are audit trail only.
+
+### Phase 6: Report status to user
+
+Before assembling the report, count closed task issues belonging to the same `<branch-name>#<seq>` as the parent:
+
+```bash
+bit issue list --closed --label "session:<branch-name>"
+```
+
+Then filter the result to titles starting with `[task:<branch-name>#<seq>:` — that count is what the report needs. (`--label` narrowing is valid for both `--open` and `--closed` lists.)
+
+Render a compact summary **before** restoring tasks. Include:
+
+- Branch + worktree path.
+- Parent issue id and plan title.
+- Count of open task issues, count of closed task issues for the same `<branch-name>#<seq>` (computed above).
+- Per-open-task: task title, target files, brief description.
+
+Ask the user to confirm if any reconstructed task looks wrong. In auto mode, proceed without confirmation but still show the summary.
+
+### Phase 7: Restore tasks via TaskCreate
+
+For each open task issue (Phase 5), call `TaskCreate` with:
+
+- `subject`: extracted from the issue title (the part after `[task:...:<task_id>]`).
+- `description`: assembled from the issue body — Target Files block + Task Description.
+
+**Important — preserve the issue↔task linkage**: the task id returned by `TaskCreate` is **new** and will not match the original `<task_id>` embedded in the bit issue title. Without re-linking, the `TaskCompleted` hook will fail to auto-close the bit issue when the restored task completes.
+
+Re-link by updating the bit issue title to embed the new task id:
+
+```bash
+bit issue update <task_id_issue> \
+  --title "[task:<branch-name>#<seq>:<NEW_task_id>] <task summary>"
+```
+
+Add an audit comment so the rename is traceable:
+
+```bash
+bit issue comment add <task_id_issue> \
+  --body "Re-linked: task_id <OLD> → <NEW> on session restore"
+```
+
+### Phase 8: Hand off to start-work conventions
+
+Once tasks are restored, work continues under the `start-work` Cross-Session Awareness Protocol (overlap detection, scope-change updates, completion protocol). `repairing-bit` does not own the rest of the lifecycle.
+
+## Error handling
+
+| Situation                                     | Response                                                                                                                                                                                      |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bit` CLI missing                             | Report and stop. No restoration possible.                                                                                                                                                     |
+| `bit issue list` returns "No issues"          | Report "no prior session" and stop.                                                                                                                                                           |
+| Open parent without matching open task issues | Report parent plan only; let user decide whether to recreate tasks.                                                                                                                           |
+| Open task issue with no matching parent       | Orphan — follow `references/examples.md` Example 3: report parent state, list options (standalone restore / parent reopen / close), pause for user input. No side effects until user replies. |
+| Parent body malformed (missing Plan section)  | Restore what is parseable; flag the missing fields in the report.                                                                                                                             |
+| Multiple open parents on the same branch      | List all with seq numbers; ask the user which session to restore.                                                                                                                             |
+| Worktree path in parent body does not exist   | Report the mismatch; do not auto-`cd`. User decides whether to recreate the worktree.                                                                                                         |
+
+## Prohibited (relay/network)
+
+Same restrictions as `start-work` — never run: `bit issue claim` / `unclaim` / `claims` / `watch` / `import`, `bit pr import`, `bit relay serve` / `sync`, `bit clone relay+*`. Restoration is a read-mostly local operation.
+
+## Worked examples
+
+See `references/examples.md` for concrete restoration walk-throughs:
+
+- Single-parent active session restore
+- No-active-parent (recent-history-only) report
+- Orphan task issue handling
+- Re-link audit trail on `TaskCreate` id remap

--- a/claude/.claude/skills/repairing-bit/references/examples.md
+++ b/claude/.claude/skills/repairing-bit/references/examples.md
@@ -1,0 +1,185 @@
+# Worked Examples — repairing-bit
+
+Concrete restoration walk-throughs. Read on demand from `SKILL.md`.
+
+## Example 1: Single-parent active session restore
+
+Setup: branch `feat/payments`, prior session interrupted with parent issue and 3 task issues (1 already closed, 2 open).
+
+```bash
+git branch --show-current
+# → feat/payments
+
+bit issue list --open --label "session:feat/payments"
+# → #42 [plan:feat/payments#1] Add Stripe checkout flow
+# → #44 [task:feat/payments#1:t_abc] Wire up webhook handler
+# → #45 [task:feat/payments#1:t_def] Add idempotency keys
+
+bit issue view 42
+# Plan body extracted: 5-step plan, worktree at /Users/me/wt/payments
+```
+
+For each open task issue:
+
+```bash
+bit issue view 44
+# Body:
+# parent: #42
+# ## Target Files
+# - src/webhook/stripe.ts (modify)
+# - src/webhook/types.ts  (create)
+# ## Task Description
+# Implement webhook signature verification and event dispatch.
+
+bit issue view 45
+# Body:
+# parent: #42
+# ## Target Files
+# - src/webhook/idempotency.ts (create)
+# - src/webhook/stripe.ts (modify)
+# ## Task Description
+# Persist idempotency keys to prevent duplicate event processing.
+```
+
+Report to user:
+
+```
+Restored session: feat/payments (parent #42, seq 1)
+  Plan: Add Stripe checkout flow
+  Worktree: /Users/me/wt/payments
+  Open tasks: 2 (1 already completed)
+
+  [#44] Wire up webhook handler
+    targets: src/webhook/stripe.ts (modify), src/webhook/types.ts (create)
+  [#45] Add idempotency keys
+    targets: src/webhook/idempotency.ts (create), src/webhook/stripe.ts (modify)
+```
+
+Restore via `TaskCreate`:
+
+```
+TaskCreate(subject="Wire up webhook handler", description="...")  → returns task_id "1"
+TaskCreate(subject="Add idempotency keys",    description="...")  → returns task_id "2"
+```
+
+Re-link bit issues to the new task ids:
+
+```bash
+bit issue update 44 --title "[task:feat/payments#1:1] Wire up webhook handler"
+bit issue comment add 44 --body "Re-linked: task_id t_abc → 1 on session restore"
+
+bit issue update 45 --title "[task:feat/payments#1:2] Add idempotency keys"
+bit issue comment add 45 --body "Re-linked: task_id t_def → 2 on session restore"
+```
+
+## Example 2: No active parent — recent history report only
+
+Setup: branch `main`, no open `[plan:...]` issues.
+
+```bash
+bit issue list --open
+# → No issues
+
+bit issue list --closed --limit 5
+# → #38 [plan:fix/race-cond#1]   Fix metrics race
+# → #37 [task:fix/race-cond#1:5] Add mutex around counter
+# → #36 [task:fix/race-cond#1:4] Add regression test
+```
+
+Inspect each:
+
+```bash
+bit issue view 38
+bit issue comment list 38
+# Last comment: "Done: shipped in PR #112"
+```
+
+Report:
+
+```
+No active session for branch `main`.
+Recent activity (last 5 closed):
+  #38 [plan:fix/race-cond#1] Fix metrics race — closed, shipped in PR #112
+  #37 task: Add mutex around counter — closed
+  #36 task: Add regression test — closed
+No tasks restored. Run /start-work for new work.
+```
+
+Stop. Do not fabricate tasks.
+
+## Example 3: Orphan task issue (parent missing or closed)
+
+Setup: open task issue `#51` whose `parent: #50` was closed manually.
+
+```bash
+bit issue list --open
+# → #51 [task:exp/cleanup#2:t_xyz] Remove dead config flag
+
+bit issue view 51
+# parent: #50
+bit issue view 50
+# (closed)
+```
+
+Report:
+
+```
+Found 1 orphan task issue:
+  [#51] Remove dead config flag (parent #50 is closed)
+
+Options:
+  1. Restore as standalone task (will not auto-close on TaskCompleted hook unless re-linked).
+  2. Reopen parent #50 if work is resumable.
+  3. Close #51 if obsolete.
+
+Awaiting user direction.
+```
+
+Pause for user input before any side effect.
+
+## Example 4: Multiple parents on same branch
+
+Setup: two open `[plan:feat/auth#...]` issues exist (seq 2 and seq 3).
+
+```bash
+bit issue list --open --label "session:feat/auth"
+# → #60 [plan:feat/auth#2] Refactor token store
+# → #71 [plan:feat/auth#3] Add OAuth provider
+```
+
+Report:
+
+```
+Multiple open sessions on `feat/auth`:
+  [#60] seq 2 — Refactor token store (worktree: /Users/me/wt/auth-2)
+  [#71] seq 3 — Add OAuth provider   (worktree: /Users/me/wt/auth-3)
+
+Which session should I restore? (60 / 71)
+```
+
+Wait for user choice. Restore only the chosen one's task tree.
+
+## Example 5: Malformed parent body
+
+Setup: parent issue body is missing the `## Plan` section (e.g., manual edit gone wrong).
+
+```bash
+bit issue view 80
+# Body has Session Info but no Plan section.
+```
+
+Report what is recoverable:
+
+```
+Restored session: feat/cache#1 (parent #80)
+  Worktree: /Users/me/wt/cache
+  ⚠ Plan section missing from parent body — only Session Info recovered.
+
+Open tasks: 1
+  [#81] Wire LRU eviction
+    targets: src/cache/lru.ts (create)
+
+Proceeding with task restore. Plan context unavailable; refer to git log if needed.
+```
+
+Continue with task restoration but flag the gap.


### PR DESCRIPTION
Restore session state (plan, target files, in-flight tasks) from bit issues created by the start-work skill. Companion to start-work — reads back what start-work wrote.