### PR TITLE
fix(pi): verify the globally installed harness version

### DIFF
--- a/scripts/check-pi-version.ts
+++ b/scripts/check-pi-version.ts
@@ -4,35 +4,65 @@
  * this is NOT part of run-all — it belongs to the machine smoke checklist in
  * pi/README.md.
  */
-import { $ } from "bun";
+import { posix, win32 } from "node:path";
 import packageJson from "../package.json";
 
 const PIN_KEY = "@earendil-works/pi-coding-agent";
 
-const pinned: string | undefined = packageJson.devDependencies?.[PIN_KEY];
-if (pinned === undefined) {
-  console.error(
-    `check-pi-version: ${PIN_KEY} is not pinned in package.json devDependencies`,
-  );
-  process.exit(1);
-}
+type CommandRunner = (argv: string[]) => Promise<string>;
 
-let installed: string;
-try {
-  installed = (await $`pi --version`.text()).trim();
-} catch {
-  console.error(
-    `check-pi-version: pi binary not found. Install with: bun install -g ${PIN_KEY}@${pinned}`,
-  );
-  process.exit(1);
-}
+const runCommand: CommandRunner = async (argv) => {
+  const child = Bun.spawn(argv, { stdout: "pipe", stderr: "ignore" });
+  const output = await new Response(child.stdout).text();
+  if ((await child.exited) !== 0) throw new Error(`command failed: ${argv[0]}`);
+  return output.trim();
+};
 
-if (installed !== pinned) {
-  console.error(
-    `check-pi-version: installed pi ${installed} != pinned ${pinned}. ` +
-      `Update the pin or run: bun install -g ${PIN_KEY}@${pinned}`,
-  );
-  process.exit(1);
-}
+const readGlobalPiVersion = async (
+  run: CommandRunner = runCommand,
+  bunExecutable = process.execPath,
+  platform = process.platform,
+): Promise<string> => {
+  const globalBin = await run([bunExecutable, "pm", "bin", "--global"]);
+  const pathApi = platform === "win32" ? win32 : posix;
+  if (!pathApi.isAbsolute(globalBin)) {
+    throw new Error("Bun global bin directory is not absolute");
+  }
+  const executable = platform === "win32" ? "pi.exe" : "pi";
+  return run([pathApi.join(globalBin, executable), "--version"]);
+};
 
-console.log(`check-pi-version: OK (${installed})`);
+const main = async (): Promise<number> => {
+  const pinned: string | undefined = packageJson.devDependencies?.[PIN_KEY];
+  if (pinned === undefined) {
+    console.error(
+      `check-pi-version: ${PIN_KEY} is not pinned in package.json devDependencies`,
+    );
+    return 1;
+  }
+
+  let installed: string;
+  try {
+    installed = await readGlobalPiVersion();
+  } catch {
+    console.error(
+      `check-pi-version: global pi binary not found. Install with: bun install -g ${PIN_KEY}@${pinned}`,
+    );
+    return 1;
+  }
+
+  if (installed !== pinned) {
+    console.error(
+      `check-pi-version: globally installed pi ${installed} != pinned ${pinned}. ` +
+        `Update the pin or run: bun install -g ${PIN_KEY}@${pinned}`,
+    );
+    return 1;
+  }
+
+  console.log(`check-pi-version: OK (${installed})`);
+  return 0;
+};
+
+if (import.meta.main) process.exit(await main());
+
+export { main, readGlobalPiVersion };

--- a/tests/pi-harness/check-pi-version.test.ts
+++ b/tests/pi-harness/check-pi-version.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { readGlobalPiVersion } from "../../scripts/check-pi-version";
+
+describe("readGlobalPiVersion", () => {
+  test("executes pi from Bun's global bin instead of PATH", async () => {
+    const calls: string[][] = [];
+    const outputs = ["/tmp/bun-global-bin", "0.80.7"];
+
+    const version = await readGlobalPiVersion(
+      async (argv) => {
+        calls.push(argv);
+        return outputs.shift() ?? "";
+      },
+      "/opt/bun/bin/bun",
+      "darwin",
+    );
+
+    expect(version).toBe("0.80.7");
+    expect(calls).toEqual([
+      ["/opt/bun/bin/bun", "pm", "bin", "--global"],
+      ["/tmp/bun-global-bin/pi", "--version"],
+    ]);
+    expect(calls[1]?.[0]).not.toBe("pi");
+  });
+
+  test("uses the Windows executable name", async () => {
+    const calls: string[][] = [];
+
+    await readGlobalPiVersion(
+      async (argv) => {
+        calls.push(argv);
+        return calls.length === 1 ? String.raw`C:\bun\bin` : "0.80.7";
+      },
+      String.raw`C:\bun\bin\bun.exe`,
+      "win32",
+    );
+
+    expect(calls[1]?.[0]).toBe(String.raw`C:\bun\bin\pi.exe`);
+  });
+
+  test("rejects a non-absolute global bin instead of falling back to PATH", async () => {
+    const calls: string[][] = [];
+
+    const promise = readGlobalPiVersion(async (argv) => {
+      calls.push(argv);
+      return "relative-bin";
+    });
+
+    await expect(promise).rejects.toThrow("not absolute");
+    expect(calls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

- resolve the pi executable from Bun's global bin directory instead of the repository-local PATH entry
- reject non-absolute global bin paths to avoid silently falling back to PATH
- add regression coverage for PATH shadowing and platform-specific executable names

## Verification

- `bun test` (780 passed, 2 skipped)
- `bun run tsc`
- targeted oxlint and Prettier checks
- confirmed the host smoke check now reports the actual global 0.80.7 versus pinned 0.80.6 mismatch