### PR TITLE
fix(codex): avoid nested ultracode handling under pi

### DIFF
--- a/codex/README.md
+++ b/codex/README.md
@@ -34,6 +34,12 @@ deployment with `bun run src/index.ts install -d` before applying it.
 | `WorktreeCreate`    | Native App worktree, or explicit create-and-reopen adapter  |
 | `WorktreeRemove`    | Native cleanup, or confirmed clean managed-worktree adapter |
 
+The Codex-native ultracode hook ignores prompts when
+`PI_CODING_AGENT=true`. pi sets that marker on its subprocesses and handles the
+prompt through pi-harness, preventing a delegated Codex CLI from starting a
+second orchestration layer. Direct Codex CLI sessions still receive the native
+ultracode context.
+
 Codex 0.144.1 does not provide the last four Claude event names, asynchronous
 command handlers, or command-rendered status lines. The compatibility layer
 preserves their outcomes without registering unsupported handlers. The TUI

--- a/codex/hooks/user_prompt_submit/ultracode_context.sh
+++ b/codex/hooks/user_prompt_submit/ultracode_context.sh
@@ -3,6 +3,12 @@
 set -euo pipefail
 
 INPUT=$(cat)
+
+# pi exports this marker to every subprocess. Its hook bridge already owns the
+# ultracode prompt in that path, so do not activate a second, Codex-native
+# orchestration layer when pi delegates work to Codex CLI.
+[ "${PI_CODING_AGENT:-}" = "true" ] && exit 0
+
 command -v jq >/dev/null 2>&1 || exit 0
 
 PROMPT=$(printf '%s' "$INPUT" | jq -r '.prompt // empty' 2>/dev/null | tr '[:upper:]' '[:lower:]') || exit 0

--- a/tests/hooks/codex-harness/hooks.test.ts
+++ b/tests/hooks/codex-harness/hooks.test.ts
@@ -399,6 +399,7 @@ describe("lifecycle compatibility", () => {
       "Codex native custom agents",
     );
     expect(disabled.stdout).toBe("");
+    expect(delegatedByPi.exitCode).toBe(0);
     expect(delegatedByPi.stdout).toBe("");
   });
 

--- a/tests/hooks/codex-harness/hooks.test.ts
+++ b/tests/hooks/codex-harness/hooks.test.ts
@@ -371,13 +371,26 @@ describe("lifecycle compatibility", () => {
     await Promise.all(tempDirectories.splice(0).map(cleanupTestDirectory));
   });
 
-  test("injects native agent guidance only for ultracode prompts", async () => {
-    const enabled = await runHook("user_prompt_submit/ultracode_context.sh", {
-      prompt: "Use ultracode for this implementation",
-    });
-    const disabled = await runHook("user_prompt_submit/ultracode_context.sh", {
-      prompt: "Implement this normally",
-    });
+  test("injects native agent guidance only for direct Codex ultracode prompts", async () => {
+    const directEnv = { PI_CODING_AGENT: "false" };
+    const enabled = await runHook(
+      "user_prompt_submit/ultracode_context.sh",
+      { prompt: "Use ultracode for this implementation" },
+      ROOT,
+      directEnv,
+    );
+    const disabled = await runHook(
+      "user_prompt_submit/ultracode_context.sh",
+      { prompt: "Implement this normally" },
+      ROOT,
+      directEnv,
+    );
+    const delegatedByPi = await runHook(
+      "user_prompt_submit/ultracode_context.sh",
+      { prompt: "Use ultracode for this implementation" },
+      ROOT,
+      { PI_CODING_AGENT: "true" },
+    );
 
     const output = JSON.parse(enabled.stdout) as {
       hookSpecificOutput: { additionalContext: string };
@@ -386,6 +399,7 @@ describe("lifecycle compatibility", () => {
       "Codex native custom agents",
     );
     expect(disabled.stdout).toBe("");
+    expect(delegatedByPi.stdout).toBe("");
   });
 
   test("explicit completion matches the sequence-aware bit task title", async () => {


### PR DESCRIPTION
## Summary

- skip the Codex-native ultracode context when `PI_CODING_AGENT=true`
- keep direct Codex CLI ultracode behavior unchanged
- document and test the harness-routing contract

## Validation

- `bun test` (780 passed, 2 skipped)
- `bun run lint` (0 errors)
- `bun run lint:sh`
- `bun run tsc`
- `git diff --check`