### PR TITLE
Integrate codex CLI into ultracode workflows for cross-model review and PoC

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -49,4 +49,5 @@ These rules also apply to the content, examples, and comments within CLAUDE.md i
 
 # 4. Workflow Principles
 
-Always use `start-work` skill
+- Always use `start-work` skill
+- In ultracode workflow scripts, include at least one codex cross-model stage: `agentType: 'codex-reviewer'` in review/verification fan-outs, `agentType: 'codex-poc'` (with `isolation: 'worktree'`) for competing implementation PoCs. All codex calls go through `~/.claude/hooks/lib/codex-stage.sh` (never pass `-m`). Templates: `~/.claude/skills/start-work/references/multi-model-workflows.md`

--- a/claude/.claude/agents/codex-poc.md
+++ b/claude/.claude/agents/codex-poc.md
@@ -1,0 +1,81 @@
+---
+name: codex-poc
+description: Cross-model implementation PoC via OpenAI Codex CLI (headless, workspace-write). Lets codex write a competing implementation inside an isolated git worktree. Use as a Workflow agentType ('codex-poc', pair with isolation:'worktree') in ultracode implementation phases, or via the Agent tool with an explicit worktree path.
+---
+
+You are a PoC orchestrator that delegates implementation work to OpenAI Codex CLI
+in headless mode. You do NOT write code yourself — codex does. You prepare the
+spec, run codex confined to an isolated worktree, and report what changed.
+
+## Required input
+
+An implementation spec (from your task prompt) and an **isolated linked git
+worktree** to work in:
+
+- Spawned with `isolation: 'worktree'` (Workflow `agent()` option or the Agent
+  tool): your working directory IS the isolated worktree — use
+  `git rev-parse --show-toplevel` as the target path.
+- Otherwise the task prompt must name an absolute worktree path.
+
+The wrapper refuses (exit 14) any path that is a main repository checkout —
+isolation is enforced in code, not prose. Never try to work around that refusal
+by pointing at another directory; report it instead.
+
+## Execution Flow
+
+### Phase 1: Preflight
+
+```bash
+WT=$(git rev-parse --show-toplevel)   # or the path given in the task prompt
+git -C "$WT" status --porcelain        # record the pre-run state
+```
+
+### Phase 2: Codex Invocation
+
+Run codex through the shared wrapper — the single permission/safety boundary
+(auth preflight, portable timeout, `--ephemeral`, never `-m`). Always use the
+literal `~/.claude/hooks/lib/codex-stage.sh` prefix so the allowlist matches:
+
+```bash
+~/.claude/hooks/lib/codex-stage.sh poc --worktree "$WT" --timeout 600 << 'SPEC_EOF'
+<implementation spec: goal, constraints, files to create/modify, how to verify>
+SPEC_EOF
+```
+
+- Add `--network` only when the spec requires installing dependencies or
+  running network-bound builds/tests.
+- Set a generous Bash timeout for the wrapper call (up to 600000 ms); raise
+  `--timeout` for large specs.
+- The wrapper runs `codex -a never exec --sandbox workspace-write -C <worktree
+toplevel>` under the hood: codex edits files directly in the worktree; `.git`,
+  `.codex` and `.agents` stay read-only by codex policy.
+- codex needs network and a local app-server: if a sandboxed Bash run of the
+  wrapper fails with "Operation not permitted", retry with the Bash sandbox
+  disabled — that is a harness sandbox restriction, not a wrapper defect.
+
+### Phase 3: Report
+
+The wrapper already appends `git status --porcelain` + `git diff --stat` of the
+worktree to its stdout. Report:
+
+- **worktree**: absolute path
+- **summary**: codex's final message (as-is)
+- **changes**: the diffstat / porcelain status
+- For structured output, map these into the requested fields faithfully.
+
+On non-zero exit treat the run as **PoC incomplete** (not "no changes"): report
+the exit code and stderr tail, plus any partial diff left in the worktree.
+Wrapper exit codes: 11 = codex missing, 12 = unauthenticated (`codex login`),
+13 = usage error, 14 = not an isolated worktree, 15 = rate limited (retries
+already exhausted — report the PoC as skipped due to rate limiting so the
+caller can proceed with the Claude PoC alone and note the gap), 124 = timed out.
+
+## Safety
+
+- Never use `--sandbox danger-full-access` or
+  `--dangerously-bypass-approvals-and-sandbox`
+- Never use `--add-dir` to widen the writable boundary into the main tree
+- Never pass `-m` — `~/.codex/config.toml` owns model selection
+- Never commit, merge, or `codex apply` the PoC — the diff stays in the
+  worktree for cross-review and a human decision
+- Privacy: the spec and repo files codex reads are sent to OpenAI

--- a/claude/.claude/agents/codex-reviewer.md
+++ b/claude/.claude/agents/codex-reviewer.md
@@ -1,32 +1,39 @@
 ---
 name: codex-reviewer
-description: Review plans using Codex CLI headless mode
+description: Cross-model review via OpenAI Codex CLI (headless). Reviews plans, designs, diffs, and findings from a non-Claude model family. Usable directly via the Agent tool or as a Workflow agentType ('codex-reviewer') in ultracode review/verification stages; composes with JSON-schema structured output.
 ---
 
-You are a review orchestrator that delegates plan review to OpenAI Codex CLI (`codex exec`) in headless mode.
+You are a review orchestrator that delegates review work to OpenAI Codex CLI in headless mode.
 
 ## Overview
 
-You do NOT review the plan yourself. Instead, you:
+You do NOT review the artifact yourself. Instead, you:
 
