### PR TITLE
fix(claude): close harness gaps against the Codex port

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -12,7 +12,7 @@ Utilize `dig` skills for information gathering. Unearth information that users h
 - Before PlanExit, review the created plan file using the `plan-review` skill before showing it to the user
 - Use `start-work` skill for non-trivial changes
 - Specify exact versions: `module@5.5.1` (NOT `^5.0.0` or `@latest`)
-- Commit to git until explicitly instructed by the user
+- Do not commit to git until explicitly instructed by the user
 
 ## TypeScript Projects
 

--- a/claude/.claude/hooks/lib/statusline_checks_lib.sh
+++ b/claude/.claude/hooks/lib/statusline_checks_lib.sh
@@ -41,7 +41,7 @@ find_project_root() {
             return 0
         fi
         if [ -f "$dir/package.json" ]; then
-            if [ -f "$dir/tsconfig.json" ] || [ -f "$dir/pnpm-lock.yaml" ] || [ -f "$dir/bun.lock" ]; then
+            if [ -f "$dir/tsconfig.json" ] || [ -f "$dir/pnpm-lock.yaml" ] || [ -f "$dir/bun.lock" ] || [ -f "$dir/bun.lockb" ]; then
                 echo "$dir"
                 return 0
             fi
@@ -62,7 +62,7 @@ detect_project_type() {
     elif [ -f "$root/moon.mod.json" ]; then
         echo "moonbit"
     elif [ -f "$root/package.json" ]; then
-        if [ -f "$root/tsconfig.json" ] || [ -f "$root/pnpm-lock.yaml" ] || [ -f "$root/bun.lock" ]; then
+        if [ -f "$root/tsconfig.json" ] || [ -f "$root/pnpm-lock.yaml" ] || [ -f "$root/bun.lock" ] || [ -f "$root/bun.lockb" ]; then
             echo "ts"
         fi
     fi
@@ -81,7 +81,7 @@ detect_package_manager() {
     local root=$1
     if [ -f "$root/pnpm-lock.yaml" ]; then
         echo "pnpm"
-    elif [ -f "$root/bun.lock" ]; then
+    elif [ -f "$root/bun.lock" ] || [ -f "$root/bun.lockb" ]; then
         echo "bun"
     fi
 }

--- a/claude/.claude/hooks/post_tool_use/coding_cycle.sh
+++ b/claude/.claude/hooks/post_tool_use/coding_cycle.sh
@@ -1,3 +1,50 @@
-#!/usr/bin/env bun
+#!/usr/bin/env bash
+# PostToolUse hook (Write|Edit|MultiEdit): run the repository format script
+# after a JavaScript/TypeScript file changes. Fires only when the nearest
+# package.json (walking up from the edited file) defines scripts.format; a
+# formatter failure feeds back as a block decision so the agent fixes it.
+set -euo pipefail
 
- bun run format
+INPUT=$(cat)
+command -v jq >/dev/null 2>&1 || exit 0
+
+# Malformed JSON must stay silent (exit 0), matching the documented contract.
+FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || exit 0
+[ -n "$FILE_PATH" ] || exit 0
+printf '%s\n' "$FILE_PATH" | grep -Eq '\.(js|ts)$' || exit 0
+
+CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || exit 0
+[ -n "$CWD" ] && [ -d "$CWD" ] || CWD=$PWD
+
+# Locate the nearest package.json upward from the edited file (falls back to
+# the session cwd when the file's directory does not exist).
+case "$FILE_PATH" in
+  /*) DIR=$(dirname "$FILE_PATH") ;;
+  *) DIR=$(dirname "$CWD/$FILE_PATH") ;;
+esac
+[ -d "$DIR" ] || DIR=$CWD
+
+command -v bun >/dev/null 2>&1 || exit 0
+
+PKG=""
+while :; do
+  if [ -f "$DIR/package.json" ]; then
+    PKG="$DIR/package.json"
+    break
+  fi
+  [ "$DIR" = "/" ] && break
+  PARENT=$(dirname "$DIR")
+  [ "$PARENT" = "$DIR" ] && break
+  DIR=$PARENT
+done
+
+[ -n "$PKG" ] || exit 0
+jq -e '.scripts.format | type == "string"' "$PKG" >/dev/null 2>&1 || exit 0
+
+if ! (cd "$DIR" && bun run format >/dev/null 2>&1); then
+  jq -n '{
+    decision: "block",
+    reason: "編集後の `bun run format` が失敗しました。formatterのエラーを確認し、修正後に再実行してください。",
+    systemMessage: "PostToolUse coding cycle: formatter failed"
+  }'
+fi

--- a/claude/.claude/hooks/task-completed/bit-issue-update.sh
+++ b/claude/.claude/hooks/task-completed/bit-issue-update.sh
@@ -1,87 +1,111 @@
 #!/usr/bin/env bash
-set -euo pipefail
+# TaskCompleted hook: close the bit issue whose title carries this task's
+# marker. Primary contract: [task:<branch>#<seq>:<task_id>] (start-work skill);
+# legacy [task:<branch>:<task_id>] titles still match as a fallback.
+# Async hook — every abort path exits 0 silently; diagnostics go to the log.
+set -u
 
-LOG_FILE="${HOME}/.claude/hooks/task-completed/debug.log"
+umask 077
+LOG_DIR="${TMPDIR:-/tmp}/claude-hooks"
+LOG_FILE="$LOG_DIR/bit-issue-update.log"
+mkdir -p "$LOG_DIR" 2>/dev/null || true
 
-log() {
-  printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$1" >> "$LOG_FILE"
+rotate_log() {
+  local size=0
+  if [ -f "$LOG_FILE" ]; then
+    size=$(wc -c < "$LOG_FILE" 2>/dev/null || echo 0)
+  fi
+  if [ "$size" -ge 262144 ]; then
+    mv -f "$LOG_FILE" "$LOG_FILE.1" 2>/dev/null || true
+  fi
 }
 
-log "=== TaskCompleted hook fired ==="
-log "CWD: $(pwd)"
+log() {
+  rotate_log
+  printf '[%s] %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$1" >> "$LOG_FILE" 2>/dev/null || true
+}
 
-# Required dependencies: jq, git, bit (bit is optional — script exits gracefully if missing)
-for cmd in jq git; do
-  if ! command -v "$cmd" &>/dev/null; then
-    log "ABORT: $cmd not found"
+for cmd in jq git bit; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    log "abort: $cmd not found"
     exit 0
   fi
 done
 
 INPUT=$(cat)
-log "INPUT: ${INPUT}"
-TASK_ID=$(printf '%s' "$INPUT" | jq -r '.task_id // empty')
-TASK_SUBJECT=$(printf '%s' "$INPUT" | jq -r '.task_subject // empty')
+TASK_ID=$(printf '%s' "$INPUT" | jq -r '.task_id // empty' 2>/dev/null) || TASK_ID=""
+TASK_SUBJECT=$(printf '%s' "$INPUT" | jq -r '.task_subject // empty' 2>/dev/null) || TASK_SUBJECT=""
 
-# task_idがなければ何もしない
 if [ -z "$TASK_ID" ]; then
-  log "ABORT: task_id is empty"
+  log "abort: task_id is empty"
   exit 0
 fi
-log "TASK_ID: ${TASK_ID}"
-log "TASK_SUBJECT: ${TASK_SUBJECT}"
+log "task ${TASK_ID}: ${TASK_SUBJECT}"
 
-# branch名取得（worktree内のHEADから）
-BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
+BRANCH=$(git branch --show-current 2>/dev/null) || BRANCH=""
 if [ -z "$BRANCH" ]; then
-  log "ABORT: branch is empty (git rev-parse --abbrev-ref HEAD failed)"
-  exit 0
-fi
-log "BRANCH: ${BRANCH}"
-
-# GIT_DIR取得（worktree/main両対応）
-# git rev-parse --git-common-dir はworktree内でも共有.gitパスを返す
-MAIN_GIT="$(git rev-parse --git-common-dir 2>/dev/null)"
-if [ ! -d "$MAIN_GIT" ]; then
-  log "ABORT: MAIN_GIT not a directory: ${MAIN_GIT}"
-  exit 0
-fi
-log "MAIN_GIT: ${MAIN_GIT}"
-
-# bit存在チェック
-if ! command -v bit &>/dev/null; then
-  log "ABORT: bit not found"
+  log "abort: branch unavailable"
   exit 0
 fi
 
-# [task:<branch>:<task_id>] を含むopen issueを検索
-# bit issue list出力形式: "#<id> [open] <title>"
-SEARCH_PATTERN="[task:${BRANCH}:${TASK_ID}]"
-log "SEARCH_PATTERN: ${SEARCH_PATTERN}"
-
-ALL_OPEN=$(GIT_DIR="$MAIN_GIT" bit issue list --open 2>/dev/null || true)
-log "ALL_OPEN_ISSUES: ${ALL_OPEN}"
-
-ISSUE_LINE=$(printf '%s' "$ALL_OPEN" | grep -F "$SEARCH_PATTERN" || true)
-if [ -z "$ISSUE_LINE" ]; then
-  log "ABORT: no matching issue found for pattern: ${SEARCH_PATTERN}"
+# The shared .git path works from any worktree.
+MAIN_GIT=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || MAIN_GIT=""
+if [ -z "$MAIN_GIT" ] || [ ! -d "$MAIN_GIT" ]; then
+  log "abort: git common directory unavailable"
   exit 0
 fi
-log "MATCHED: ${ISSUE_LINE}"
 
-# 全マッチのissue IDを抽出し、それぞれ comment + close
-printf '%s\n' "$ISSUE_LINE" | while IFS= read -r line; do
-  ISSUE_ID=$(printf '%s' "$line" | sed 's/^#\([^ ]*\).*/\1/')
-  [ -z "$ISSUE_ID" ] && continue
+ALL_OPEN=$(GIT_DIR="$MAIN_GIT" bit issue list --open 2>/dev/null) || ALL_OPEN=""
+if [ -z "$ALL_OPEN" ]; then
+  log "abort: no open issues"
+  exit 0
+fi
 
-  log "CLOSING: issue #${ISSUE_ID}"
+# Preferred contract: [task:<branch>#<seq>:<id>]. Parse the final id instead of
+# interpolating a regex so branch names containing regex punctuation are safe.
+MATCHES=$(printf '%s\n' "$ALL_OPEN" | awk -v branch="$BRANCH" -v wanted="$TASK_ID" '
+  {
+    marker = "[task:" branch "#"
+    pos = index($0, marker)
+    if (pos == 0) next
+    rest = substr($0, pos + length(marker))
+    closing = index(rest, "]")
+    if (closing == 0) next
+    token = substr(rest, 1, closing - 1)
+    colon = 0
+    for (i = 1; i <= length(token); i++) {
+      if (substr(token, i, 1) == ":") colon = i
+    }
+    if (colon > 0 && substr(token, colon + 1) == wanted) print $0
+  }
+')
+
+# Backward compatibility for historical [task:<branch>:<id>] issues.
+if [ -z "$MATCHES" ]; then
+  MATCHES=$(printf '%s\n' "$ALL_OPEN" | awk -v marker="[task:${BRANCH}:${TASK_ID}]" '
+    index($0, marker) > 0 { print $0 }
+  ')
+fi
+
+if [ -z "$MATCHES" ]; then
+  log "abort: no matching issue for task ${TASK_ID} on ${BRANCH}"
+  exit 0
+fi
+
+printf '%s\n' "$MATCHES" | while IFS= read -r line; do
+  [ -n "$line" ] || continue
+  ISSUE_ID=$(printf '%s' "$line" | sed -n 's/^#\([^ ]*\).*/\1/p')
+  [ -n "$ISSUE_ID" ] || continue
 
   GIT_DIR="$MAIN_GIT" bit issue comment add "$ISSUE_ID" \
-    --body "Task completed: ${TASK_SUBJECT}" 2>/dev/null || true
+    --body "Task completed: ${TASK_SUBJECT}" >/dev/null 2>&1 \
+    || log "warn: comment failed for issue ${ISSUE_ID}"
 
-  GIT_DIR="$MAIN_GIT" bit issue close "$ISSUE_ID" 2>/dev/null || true
-
-  log "CLOSED: issue #${ISSUE_ID}"
+  if GIT_DIR="$MAIN_GIT" bit issue close "$ISSUE_ID" >/dev/null 2>&1; then
+    log "closed: issue ${ISSUE_ID}"
+  else
+    log "warn: close failed for issue ${ISSUE_ID}"
+  fi
 done
 
-log "=== TaskCompleted hook done ==="
+exit 0

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -71,14 +71,9 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path | select(endswith(\".js\") or endswith(\".ts\"))' | ~/.claude/hooks/post_tool_use/coding_cycle.sh",
+            "command": "~/.claude/hooks/post_tool_use/coding_cycle.sh",
             "timeout": 10
-          }
-        ]
-      },
-      {
-        "matcher": "Write|Edit",
-        "hooks": [
+          },
           {
             "type": "command",
             "command": "~/.claude/hooks/post_tool_use/type_safety_check.sh",

--- a/claude/.claude/skills/start-work/SKILL.md
+++ b/claude/.claude/skills/start-work/SKILL.md
@@ -265,7 +265,7 @@ Close task issues **before** removing the worktree. Reversing this order creates
 task done → TaskUpdate(task_id, completed) → TaskCompleted hook → bit issue close
 ```
 
-The hook matches the open issue containing `[task:<branch>:<task_id>]` in its title. It runs async, so it doesn't block the main agent.
+The hook matches the open issue containing `[task:<branch>#<seq>:<task_id>]` in its title (legacy `[task:<branch>:<task_id>]` titles still match as a fallback). It runs async, so it doesn't block the main agent.
 
 Fallback if the hook fails (async, so no error is raised):
 

--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -15,7 +15,7 @@ ffmpeg = "8.0.1"
 "github:ushironoko/octorus" = "latest"
 "github:ushironoko/abbrs" = "0.2.10"
 "github:ushironoko/gitfilm" = "0.3.0"
-"github:bit-vcs/bit" = "0.35.2"
+"github:bit-vcs/bit" = "0.42.1"
 "github:ast-grep/ast-grep" = "0.42.2"
 "github:d-kuro/gwq" = "0.1.1"
 "github:atanunq/viu" = { version = "1.6.1", bin = "viu" }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "bun build src/index.ts --outdir=dist --target=bun",
     "test": "bun test",
     "lint": "oxlint",
-    "lint:sh": "if command -v shellcheck >/dev/null 2>&1; then shellcheck -x bin/svgshow claude/.claude/statusline.sh claude/.claude/hooks/lib/statusline_checks_lib.sh claude/.claude/hooks/lib/statusline_checks_run.sh claude/.claude/hooks/session_start/statusline_checks.sh claude/.claude/hooks/stop/statusline_checks.sh && find codex/hooks -type f -name '*.sh' -exec shellcheck -x {} +; else echo 'shellcheck not installed; skipping shell lint. Install with: mise use -g github:koalaman/shellcheck'; fi",
+    "lint:sh": "if command -v shellcheck >/dev/null 2>&1; then shellcheck -x bin/svgshow claude/.claude/statusline.sh claude/.claude/hooks/lib/statusline_checks_lib.sh claude/.claude/hooks/lib/statusline_checks_run.sh claude/.claude/hooks/session_start/statusline_checks.sh claude/.claude/hooks/stop/statusline_checks.sh claude/.claude/hooks/post_tool_use/coding_cycle.sh claude/.claude/hooks/task-completed/bit-issue-update.sh && find codex/hooks -type f -name '*.sh' -exec shellcheck -x {} +; else echo 'shellcheck not installed; skipping shell lint. Install with: mise use -g github:koalaman/shellcheck'; fi",
     "sync:codex-agents": "bun scripts/sync-codex-agents.ts",
     "check:codex-agents": "bun scripts/sync-codex-agents.ts --check",
     "check:codex-rules": "bun scripts/check-codex-rules.ts",

--- a/tests/hooks/claude-harness/bit-issue-update.test.ts
+++ b/tests/hooks/claude-harness/bit-issue-update.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import { join, resolve } from "node:path";
+import { cleanupTestDirectory, setupTestDirectory } from "../../test-helpers";
+
+const ROOT = resolve(import.meta.dir, "../../..");
+const HOOK = join(
+  ROOT,
+  "claude/.claude/hooks/task-completed/bit-issue-update.sh",
+);
+
+interface HookResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+const runHook = async (
+  input: Record<string, unknown>,
+  cwd: string,
+  env: Record<string, string | undefined> = {},
+): Promise<HookResult> => {
+  const proc = Bun.spawn(["bash", HOOK], {
+    cwd,
+    env: { ...process.env, ...env },
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  proc.stdin.write(JSON.stringify(input));
+  proc.stdin.end();
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout: stdout.trim(), stderr, exitCode };
+};
+
+const setupRepoWithBitStub = async (
+  name: string,
+  branch: string,
+): Promise<{ directory: string; bin: string; calls: string }> => {
+  const directory = await setupTestDirectory(name);
+  const bin = join(directory, "bin");
+  const calls = join(directory, "bit-calls.log");
+  await fs.mkdir(bin, { recursive: true });
+  await fs.writeFile(
+    join(bin, "bit"),
+    [
+      "#!/usr/bin/env bash",
+      String.raw`printf "%s\n" "$*" >> "$BIT_CALLS"`,
+      'if [ "$1 $2 $3" = "issue list --open" ]; then',
+      String.raw`  printf "%s\n" "$BIT_OPEN_LINES"`,
+      "fi",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+  const init = Bun.spawn(["git", "init", "-q", "-b", branch, directory], {
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+  expect(await init.exited).toBe(0);
+  return { directory, bin, calls };
+};
+
+describe("TaskCompleted bit issue hook", () => {
+  const tempDirectories: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirectories.splice(0).map(cleanupTestDirectory));
+  });
+
+  test("closes the issue matching the sequence-aware task title", async () => {
+    const { directory, bin, calls } = await setupRepoWithBitStub(
+      "claude-bit-task-seq",
+      "feature/harness",
+    );
+    tempDirectories.push(directory);
+
+    const result = await runHook(
+      { task_id: "task-123", task_subject: "Implement adapter" },
+      directory,
+      {
+        PATH: `${bin}:${process.env.PATH ?? ""}`,
+        TMPDIR: join(directory, "tmp"),
+        BIT_CALLS: calls,
+        BIT_OPEN_LINES:
+          "#42 [open] [task:feature/harness#3:task-123] Implement adapter",
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("");
+    const recorded = await fs.readFile(calls, "utf8");
+    expect(recorded).toContain("issue comment add 42");
+    expect(recorded).toContain("--body Task completed: Implement adapter");
+    expect(recorded).toContain("issue close 42");
+  });
+
+  test("falls back to the legacy title format", async () => {
+    const { directory, bin, calls } = await setupRepoWithBitStub(
+      "claude-bit-task-legacy",
+      "feature/harness",
+    );
+    tempDirectories.push(directory);
+
+    const result = await runHook(
+      { task_id: "task-9", task_subject: "Legacy task" },
+      directory,
+      {
+        PATH: `${bin}:${process.env.PATH ?? ""}`,
+        TMPDIR: join(directory, "tmp"),
+        BIT_CALLS: calls,
+        BIT_OPEN_LINES: "#7 [open] [task:feature/harness:task-9] Legacy task",
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    const recorded = await fs.readFile(calls, "utf8");
+    expect(recorded).toContain("issue comment add 7");
+    expect(recorded).toContain("issue close 7");
+  });
+
+  test("ignores issues from other branches or other task ids", async () => {
+    const { directory, bin, calls } = await setupRepoWithBitStub(
+      "claude-bit-task-nomatch",
+      "feature/harness",
+    );
+    tempDirectories.push(directory);
+
+    const result = await runHook(
+      { task_id: "task-123", task_subject: "No match" },
+      directory,
+      {
+        PATH: `${bin}:${process.env.PATH ?? ""}`,
+        TMPDIR: join(directory, "tmp"),
+        BIT_CALLS: calls,
+        BIT_OPEN_LINES: [
+          "#1 [open] [task:other-branch#1:task-123] Other branch",
+          "#2 [open] [task:feature/harness#1:task-999] Other task",
+        ].join("\n"),
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    const recorded = await fs.readFile(calls, "utf8");
+    expect(recorded).not.toContain("issue close");
+  });
+
+  test("does nothing when task_id is missing", async () => {
+    const { directory, bin, calls } = await setupRepoWithBitStub(
+      "claude-bit-task-noid",
+      "feature/harness",
+    );
+    tempDirectories.push(directory);
+
+    const result = await runHook({}, directory, {
+      PATH: `${bin}:${process.env.PATH ?? ""}`,
+      TMPDIR: join(directory, "tmp"),
+      BIT_CALLS: calls,
+      BIT_OPEN_LINES: "#42 [open] [task:feature/harness#3:task-123] Anything",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(fs.access(calls)).rejects.toThrow();
+  });
+});

--- a/tests/hooks/claude-harness/coding-cycle.test.ts
+++ b/tests/hooks/claude-harness/coding-cycle.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import { join, resolve } from "node:path";
+import { cleanupTestDirectory, setupTestDirectory } from "../../test-helpers";
+
+const ROOT = resolve(import.meta.dir, "../../..");
+const HOOK = join(ROOT, "claude/.claude/hooks/post_tool_use/coding_cycle.sh");
+
+interface HookResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+const runHook = async (
+  input: Record<string, unknown>,
+  cwd: string,
+): Promise<HookResult> => {
+  const proc = Bun.spawn(["bash", HOOK], {
+    cwd,
+    env: { ...process.env },
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  proc.stdin.write(JSON.stringify(input));
+  proc.stdin.end();
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout: stdout.trim(), stderr, exitCode };
+};
+
+describe("coding cycle format hook", () => {
+  const tempDirectories: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirectories.splice(0).map(cleanupTestDirectory));
+  });
+
+  const setupProject = async (
+    name: string,
+    packageJson: Record<string, unknown> | null,
+  ): Promise<string> => {
+    const directory = await setupTestDirectory(name);
+    tempDirectories.push(directory);
+    if (packageJson !== null) {
+      await fs.writeFile(
+        join(directory, "package.json"),
+        JSON.stringify(packageJson),
+      );
+    }
+    return directory;
+  };
+
+  test("runs the format script for a TypeScript file and stays silent on success", async () => {
+    const directory = await setupProject("coding-cycle-ok", {
+      scripts: { format: "touch format-ran" },
+    });
+
+    const result = await runHook(
+      {
+        tool_input: { file_path: join(directory, "src.ts") },
+        cwd: directory,
+      },
+      directory,
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("");
+    await fs.access(join(directory, "format-ran"));
+  });
+
+  test("emits a block decision when the format script fails", async () => {
+    const directory = await setupProject("coding-cycle-fail", {
+      scripts: { format: "exit 1" },
+    });
+
+    const result = await runHook(
+      {
+        tool_input: { file_path: join(directory, "src.ts") },
+        cwd: directory,
+      },
+      directory,
+    );
+
+    expect(result.exitCode).toBe(0);
+    const output = JSON.parse(result.stdout) as { decision: string };
+    expect(output.decision).toBe("block");
+  });
+
+  test("skips files that are not JavaScript or TypeScript", async () => {
+    const directory = await setupProject("coding-cycle-skip-ext", {
+      scripts: { format: "touch format-ran" },
+    });
+
+    const result = await runHook(
+      {
+        tool_input: { file_path: join(directory, "README.md") },
+        cwd: directory,
+      },
+      directory,
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("");
+    expect(fs.access(join(directory, "format-ran"))).rejects.toThrow();
+  });
+
+  test("skips projects without a format script", async () => {
+    const directory = await setupProject("coding-cycle-no-script", {
+      scripts: { lint: "exit 0" },
+    });
+
+    const result = await runHook(
+      {
+        tool_input: { file_path: join(directory, "src.ts") },
+        cwd: directory,
+      },
+      directory,
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("");
+  });
+});

--- a/tests/hooks/statusline-checks/lib.test.ts
+++ b/tests/hooks/statusline-checks/lib.test.ts
@@ -69,6 +69,15 @@ describe("find_project_root", () => {
     expect(result.stdout).toBe(root);
   });
 
+  test("finds TS root with a binary bun.lockb lockfile", async () => {
+    const root = await setupTestDirectory("lib-ts-lockb");
+    tmps.push(root);
+    await createTestFile(join(root, "package.json"), "{}");
+    await createTestFile(join(root, "bun.lockb"), "");
+    const result = await callShellFn("find_project_root", [root]);
+    expect(result.stdout).toBe(root);
+  });
+
   test("skips bare package.json without tsconfig or lockfile", async () => {
     const root = await setupTestDirectory("lib-ts-skip");
     tmps.push(root);
@@ -106,6 +115,15 @@ describe("detect_project_type", () => {
     tmps.push(root);
     await createTestFile(join(root, "package.json"), "{}");
     await createTestFile(join(root, "tsconfig.json"), "{}");
+    const result = await callShellFn("detect_project_type", [root]);
+    expect(result.stdout).toBe("ts");
+  });
+
+  test("returns ts for package.json + bun.lockb", async () => {
+    const root = await setupTestDirectory("type-ts-lockb");
+    tmps.push(root);
+    await createTestFile(join(root, "package.json"), "{}");
+    await createTestFile(join(root, "bun.lockb"), "");
     const result = await callShellFn("detect_project_type", [root]);
     expect(result.stdout).toBe("ts");
   });
@@ -159,6 +177,14 @@ describe("detect_package_manager", () => {
     const root = await setupTestDirectory("pm-bun");
     tmps.push(root);
     await createTestFile(join(root, "bun.lock"), "");
+    const result = await callShellFn("detect_package_manager", [root]);
+    expect(result.stdout).toBe("bun");
+  });
+
+  test("bun.lockb -> bun", async () => {
+    const root = await setupTestDirectory("pm-bun-lockb");
+    tmps.push(root);
+    await createTestFile(join(root, "bun.lockb"), "");
     const result = await callShellFn("detect_package_manager", [root]);
     expect(result.stdout).toBe("bun");
   });


### PR DESCRIPTION
## Summary

A diff audit of the two harnesses (Claude Code hooks/skills vs the Codex spawn-based port) found 5 places where improvements made during the Codex port never flowed back to the Claude side. This PR closes those gaps.

1. **TaskCompleted hook never matched current task issues** — the `start-work` skill creates issues titled `[task:<branch>#<seq>:<task_id>]`, but the hook grepped for the legacy `[task:<branch>:<task_id>]` literal, so auto-close silently no-oped every time. Ported the Codex awk parser (sequence-aware, legacy fallback), moved the debug log out of the repo tree into `$TMPDIR/claude-hooks/` with rotation, and updated the SKILL.md description.
2. **coding_cycle hook ran unconditionally** — the jq pipe in settings.json fed a Bun-shell script that never read stdin, so `bun run format` ran on every edit regardless of file type or whether a format script exists, and failures were swallowed. Rewritten as bash: js/ts filter, nearest-package.json lookup from the edited file, `scripts.format` existence check, and a `block` decision on formatter failure.
3. **type_safety_check missed MultiEdit** — the script already handles `.tool_input.edits`, but the matcher only covered `Write|Edit`. PostToolUse is now a single `Write|Edit|MultiEdit` block, mirroring the Codex hooks.json layout.
4. **bun.lockb not detected** — `find_project_root` / `detect_project_type` / `detect_package_manager` in the statusline lib now recognize `bun.lockb` like the Codex lib does.
5. **CLAUDE.md commit rule was missing its negation** — "Commit to git until…" → "Do not commit to git until explicitly instructed by the user".

Also bumps the mise pin for bit to 0.42.1 (separate commit).

## Testing

- New hook tests: `tests/hooks/claude-harness/` (TaskCompleted marker matching incl. legacy fallback and non-match cases; coding_cycle success/failure/skip paths), plus `bun.lockb` cases in the statusline lib tests
- `bun run run-all` passes (prettier, codex-agents/rules sync checks, oxlint, shellcheck incl. the two rewritten scripts, tsgo, 297 tests)
- Live-verified the TaskCompleted fix: the hook auto-closed all 5 of this session's own bit task issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)