-1. Receive plan content from the task prompt
-2. Invoke `codex exec` to get Codex's review
+1. Receive the artifact (plan, design, diff description, or findings) from the task prompt
+2. Invoke codex through the shared wrapper to get Codex's review
 3. Present the results as-is
+
+The wrapper `~/.claude/hooks/lib/codex-stage.sh` is the single boundary for codex
+invocations. It handles auth preflight (`codex login status`), a portable timeout
+(macOS has no `timeout(1)`), `--ephemeral` (parallel-safe), and never passes `-m`
+(the model comes from `~/.codex/config.toml`). Always call it with the literal
+`~/.claude/hooks/lib/codex-stage.sh` prefix so the permission allowlist matches.
 
 ## Execution Flow
 
-### Phase 1: Plan Content Extraction
+### Phase 1: Artifact Extraction
 
-The plan content is provided in your task prompt (from `/plan-review codex-reviewer`). Extract the full plan text between the `---` delimiters.
+The artifact to review is provided in your task prompt (e.g. from `/plan-review`,
+an ultracode Workflow stage, or a direct Agent call). Extract the full content
+between the `---` delimiters when present, otherwise use the prompt body.
 
-### Phase 2: Codex Exec Invocation
+### Phase 2: Codex Invocation
 
-Run codex exec in headless mode. Pass the review prompt with plan content via stdin (`-`), and capture stdout directly:
+**Content review** (plan, design, findings — the default): pass the review prompt
+with the artifact via stdin:
 
 ```bash
-codex exec \
-  --sandbox read-only \
-  - << 'PROMPT_EOF'
+~/.claude/hooks/lib/codex-stage.sh prompt --dir "$PWD" --timeout 600 << 'PROMPT_EOF'
 You are a software architecture reviewer.
 Review the following implementation plan from an expert perspective.
 
@@ -47,13 +54,13 @@ Use the following format:
 [1-2 sentence overall assessment]
 
 ## Strengths
-- [Good points in the plan]
+- [Good points]
 
 ## Issues
 
 ### [Category]: [Specific issue]
 **Severity**: Critical / High / Medium / Low
-**Location**: [Plan section]
+**Location**: [Section]
 **Problem**: [What is wrong]
 **Suggestion**: [How to fix]
 
@@ -62,36 +69,51 @@ Use the following format:
 
 ---
 
-Plan file to review:
+Artifact to review:
 
-<extracted plan content here>
+<extracted artifact content here>
 PROMPT_EOF
 ```
 
-**Important**: Set a generous timeout for `codex exec` (up to 600 seconds).
+**Diff review** (uncommitted changes, a branch, or a single commit): use the
+first-class review mode instead of pasting the diff into a prompt:
+
+```bash
+# uncommitted changes in a repo / worktree
+~/.claude/hooks/lib/codex-stage.sh review --uncommitted --dir <repo-or-worktree-abs-path>
+
+# a branch against its base, or a single commit
+~/.claude/hooks/lib/codex-stage.sh review --base main --dir <repo-abs-path>
+~/.claude/hooks/lib/codex-stage.sh review --commit <sha> --dir <repo-abs-path>
+```
+
+Note: `codex exec review` accepts no `--sandbox`/`-C` flags — the wrapper enters
+the target directory itself, which is why `--dir` exists.
+
+**Important**: Set a generous Bash timeout for the wrapper call (up to 600000 ms).
 
 ### Phase 3: Result Presentation
 
-Present the stdout output from Codex CLI as-is. Do not add edits or interpretation.
-If codex exec fails, report the exit code and stderr content.
+Present the wrapper's stdout (Codex's review) as-is. Do not add edits or
+interpretation. When your task prompt requires structured output, map Codex's
+findings into the requested fields faithfully — do not invent findings Codex did
+not raise, and attribute the content to codex.
 
-## Review Scope
-
-This agent evaluates both code reviews and plan reviews (`/plan-review`) using the same perspectives listed in Phase 2.
-
-## Error Handling
-
-| Situation               | Response                                   |
-| ----------------------- | ------------------------------------------ |
-| codex command not found | Guide user to install the `codex` CLI      |
-| codex exec timeout      | Report the timeout and suggest retry       |
-| Authentication error    | Guide user to verify API key configuration |
-| Empty stdout            | Report the codex exec exit code            |
+If the wrapper fails, report its exit code and stderr tail. Wrapper exit codes:
+11 = codex CLI missing, 12 = unauthenticated (remedy: `codex login`),
+13 = usage error, 14 = validation refused, 15 = rate limited (the wrapper
+already retried with backoff — report that the codex stage was skipped due to
+rate limiting so the caller can proceed with Claude-only results and note the
+gap), 124 = timed out.
 
 ## Notes
 
-- The actual review is performed by Codex CLI
-- This agent only handles orchestration
-- `--sandbox read-only` ensures safe read-only file access
-- Uses stdin/stdout — no temporary files
-- always NOT used `-m` option in `codex exec`
+- The actual review is performed by Codex CLI; this agent only orchestrates
+- Review runs are read-only (`--sandbox read-only` / the review subcommand)
+- codex needs network and a local app-server: if a sandboxed Bash run of the
+  wrapper fails with "Operation not permitted", retry with the Bash sandbox
+  disabled — that is a harness sandbox restriction, not a wrapper defect
+- Never pass `-m` — `~/.codex/config.toml` owns model selection
+- Privacy: the artifact and any repo files codex reads are sent to OpenAI
+- Fallback if the wrapper is missing: `codex exec --sandbox read-only --ephemeral -`
+  with the prompt heredoc piped to stdin

--- a/claude/.claude/hooks/lib/codex-stage.sh
+++ b/claude/.claude/hooks/lib/codex-stage.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# codex-stage.sh — single safety/permission boundary for delegating work to OpenAI Codex CLI.
+#
+# Used by the codex-reviewer / codex-poc agents and by ultracode Workflow stages.
+# Centralizes the invariants every codex call must honor, so agents and workflow
+# scripts never re-derive flags:
+#   - never passes -m / --model (model comes from ~/.codex/config.toml)
+#   - always --ephemeral (parallel-safe: no ~/.codex/sessions state collisions)
+#   - auth preflight via `codex login status`
+#   - in-script timeout (macOS ships no timeout(1) / gtimeout)
+#   - poc mode validates the target is an isolated *linked* git worktree in code,
+#     not prose — it refuses a main repository checkout
+#
+# Modes:
+#   codex-stage.sh review [--uncommitted | --base <branch> | --commit <sha>]
+#                         [--dir <path>] [--timeout <sec>] [--title <t>] [--out <file>]
+#       First-class diff review (codex exec review). `codex exec review` accepts
+#       no -C/--sandbox flags, so the target directory is entered with cd.
+#       Default selector: --uncommitted. Read-only by nature.
+#
+#   codex-stage.sh prompt [--dir <path>] [--timeout <sec>] [--out <file>] [--schema <file>]
+#       Read-only analysis/review with a custom prompt read from stdin
+#       (codex exec --sandbox read-only -C <dir> -).
+#
+#   codex-stage.sh poc --worktree <abs-path> [--timeout <sec>] [--network] [--out <file>]
+#       Implementation PoC read from stdin, confined to an isolated linked git
+#       worktree (codex -a never exec --sandbox workspace-write -C <worktree> -).
+#       Prints `git status --porcelain` + `git diff --stat` of the worktree after
+#       the run so callers get a machine-checkable change summary.
+#
+# Retry (all modes):
+#   --retry <n>        retries when codex fails with a rate-limit error
+#                      (default 1; 0 disables)
+#   --retry-wait <sec> backoff base; waits base, 2*base, 4*base... (default 30)
+#   Only rate-limited failures are retried — timeouts (124) and other errors
+#   are not. A rate-limited run with no retries left exits 15 so callers can
+#   distinguish "retry later / proceed Claude-only" from a permanent failure.
+#
+# Exit codes: 0 ok / 11 codex missing / 12 unauthenticated / 13 usage error
+#             14 validation refused (poc) / 15 rate limited (retryable)
+#             124 timed out / else codex's own code.
+set -euo pipefail
+
+# codex is installed via bun; agent shells may lack that PATH entry.
+if ! command -v codex >/dev/null 2>&1; then
+  [ -x "$HOME/.bun/bin/codex" ] && export PATH="$HOME/.bun/bin:$PATH"
+fi
+
+usage() {
+  # Print the header comment block (everything up to the first non-comment line).
+  sed -n '2,/^set -euo pipefail/p' "$0" | sed '$d' | sed 's/^# \{0,1\}//'
+  exit 13
+}
+
+die() {
+  echo "codex-stage: $1" >&2
+  exit "${2:-13}"
+}
+
+# Portable timeout: background the command, kill it from a watchdog.
+# Background jobs get stdin rewired to /dev/null by the shell, so the prompt
+# is buffered to a temp file and redirected explicitly inside the job.
+# Usage: run_with_timeout <secs> <stdin-file-or-empty> <cmd> [args...]
+run_with_timeout() {
+  local secs=$1 stdin_file=$2
+  shift 2
+  local mark
+  mark=$(mktemp "${TMPDIR:-/tmp}/codex-stage-timeout.XXXXXX")
+  rm -f "$mark"
+  "$@" < "${stdin_file:-/dev/null}" &
+  local cmd_pid=$!
+  (
+    sleep "$secs"
+    # Mark a timeout only when the process is still alive at the deadline: a
+    # command that finished right at the deadline stays a success, and a
+    # command that traps TERM and exits 0 is still classified as timed out.
+    # The mark is written BEFORE the kill so the parent (woken by the kill)
+    # can never observe the death without the mark.
+    if kill -0 "$cmd_pid" 2>/dev/null; then
+      touch "$mark"
+      kill -TERM "$cmd_pid" 2>/dev/null
+      sleep 5
+      kill -KILL "$cmd_pid" 2>/dev/null
+    fi
+  ) &
+  local watchdog_pid=$!
+  local rc=0
+  wait "$cmd_pid" || rc=$?
+  kill "$watchdog_pid" 2>/dev/null || true
+  wait "$watchdog_pid" 2>/dev/null || true
+  if [ -e "$mark" ]; then
+    rm -f "$mark"
+    return 124
+  fi
+  return "$rc"
+}
+
+preflight() {
+  command -v codex >/dev/null 2>&1 \
+    || die "codex CLI not found — install it, then run 'codex login'" 11
+  codex login status >/dev/null 2>&1 \
+    || die "codex is not authenticated — run 'codex login'" 12
+}
+
+# Rate limits are only visible at execution time (auth preflight still passes),
+# so they are classified from codex's stderr after a failed run.
+is_rate_limited() {
+  grep -qiE 'rate.?limit|too many requests|429|usage limit|quota exceeded' "$STDERR_FILE"
+}
+
+# Shared execution path for all modes: runs codex under the timeout, classifies
+# rate-limited failures as exit 15, and retries those (and only those) with
+# exponential backoff. Usage: run_codex <stdin-file-or-empty> <cmd> [args...]
+run_codex() {
+  local stdin_file=$1
+  shift
+  local attempt=0 rc wait_s
+  while :; do
+    : > "$STDERR_FILE"
+    rc=0
+    run_with_timeout "$TIMEOUT" "$stdin_file" "$@" 2>"$STDERR_FILE" || rc=$?
+    if [ "$rc" -ne 0 ] && [ "$rc" -ne 124 ] && is_rate_limited; then
+      rc=15
+    fi
+    if [ "$rc" -eq 15 ] && [ "$attempt" -lt "$RETRY" ]; then
+      attempt=$((attempt + 1))
+      wait_s=$((RETRY_WAIT * (1 << (attempt - 1))))
+      echo "codex-stage: codex is rate limited — retry $attempt/$RETRY in ${wait_s}s" >&2
+      sleep "$wait_s"
+      continue
+    fi
+    break
+  done
+  return "$rc"
+}
+
+# Buffer stdin to a temp file so the backgrounded codex process gets a stable fd.
+buffer_stdin() {
+  [ -t 0 ] && die "this mode reads its prompt from stdin (pipe or heredoc)" 13
+  PROMPT_FILE=$(mktemp "${TMPDIR:-/tmp}/codex-stage.XXXXXX")
+  cat > "$PROMPT_FILE"
+  [ -s "$PROMPT_FILE" ] || die "empty prompt on stdin" 13
+}
+
+STDERR_FILE=$(mktemp "${TMPDIR:-/tmp}/codex-stage-err.XXXXXX")
+PROMPT_FILE=""
+cleanup() {
+  rm -f "$STDERR_FILE" ${PROMPT_FILE:+"$PROMPT_FILE"}
+}
+trap cleanup EXIT
+
+report_failure() {
+  local rc=$1
+  if [ "$rc" -eq 124 ]; then
+    echo "codex-stage: codex timed out after ${TIMEOUT}s" >&2
+  elif [ "$rc" -eq 15 ]; then
+    echo "codex-stage: codex is rate limited (retries exhausted) — retry later or proceed without the codex stage" >&2
+  else
+    echo "codex-stage: codex exited with code $rc" >&2
+  fi
+  echo "--- codex stderr (tail) ---" >&2
+  tail -n 40 "$STDERR_FILE" >&2 || true
+}
+
+MODE=${1:-}
+case $MODE in
+  ""|-h|--help) usage ;;
+esac
+shift
+
+TIMEOUT=600
+RETRY=1
+RETRY_WAIT=30
+DIR=$PWD
+OUT=""
+SCHEMA=""
+TITLE=""
+WORKTREE=""
+NETWORK=0
+SELECTOR=()
+
+while [ $# -gt 0 ]; do
+  case $1 in
+    --uncommitted) SELECTOR=(--uncommitted) ;;
+    --base) SELECTOR=(--base "${2:?--base needs a branch}"); shift ;;
+    --commit) SELECTOR=(--commit "${2:?--commit needs a sha}"); shift ;;
+    --dir) DIR=${2:?--dir needs a path}; shift ;;
+    --timeout) TIMEOUT=${2:?--timeout needs seconds}; shift ;;
+    --retry) RETRY=${2:?--retry needs a count}; shift ;;
+    --retry-wait) RETRY_WAIT=${2:?--retry-wait needs seconds}; shift ;;
+    --title) TITLE=${2:?--title needs text}; shift ;;
+    --out) OUT=${2:?--out needs a file}; shift ;;
+    --schema) SCHEMA=${2:?--schema needs a file}; shift ;;
+    --worktree) WORKTREE=${2:?--worktree needs an absolute path}; shift ;;
+    --network) NETWORK=1 ;;
+    -h|--help) usage ;;
+    *) die "unknown argument: $1" 13 ;;
+  esac
+  shift
+done
+
+preflight
+
+# Absolutize --out before any cd/-C changes what "relative" means.
+if [ -n "$OUT" ]; then
+  case $OUT in
+    /*) ;;
+    *) OUT="$PWD/$OUT" ;;
+  esac
+fi
+
+case $MODE in
+  review)
+    [ -d "$DIR" ] || die "no such directory: $DIR" 13
+    [ ${#SELECTOR[@]} -gt 0 ] || SELECTOR=(--uncommitted)
+    cd "$DIR"
+    git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+      || die "review mode requires a git repository: $DIR" 13
+    rc=0
+    run_codex "" codex exec review "${SELECTOR[@]}" \
+      --ephemeral \
+      ${TITLE:+--title "$TITLE"} \
+      ${OUT:+-o "$OUT"} || rc=$?
+    [ "$rc" -eq 0 ] || { report_failure "$rc"; exit "$rc"; }
+    ;;
+
+  prompt)
+    [ -d "$DIR" ] || die "no such directory: $DIR" 13
+    buffer_stdin
+    rc=0
+    run_codex "$PROMPT_FILE" codex exec \
+      --sandbox read-only \
+      -C "$DIR" \
+      --ephemeral \
+      --skip-git-repo-check \
+      ${OUT:+-o "$OUT"} \
+      ${SCHEMA:+--output-schema "$SCHEMA"} \
+      - || rc=$?
+    [ "$rc" -eq 0 ] || { report_failure "$rc"; exit "$rc"; }
+    ;;
+
+  poc)
+    [ -n "$WORKTREE" ] || die "poc mode requires --worktree <abs-path>" 13
+    case $WORKTREE in
+      /*) ;;
+      *) die "worktree path must be absolute: $WORKTREE" 14 ;;
+    esac
+    git -C "$WORKTREE" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+      || die "not a git work tree: $WORKTREE" 14
+    TOPLEVEL=$(git -C "$WORKTREE" rev-parse --show-toplevel)
+    # A linked worktree has its own git-dir under <main>/.git/worktrees/<name>;
+    # in a main checkout git-dir == git-common-dir. Refuse main checkouts so a
+    # workspace-write codex run can never touch the primary working copy.
+    # Both sides MUST come from the same producer with the same symlink
+    # handling: deriving one via --absolute-git-dir (canonicalized) and the
+    # other via cd+pwd (not canonicalized) let a main checkout reached through
+    # a symlinked path (e.g. macOS /tmp -> /private/tmp) pass as a worktree.
+    GIT_DIR=$(git -C "$WORKTREE" rev-parse --git-dir)
+    GIT_COMMON_DIR=$(git -C "$WORKTREE" rev-parse --git-common-dir)
+    [ "$GIT_DIR" != "$GIT_COMMON_DIR" ] \
+      || die "refusing: $TOPLEVEL is a main repository checkout, not an isolated linked worktree" 14
+    buffer_stdin
+    NETWORK_OPT=""
+    [ "$NETWORK" -eq 1 ] && NETWORK_OPT="sandbox_workspace_write.network_access=true"
+    rc=0
+    run_codex "$PROMPT_FILE" codex -a never exec \
+      --sandbox workspace-write \
+      -C "$TOPLEVEL" \
+      --ephemeral \
+      ${NETWORK_OPT:+-c "$NETWORK_OPT"} \
+      ${OUT:+-o "$OUT"} \
+      - || rc=$?
+    [ "$rc" -eq 0 ] || { report_failure "$rc"; exit "$rc"; }
+    echo ""
+    echo "--- codex-stage poc: resulting changes in $TOPLEVEL ---"
+    git -C "$TOPLEVEL" status --porcelain
+    git -C "$TOPLEVEL" diff --stat
+    ;;
+
+  *)
+    die "unknown mode: $MODE (expected review | prompt | poc)" 13
+    ;;
+esac

--- a/claude/.claude/hooks/pre_tool_use/codex_stage_guard.sh
+++ b/claude/.claude/hooks/pre_tool_use/codex_stage_guard.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# PreToolUse hook (matcher: Workflow): advisory guard that checks the
+# about-to-run workflow script for a cross-model codex stage and injects a
+# reminder when none is present. ADVISORY ONLY — it never emits a
+# permissionDecision and never blocks; the marker grep is best-effort
+# (a roster variable defined elsewhere can produce a false nudge).
+# Silent when codex is absent/unauthenticated or the script has a codex stage.
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Malformed JSON must stay silent (exit 0), matching the documented contract.
+TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null) || exit 0
+[ "$TOOL" = "Workflow" ] || exit 0
+
+SCRIPT=$(printf '%s' "$INPUT" | jq -r '.tool_input.script // empty' 2>/dev/null) || exit 0
+if [ -z "$SCRIPT" ]; then
+  SCRIPT_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.scriptPath // empty' 2>/dev/null) || exit 0
+  # Named/saved workflows ({name}) and unreadable paths: stay silent.
+  [ -n "$SCRIPT_PATH" ] && [ -r "$SCRIPT_PATH" ] || exit 0
+  SCRIPT=$(cat "$SCRIPT_PATH")
+fi
+
+# Markers that count as a codex stage; codex-skip is the explicit opt-out.
+printf '%s' "$SCRIPT" | grep -qiE 'codex-reviewer|codex-poc|codex-stage|codex exec|codex-skip' && exit 0
+
+# codex is installed via bun; the hook shell may lack that PATH entry.
+command -v codex >/dev/null 2>&1 || {
+  [ -x "$HOME/.bun/bin/codex" ] && export PATH="$HOME/.bun/bin:$PATH" || exit 0
+}
+
+AUTH_CACHE="${TMPDIR:-/tmp}/codex_auth_ok.$(id -u)"
+if [ ! -f "$AUTH_CACHE" ] || [ -n "$(find "$AUTH_CACHE" -mmin +60 2>/dev/null)" ]; then
+  codex login status >/dev/null 2>&1 || exit 0
+  touch "$AUTH_CACHE"
+fi
+
+CTX='This workflow script contains no cross-model (codex) stage. ultracode workflows should include at least one: agentType "codex-reviewer" in review/verification fan-outs, agentType "codex-poc" (with isolation "worktree") for competing implementation PoCs, or a Bash stage calling ~/.claude/hooks/lib/codex-stage.sh for diff review. Templates: ~/.claude/skills/start-work/references/multi-model-workflows.md. If codex was intentionally omitted (trivial or non-review workflow, or the user opted out), proceed and add the comment "// codex-skip" to the script next time.'
+
+jq -n --arg ctx "$CTX" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    additionalContext: $ctx
+  }
+}'

--- a/claude/.claude/hooks/user_prompt_submit/ultracode_codex_context.sh
+++ b/claude/.claude/hooks/user_prompt_submit/ultracode_codex_context.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# UserPromptSubmit hook: when the prompt opts into ultracode, deterministically
+# inject the cross-model (codex) mandate so workflow authoring cannot miss it.
+# Silent (exit 0, no output) on every other prompt and on machines where codex
+# is absent or unauthenticated.
+set -euo pipefail
+
+INPUT=$(cat)
+# Field name differs across harness builds (.prompt / .user_prompt); malformed
+# JSON must stay silent (exit 0), matching the documented contract.
+PROMPT=$(printf '%s' "$INPUT" | jq -r '.prompt // .user_prompt // empty' 2>/dev/null | tr '[:upper:]' '[:lower:]') || exit 0
+
+case $PROMPT in
+  *ultracode*|*"ultra code"*) ;;
+  *) exit 0 ;;
+esac
+
+# codex is installed via bun; the hook shell may lack that PATH entry.
+command -v codex >/dev/null 2>&1 || {
+  [ -x "$HOME/.bun/bin/codex" ] && export PATH="$HOME/.bun/bin:$PATH" || exit 0
+}
+
+# Auth preflight, cached for 1h so repeated ultracode prompts stay fast.
+AUTH_CACHE="${TMPDIR:-/tmp}/codex_auth_ok.$(id -u)"
+if [ ! -f "$AUTH_CACHE" ] || [ -n "$(find "$AUTH_CACHE" -mmin +60 2>/dev/null)" ]; then
+  codex login status >/dev/null 2>&1 || exit 0
+  touch "$AUTH_CACHE"
+fi
+
+CTX='Codex CLI is installed and authenticated on this machine. ultracode workflows must include cross-model (non-Claude) stages to counter single-model-family blind spots: (1) every review/verification fan-out includes an agent with agentType "codex-reviewer"; (2) competing implementation phases include an agent with agentType "codex-poc" spawned with isolation "worktree". All codex calls go through ~/.claude/hooks/lib/codex-stage.sh (auth preflight, timeout, --ephemeral; never pass -m). Workflow script templates: ~/.claude/skills/start-work/references/multi-model-workflows.md. If the user explicitly opts out of codex, add the comment "// codex-skip" to the workflow script.'
+
+jq -n --arg ctx "$CTX" '{
+  hookSpecificOutput: {
+    hookEventName: "UserPromptSubmit",
+    additionalContext: $ctx
+  }
+}'

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -7,6 +7,8 @@
       "Bash(find:*)",
       "Bash(gh:*)",
       "Bash(mise:*)",
+      "Bash(codex login status:*)",
+      "Bash(~/.claude/hooks/lib/codex-stage.sh:*)",
       "Bash(bit issue init:*)",
       "Bash(bit issue create:*)",
       "Bash(bit issue list:*)",
@@ -36,6 +38,30 @@
   },
   "enableAllProjectMcpServers": true,
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/user_prompt_submit/ultracode_codex_context.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Workflow",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/pre_tool_use/codex_stage_guard.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "Notification": [
       {
         "matcher": ".*",

--- a/claude/.claude/skills/plan-review/SKILL.md
+++ b/claude/.claude/skills/plan-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plan-review
 description: Plan modeで作成したプランに対して、プロジェクト特性を分析し適切なレビューエージェントを自動選択・並列起動するスキル。引数なしで実行可能。
-allowed-tools: Bash(codex exec *)
+allowed-tools: Bash(codex exec *), Bash(~/.claude/hooks/lib/codex-stage.sh *)
 ---
 
 # Plan Review
@@ -75,6 +75,7 @@ Readツールで検出したPlanファイルの内容を取得。
 | テスト基盤が存在する               | `tdd-reviewer`       |
 
 - 複数条件に該当する場合は**すべて**起動する（並列）
+- codex CLI が利用可能な場合、`codex-reviewer` は他の条件に関わらず**必ず**起動する（クロスモデル視点の確保。Claude系モデル固有の盲点を補う）
 - **どの条件にも該当しない場合**: 利用可能なレビュワーがない旨をユーザーに通知し、手動指定を促す
 
 #### 2c: 選択結果の表示

--- a/claude/.claude/skills/start-work/SKILL.md
+++ b/claude/.claude/skills/start-work/SKILL.md
@@ -292,6 +292,23 @@ bit issue close <parent_id>
 | Orphan issue      | Check `gwq list` for worktree existence. If no matching worktree, exclude from overlap detection. |
 | Worktree trouble  | `gwq list` (list all), `gwq prune` (clean stale refs), `gwq status` (check changes)               |
 
+## Cross-Model Stages (ultracode)
+
+When the session runs in ultracode mode and you author multi-agent Workflow
+scripts for the work started here, include cross-model (codex) stages so the
+result is not blind to single-model-family biases:
+
+- Every review/verification fan-out includes an `agentType: 'codex-reviewer'`
+  stage.
+- Competing implementation phases include an `agentType: 'codex-poc'` stage
+  spawned with `isolation: 'worktree'` — codex writes its PoC in its own
+  isolated worktree (a sibling of this session's worktree), and each PoC diff
+  is reviewed by the OTHER model family before judging.
+
+All codex calls go through `~/.claude/hooks/lib/codex-stage.sh`. For ready-made
+workflow script templates (review fan-out, dual-PoC cross-review), read
+`references/multi-model-workflows.md`.
+
 ## Worked Examples
 
 For concrete workflow examples (solo session, parallel sessions without overlap, parallel sessions with overlap adjustment), read `references/examples.md`.

--- a/claude/.claude/skills/start-work/references/multi-model-workflows.md
+++ b/claude/.claude/skills/start-work/references/multi-model-workflows.md
@@ -1,0 +1,222 @@
+# Multi-Model Workflow Templates (codex cross-model stages)
+
+Templates for weaving OpenAI codex (a non-Claude model family) into ultracode
+Workflow scripts. Two integration shapes:
+
+1. **Cross-model review** — every review/verification fan-out includes an
+   `agentType: 'codex-reviewer'` stage alongside Claude lenses.
+2. **Dual-PoC cross-review** — Claude and codex each implement the same spec in
+   isolated worktrees, then each diff is reviewed by the OTHER model family.
+
+Ground rules baked into these templates:
+
+- All codex invocations go through `~/.claude/hooks/lib/codex-stage.sh`
+  (auth preflight, portable timeout, `--ephemeral` for parallel safety,
+  never `-m` — `~/.codex/config.toml` owns model selection).
+- `codex-poc` must run paired with `isolation: 'worktree'` — the wrapper
+  refuses (exit 14) to run workspace-write against a main repository checkout.
+- Rosters are plain arrays: adding a future model family (gemini etc.) is a
+  one-line push once its agent definition exists.
+- To intentionally omit codex from a workflow, add the comment `// codex-skip`
+  to the script — the PreToolUse guard hook treats it as an explicit opt-out.
+- Never auto-merge a PoC diff; it stays in its worktree for a human decision.
+- Degrade gracefully on rate limits: the wrapper retries rate-limited runs
+  with backoff (`--retry`, default 1) and exits 15 when exhausted. A codex
+  stage failing with 15 must not abort the workflow — proceed with the
+  Claude-only results and state the coverage gap in the synthesis.
+
+## Template A: cross-model review fan-out
+
+```js
+export const meta = {
+  name: "cross-model-review",
+  description:
+    "Claude lenses + codex cross-model review of the working tree, disagreement-first synthesis",
+  phases: [{ title: "Review" }, { title: "Synthesize" }],
+};
+
+const REPO = "<absolute path to the repo or worktree under review>";
+
+// Rosters — push another agentType here when a new model-family CLI lands.
+const CLAUDE_LENSES = [
+  {
+    key: "correctness",
+    prompt: `Review the uncommitted changes in ${REPO} for correctness bugs. Read the diff with git -C ${REPO} diff. Report findings with file:line.`,
+  },
+  {
+    key: "conventions",
+    prompt: `Review the uncommitted changes in ${REPO} for convention violations and risky patterns. Report findings with file:line.`,
+  },
+];
+const CROSS_MODEL = ["codex-reviewer"];
+
+const REVIEW_SCHEMA = {
+  type: "object",
+  properties: {
+    reviewer: { type: "string", description: "claude:<lens> or codex" },
+    summary: { type: "string" },
+    findings: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          severity: {
+            type: "string",
+            description: "Critical | High | Medium | Low",
+          },
+          location: { type: "string" },
+          problem: { type: "string" },
+          suggestion: { type: "string" },
+        },
+        required: ["severity", "problem"],
+      },
+    },
+  },
+  required: ["reviewer", "summary", "findings"],
+};
+
+phase("Review");
+const reviews = (
+  await parallel([
+    ...CLAUDE_LENSES.map(
+      (l) => () =>
+        agent(l.prompt, {
+          label: `claude:${l.key}`,
+          phase: "Review",
+          schema: REVIEW_SCHEMA,
+        }),
+    ),
+    ...CROSS_MODEL.map(
+      (t) => () =>
+        agent(
+          `Review the uncommitted changes in ${REPO}. Run: ~/.claude/hooks/lib/codex-stage.sh review --uncommitted --dir ${REPO} (Bash timeout 600000 ms). Map codex's findings into the structured output faithfully; set reviewer='codex'.`,
+          {
+            label: `crossmodel:${t}`,
+            phase: "Review",
+            agentType: t,
+            schema: REVIEW_SCHEMA,
+          },
+        ),
+    ),
+  ])
+).filter(Boolean);
+
+phase("Synthesize");
+const synthesis = await agent(
+  `Synthesize these reviews. Rank cross-model DISAGREEMENTS first (issues one model family found and the other missed), then agreements by severity. Reviews: ${JSON.stringify(reviews)}`,
+  { label: "synthesize", phase: "Synthesize" },
+);
+
+return { reviews, synthesis };
+```
+
+## Template B: dual-PoC cross-review
+
+```js
+export const meta = {
+  name: "dual-poc",
+  description:
+    "Claude and codex implement the same spec in isolated worktrees; each diff is reviewed by the other model family; judge recommends one",
+  phases: [
+    { title: "Implement" },
+    { title: "Cross-review" },
+    { title: "Judge" },
+  ],
+};
+
+const SPEC = `<implementation spec: goal, constraints, files, verification>`;
+
+const POC_SCHEMA = {
+  type: "object",
+  properties: {
+    builder: { type: "string", description: "claude or codex" },
+    worktree: {
+      type: "string",
+      description: "absolute path of the isolated worktree holding the diff",
+    },
+    summary: { type: "string" },
+    diffstat: { type: "string" },
+  },
+  required: ["builder", "worktree", "summary", "diffstat"],
+};
+const REVIEW_SCHEMA = {
+  /* same as Template A */
+};
+
+phase("Implement");
+const pocs = (
+  await parallel([
+    () =>
+      agent(
+        `Implement this spec in your isolated worktree (your cwd): ${SPEC}\nReport builder='claude', the worktree absolute path (git rev-parse --show-toplevel), and git diff --stat.`,
+        {
+          label: "poc:claude",
+          phase: "Implement",
+          isolation: "worktree",
+          schema: POC_SCHEMA,
+        },
+      ),
+    () =>
+      agent(
+        `Delegate this spec to codex: ${SPEC}\nYour cwd is an isolated worktree — follow your Execution Flow (codex-stage.sh poc). Report builder='codex'.`,
+        {
+          label: "poc:codex",
+          phase: "Implement",
+          agentType: "codex-poc",
+          isolation: "worktree",
+          schema: POC_SCHEMA,
+        },
+      ),
+  ])
+).filter(Boolean);
+
+phase("Cross-review"); // each diff is reviewed by the OTHER model family
+const crossReviews = (
+  await parallel(
+    pocs.map(
+      (p) => () =>
+        p.builder === "claude"
+          ? agent(
+              `Review the uncommitted changes in ${p.worktree}. Run: ~/.claude/hooks/lib/codex-stage.sh review --uncommitted --dir ${p.worktree}. Set reviewer='codex'.`,
+              {
+                label: "codex-reviews-claude",
+                phase: "Cross-review",
+                agentType: "codex-reviewer",
+                schema: REVIEW_SCHEMA,
+              },
+            )
+          : agent(
+              `Review the uncommitted changes in ${p.worktree} (git -C ${p.worktree} diff) for correctness, safety, and fit. Set reviewer='claude'.`,
+              {
+                label: "claude-reviews-codex",
+                phase: "Cross-review",
+                schema: REVIEW_SCHEMA,
+              },
+            ),
+    ),
+  )
+).filter(Boolean);
+
+phase("Judge");
+const verdict = await agent(
+  `Two PoCs implemented the same spec; each was reviewed by the other model family. Recommend ONE to adopt (with required fixes) and say what to graft from the loser. NEVER merge anything yourself. PoCs: ${JSON.stringify(pocs)} Cross-reviews: ${JSON.stringify(crossReviews)}`,
+  { label: "judge", phase: "Judge" },
+);
+
+return { pocs, crossReviews, verdict };
+```
+
+## Wrapper quick reference
+
+```bash
+~/.claude/hooks/lib/codex-stage.sh review [--uncommitted | --base <branch> | --commit <sha>] --dir <abs> [--timeout <sec>]
+~/.claude/hooks/lib/codex-stage.sh prompt [--dir <abs>] [--timeout <sec>]   # prompt on stdin, read-only
+~/.claude/hooks/lib/codex-stage.sh poc --worktree <abs> [--timeout <sec>] [--network]   # spec on stdin, workspace-write
+```
+
+All modes also accept `--retry <n>` / `--retry-wait <sec>` (rate-limit backoff;
+defaults 1 / 30).
+
+Exit codes: 0 ok / 11 codex missing / 12 unauthenticated (`codex login`) /
+13 usage / 14 not an isolated worktree / 15 rate limited (retryable) /
+124 timed out.


### PR DESCRIPTION
## Why

Claude-only multi-agent (ultracode) workflows share model-family blind spots. This PR weaves OpenAI codex CLI into those workflows as (1) a cross-model reviewer and (2) a cross-model implementation PoC builder, preferring harness-executed mechanisms over prose instructions.

## What

| Layer | Change |
|---|---|
| Wrapper | `hooks/lib/codex-stage.sh` — single boundary for all codex calls: `review` / `prompt` / `poc` modes, auth preflight, in-script timeout (macOS has no `timeout(1)`), `--ephemeral` for parallel safety, rate-limit retry with backoff (`--retry`, exit 15), never `-m` |
| Agents | `codex-reviewer` reworked around the wrapper (+ diff-review mode, Workflow `agentType` notes); `codex-poc` added — workspace-write PoC confined to an isolated linked worktree, enforced in code (exit 14 on a main checkout) |
| Hooks | `UserPromptSubmit`: injects the codex mandate when the prompt opts into ultracode; `PreToolUse(Workflow)`: advisory nudge when a workflow script has no codex stage (`// codex-skip` opts out). Both silent when codex is absent/unauthenticated |
| Skills | `start-work`: Cross-Model Stages section + `references/multi-model-workflows.md` (review fan-out & dual-PoC cross-review templates); `plan-review`: codex-reviewer mandatory when codex is available |
| Settings | Hook registrations + narrow allowlist (`codex login status`, wrapper path) |
| CLAUDE.md | One-bullet backstop |

## Failure semantics

- codex missing/unauthenticated → hooks stay silent, wrapper exits 11/12 with remedy; workflows degrade to Claude-only
- Rate limited → wrapper retries with exponential backoff, then exits 15; workflows proceed Claude-only and report the gap
- Timeout → exit 124, no retry

## Verification

- e2e with real codex inference: `prompt` (echo test), `poc` (file written inside a temp linked worktree, main checkout untouched, refusal paths exit 14), `review --uncommitted`
- Cross-model adversarial review of this very diff (3 Claude lenses + codex via `agentType`): 1 Critical found independently by both model families (symlink-asymmetric worktree check) — fixed and regression-tested, incl. symlinked `/tmp` main-checkout refusal
- `run_with_timeout` unit tests: 20/20 boundary runs, hard timeout, TERM-trapping child
- Rate-limit stub tests: retry counts, exit 15, stdout passthrough
- Hook contract tests for all branches (keyword gate, malformed JSON silence, `codex-skip`, codex-absent machine)
- shellcheck clean; `bun test` failure is pre-existing on main (statusline fixture)

## Notes

- Saved workflows (`.claude/workflows/`) were probed (home + project scope) and are not discovered by this build — replaced by reference templates, not load-bearing
- Session restart required after merge for hook registration + agent registry
- `PreToolUse` matcher firing on the Workflow tool should be confirmed once after restart (hook is advisory-only either way)

🤖 Generated with [Claude Code](https://claude.com/claude-code)