### PR TITLE
feat(pi): mirror Claude statusline in footer

### DIFF
--- a/pi/README.md
+++ b/pi/README.md
@@ -95,7 +95,7 @@ typebox baseline + acceptance/rejection through pi's real `validateToolArguments
 | AskUserQuestion                      | exact-name `AskUserQuestion` compatibility tool                              |
 | Notification (asuku)                 | asuku-notify feature (`agent_settled`, detached)                             |
 | permissions.deny                     | permission-policy rules (fail-closed)                                        |
-| statusLine                           | statusline feature (`setWidget`)                                             |
+| statusLine                           | statusline feature (Claude-equivalent custom footer)                         |
 | logproxy                             | provider-log feature (opt-in, reduced scope)                                 |
 
 Known gaps vs Claude Code: no auto mode (server-side classifier is Claude
@@ -175,12 +175,13 @@ Automated coverage lives in `tests/pi-harness/` + `tests/hooks/pi-harness/`
       poc worktree auto-provisioned via gwq; workflow→codex-stage.sh
       roundtrip returns (2026-07-11)
 - [x] Phase 5: statusline runner launches only for trusted roots (cache JSON
-      written); provider-log stays off until opted in, JSONL 0700/0600 when
-      on; asuku binary spawn path verified
+      written); custom footer mirrors Claude's repo/directory/branch/diff,
+      checks, model, and remaining-context fields; provider-log stays off until
+      opted in, JSONL 0700/0600 when on; asuku binary spawn path verified
 - [x] Phase 6: pi-vocabulary `start-work` walks worktree_create → bit issue
       creation → task_completed close-verified on a real repo (2026-07-11);
       fork shadows the shared skill on name collision (V7 settled)
-- [ ] TUI-only: status widget renders in an interactive pi session
-      (`session_start`); asuku toast visually confirmed
+- [ ] TUI-only: Claude-equivalent custom footer renders in an interactive pi
+      session (`session_start`); asuku toast visually confirmed
 - [ ] Anthropic-transport provider-log response records (once extra-usage
       balance exists)

--- a/pi/extensions/pi-harness/features/statusline/index.ts
+++ b/pi/extensions/pi-harness/features/statusline/index.ts
@@ -1,39 +1,51 @@
 /**
- * statusline feature — refreshes the quality-check cache and renders it as a
- * pi widget.
+ * Claude-compatible statusline feature.
  *
- * - agent_settled launches statusline_checks_run.sh detached (output
- *   discarded), gated by the trusted-root check (S2): the runner executes
- *   repository-defined lint/typecheck/test commands.
- * - session_start and agent_settled render the cache JSON + git branch via
- *   ctx.ui.setWidget. Rendering only reads files, so it is not trust-gated.
+ * - agent_settled launches statusline_checks_run.sh detached, gated by the
+ *   trusted-root check because the runner executes repository-defined commands.
+ * - session_start and agent_settled refresh read-only git/check state.
+ * - a custom footer renders repository, directory, branch, tracked diff,
+ *   checks, model, and remaining context in the same order as Claude Code.
  *
- * Cache location and project-root detection mirror
- * statusline_checks_lib.sh so both harnesses share one cache.
+ * Cache location and project-root detection mirror statusline_checks_lib.sh so
+ * Claude Code and pi share one quality-check cache.
  */
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, statSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import type { HarnessConfig } from "../../config";
 import { sanitizeChildEnv } from "../../lib/child-env";
 import { launchDetached, type DetachedSpawnFunction } from "../../lib/detached";
-import type { CtxLike, PiLike } from "../../lib/pi-like";
+import type { CtxLike, PiLike, ThemeLike } from "../../lib/pi-like";
 import { matchedTrustedRoot } from "../../lib/trust";
 import {
+  formatModelName,
+  type GitStatus,
   parseStatuslineCache,
+  remainingContextPercent,
   renderStatusline,
   STATUSLINE_WIDGET_KEY,
   type StatuslineCache,
+  type StatuslineSnapshot,
 } from "./render";
 
 interface StatuslineDeps {
   cacheDir?: string;
   spawnDetached?: DetachedSpawnFunction;
+  getGitStatus?: (cwd: string) => Promise<GitStatus>;
   getBranch?: (cwd: string) => Promise<string | undefined>;
 }
+
+const EMPTY_GIT_STATUS: GitStatus = {
+  isRepository: false,
+  additions: 0,
+  deletions: 0,
+};
+
+const IDENTITY_THEME: ThemeLike = { fg: (_color, text) => text };
 
 // The shell library tests markers with [ -f ] (regular file, symlinks
 // followed); existsSync would also accept directories and make the two
@@ -71,6 +83,13 @@ const findProjectRoot = (start: string): string | undefined => {
   }
 };
 
+const projectLabel = (root: string): string | undefined => {
+  if (isRegularFile(join(root, "Cargo.toml"))) return "RS";
+  if (isRegularFile(join(root, "moon.mod.json"))) return "MB";
+  if (isRegularFile(join(root, "package.json"))) return "TS";
+  return undefined;
+};
+
 const defaultCacheDir = (): string =>
   process.env.STATUSLINE_CACHE_DIR ??
   join(tmpdir(), "claude-statusline-checks");
@@ -78,22 +97,82 @@ const defaultCacheDir = (): string =>
 const cacheFilePath = (cacheDir: string, root: string): string =>
   join(cacheDir, `${createHash("sha1").update(root).digest("hex")}.json`);
 
-const defaultGetBranch = (cwd: string): Promise<string | undefined> =>
+const gitOutput = (cwd: string, args: string[]): Promise<string | undefined> =>
   new Promise((resolve) => {
     execFile(
       "git",
-      ["branch", "--show-current"],
-      { cwd, timeout: 2_000, env: sanitizeChildEnv(process.env, {}, { cwd }) },
+      args,
+      {
+        cwd,
+        encoding: "utf8",
+        maxBuffer: 1_000_000,
+        timeout: 2_000,
+        env: sanitizeChildEnv(process.env, {}, { cwd }),
+      },
       (error, stdout) => {
-        if (error !== null || typeof stdout !== "string") {
-          resolve(undefined);
-          return;
-        }
-        const branch = stdout.trim();
-        resolve(branch === "" ? undefined : branch);
+        resolve(
+          error === null && typeof stdout === "string" ? stdout : undefined,
+        );
       },
     );
   });
+
+/** Extract the final org/repo pair from SSH, HTTPS, or file-style remotes. */
+export const parseOriginRepository = (origin: string): string | undefined => {
+  const trimmed = origin.trim().replace(/\.git$/, "");
+  if (/^[^/:]+\/[^/:]+$/.test(trimmed)) return trimmed;
+  const match = /[/:]([^/:]+\/[^/:]+)$/.exec(trimmed);
+  return match?.[1];
+};
+
+/** Sum text-file additions/deletions from git diff --numstat output. */
+export const parseNumstat = (
+  output: string,
+): Pick<GitStatus, "additions" | "deletions"> => {
+  let additions = 0;
+  let deletions = 0;
+  for (const line of output.split("\n")) {
+    const [added, deleted] = line.split("\t", 3);
+    if (added !== undefined && /^\d+$/.test(added)) {
+      additions += Number(added);
+    }
+    if (deleted !== undefined && /^\d+$/.test(deleted)) {
+      deletions += Number(deleted);
+    }
+  }
+  return { additions, deletions };
+};
+
+const defaultGetGitStatus = async (cwd: string): Promise<GitStatus> => {
+  const gitDir = await gitOutput(cwd, ["rev-parse", "--git-dir"]);
+  if (gitDir === undefined) return { ...EMPTY_GIT_STATUS };
+
+  const [origin, numstat] = await Promise.all([
+    gitOutput(cwd, ["remote", "get-url", "origin"]),
+    gitOutput(cwd, [
+      "-c",
+      "core.fsmonitor=false",
+      "diff",
+      "--no-ext-diff",
+      "--no-textconv",
+      "--numstat",
+      "HEAD",
+    ]),
+  ]);
+  const diff = parseNumstat(numstat ?? "");
+  return {
+    isRepository: true,
+    repository:
+      origin === undefined ? undefined : parseOriginRepository(origin),
+    ...diff,
+  };
+};
+
+const defaultGetBranch = async (cwd: string): Promise<string | undefined> => {
+  const branch = await gitOutput(cwd, ["branch", "--show-current"]);
+  const trimmed = branch?.trim();
+  return trimmed === "" ? undefined : trimmed;
+};
 
 export default function setupStatusline(
   pi: PiLike,
@@ -101,27 +180,101 @@ export default function setupStatusline(
   deps: StatuslineDeps = {},
 ): void {
   const spawnDetached = deps.spawnDetached ?? launchDetached;
+  const getGitStatus = deps.getGitStatus ?? defaultGetGitStatus;
   const getBranch = deps.getBranch ?? defaultGetBranch;
   const runner = join(
     config.paths.claudeHooksDir,
     "lib/statusline_checks_run.sh",
   );
 
+  let snapshot: StatuslineSnapshot = {
+    directory: "",
+    git: { ...EMPTY_GIT_STATUS },
+  };
+  let activeContext: CtxLike | undefined;
+  let footerInstalled = false;
+  let requestFooterRender: (() => void) | undefined;
+
+  const installOrRefreshFooter = async (
+    ctx: CtxLike,
+    allowGit: boolean,
+  ): Promise<void> => {
+    activeContext = ctx;
+    if (ctx.mode === "tui" && ctx.ui.setFooter !== undefined) {
+      if (!footerInstalled) {
+        // Clear the legacy widget when hot-reloading from an older pi-harness.
+        ctx.ui.setWidget?.(STATUSLINE_WIDGET_KEY, undefined);
+        ctx.ui.setFooter((tui, theme, footerData) => {
+          const requestRender = () => tui.requestRender();
+          requestFooterRender = requestRender;
+          const unsubscribeBranch = footerData.onBranchChange(requestRender);
+          return {
+            invalidate() {},
+            render(width: number): string[] {
+              const current = activeContext;
+              return renderStatusline(
+                snapshot,
+                {
+                  branch: footerData.getGitBranch(),
+                  modelName: formatModelName(current?.model),
+                  remainingContext: remainingContextPercent(
+                    current?.getContextUsage?.(),
+                  ),
+                },
+                width,
+                theme,
+              );
+            },
+            dispose() {
+              unsubscribeBranch();
+              if (requestFooterRender === requestRender) {
+                requestFooterRender = undefined;
+              }
+            },
+          };
+        });
+        footerInstalled = true;
+      }
+      requestFooterRender?.();
+      return;
+    }
+
+    // RPC supports widgets but intentionally ignores component factories.
+    // Git subprocesses remain trust-gated in this fallback too.
+    const branch = allowGit
+      ? await getBranch(ctx.cwd ?? process.cwd())
+      : undefined;
+    ctx.ui.setWidget?.(
+      STATUSLINE_WIDGET_KEY,
+      renderStatusline(
+        snapshot,
+        {
+          branch,
+          modelName: formatModelName(ctx.model),
+          remainingContext: remainingContextPercent(ctx.getContextUsage?.()),
+        },
+        Number.MAX_SAFE_INTEGER,
+        IDENTITY_THEME,
+      ),
+    );
+  };
+
   const refresh = async (ctx: CtxLike, launchChecks: boolean) => {
     const cwd = ctx.cwd ?? process.cwd();
     // Pass the canonical trusted root down as a boundary: the runner executes
     // repository-defined commands, and its own find_project_root can otherwise
-    // ascend past the trusted root into an untrusted parent (review finding).
-    const trustedRoot = launchChecks
-      ? matchedTrustedRoot(cwd, config.trust)
-      : undefined;
-    if (trustedRoot !== undefined && existsSync(runner)) {
+    // ascend past the trusted root into an untrusted parent.
+    const trustedRoot = matchedTrustedRoot(cwd, config.trust);
+    if (launchChecks && trustedRoot !== undefined && existsSync(runner)) {
       spawnDetached("bash", [runner, cwd, trustedRoot], { cwd });
     }
 
-    if (ctx.ui.setWidget === undefined) return;
-    let cache: StatuslineCache | undefined;
+    // Print/JSON modes expose no-op UI methods. Preserve lifecycle checks, but
+    // avoid paying for git/cache collection that no statusline can consume.
+    if (ctx.mode === "print" || ctx.mode === "json") return;
+
     const root = findProjectRoot(cwd);
+    let cache: StatuslineCache | undefined;
     if (root !== undefined) {
       const cacheDir = deps.cacheDir ?? defaultCacheDir();
       try {
@@ -132,8 +285,22 @@ export default function setupStatusline(
         cache = undefined;
       }
     }
-    const branch = await getBranch(cwd);
-    ctx.ui.setWidget(STATUSLINE_WIDGET_KEY, renderStatusline(cache, branch));
+
+    let git: GitStatus = { ...EMPTY_GIT_STATUS };
+    if (trustedRoot !== undefined) {
+      try {
+        git = await getGitStatus(cwd);
+      } catch {
+        git = { ...EMPTY_GIT_STATUS };
+      }
+    }
+    snapshot = {
+      directory: basename(cwd),
+      git,
+      projectLabel: root === undefined ? undefined : projectLabel(root),
+      cache,
+    };
+    await installOrRefreshFooter(ctx, trustedRoot !== undefined);
   };
 
   pi.on("session_start", async (_event, ctx) => {

--- a/pi/extensions/pi-harness/features/statusline/render.ts
+++ b/pi/extensions/pi-harness/features/statusline/render.ts
@@ -1,9 +1,9 @@
-/**
- * Pure rendering for the statusline widget: cache JSON written by
- * statusline_checks_run.sh + git branch → widget lines. Glyphs follow
- * status_to_glyph in statusline_checks_lib.sh (without ANSI colors — the
- * widget line is plain text).
- */
+import type {
+  ContextUsageLike,
+  ModelLike,
+  ThemeColorLike,
+  ThemeLike,
+} from "../../lib/pi-like";
 
 export const STATUSLINE_WIDGET_KEY = "pi-harness-statusline";
 
@@ -18,25 +18,218 @@ export interface StatuslineCache {
   [key: string]: unknown;
 }
 
-const GLYPHS: Record<string, string> = {
-  ok: "✓",
-  fail: "✗",
-  running: "…",
-  skipped: "-",
-};
+export interface GitStatus {
+  isRepository: boolean;
+  repository?: string;
+  additions: number;
+  deletions: number;
+}
 
-/** Display order and short names for the three check slots. */
+export interface StatuslineSnapshot {
+  directory: string;
+  git: GitStatus;
+  projectLabel?: string;
+  cache?: StatuslineCache;
+}
+
+export interface StatuslineRuntime {
+  branch?: string | null;
+  modelName?: string;
+  remainingContext?: number;
+}
+
+interface Span {
+  text: string;
+  tone?: ThemeColorLike;
+}
+
+const STATUS_STYLES = new Map<string, readonly [string, ThemeColorLike]>([
+  ["ok", ["✓", "success"]],
+  ["fail", ["✗", "error"]],
+  ["running", ["…", "warning"]],
+  ["skipped", ["-", "dim"]],
+]);
+
+/** Display order and Claude-compatible initials for the three check slots. */
 const SLOTS: readonly (readonly [slot: string, display: string])[] = [
-  ["lint", "lint"],
-  ["typecheck", "type"],
-  ["test", "test"],
+  ["lint", "L"],
+  ["typecheck", "T"],
+  ["test", "X"],
 ];
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
 
-const glyph = (status: unknown): string =>
-  typeof status === "string" ? (GLYPHS[status] ?? "?") : "?";
+const singleLine = (value: string): string =>
+  [...value]
+    .map((character) => {
+      const codePoint = character.codePointAt(0) ?? 0;
+      return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f)
+        ? " "
+        : character;
+    })
+    .join("")
+    .replace(/ +/g, " ")
+    .trim();
+
+const checkStatus = (
+  cache: StatuslineCache | undefined,
+  slot: string,
+): string => {
+  const state = cache?.checks?.[slot];
+  return isRecord(state) && typeof state.status === "string"
+    ? state.status
+    : "pending";
+};
+
+// Keep these classifiers aligned with pi-tui 0.80.6's graphemeWidth.
+const ZERO_WIDTH_GRAPHEME =
+  /^(?:\p{Default_Ignorable_Code_Point}|\p{Control}|\p{Mark}|\p{Surrogate})+$/v;
+const LEADING_NON_PRINTING =
+  /^[\p{Default_Ignorable_Code_Point}\p{Control}\p{Format}\p{Mark}\p{Surrogate}]+/v;
+const RGI_EMOJI = /^\p{RGI_Emoji}$/v;
+
+const couldBeEmoji = (grapheme: string): boolean => {
+  const codePoint = grapheme.codePointAt(0) ?? 0;
+  return (
+    (codePoint >= 0x1f000 && codePoint <= 0x1fbff) ||
+    (codePoint >= 0x2300 && codePoint <= 0x23ff) ||
+    (codePoint >= 0x2600 && codePoint <= 0x27bf) ||
+    (codePoint >= 0x2b50 && codePoint <= 0x2b55) ||
+    grapheme.includes("\uFE0F") ||
+    grapheme.length > 2
+  );
+};
+
+// Fullwidth + wide ranges from the same Unicode EastAsianWidth table used by
+// pi-tui 0.80.6's get-east-asian-width dependency. Keeping the compact table
+// local preserves pi-harness's no-runtime-dependency deployment contract.
+const EAST_ASIAN_WIDE_RANGES: readonly number[] = [
+  12_288, 12_288, 65_281, 65_376, 65_504, 65_510, 4_352, 4_447, 8_986, 8_987,
+  9_001, 9_002, 9_193, 9_196, 9_200, 9_200, 9_203, 9_203, 9_725, 9_726, 9_748,
+  9_749, 9_776, 9_783, 9_800, 9_811, 9_855, 9_855, 9_866, 9_871, 9_875, 9_875,
+  9_889, 9_889, 9_898, 9_899, 9_917, 9_918, 9_924, 9_925, 9_934, 9_934, 9_940,
+  9_940, 9_962, 9_962, 9_970, 9_971, 9_973, 9_973, 9_978, 9_978, 9_981, 9_981,
+  9_989, 9_989, 9_994, 9_995, 10_024, 10_024, 10_060, 10_060, 10_062, 10_062,
+  10_067, 10_069, 10_071, 10_071, 10_133, 10_135, 10_160, 10_160, 10_175,
+  10_175, 11_035, 11_036, 11_088, 11_088, 11_093, 11_093, 11_904, 11_929,
+  11_931, 12_019, 12_032, 12_245, 12_272, 12_287, 12_289, 12_350, 12_353,
+  12_438, 12_441, 12_543, 12_549, 12_591, 12_593, 12_686, 12_688, 12_773,
+  12_783, 12_830, 12_832, 12_871, 12_880, 42_124, 42_128, 42_182, 43_360,
+  43_388, 44_032, 55_203, 63_744, 64_255, 65_040, 65_049, 65_072, 65_106,
+  65_108, 65_126, 65_128, 65_131, 94_176, 94_180, 94_192, 94_198, 94_208,
+  101_589, 101_631, 101_662, 101_760, 101_874, 110_576, 110_579, 110_581,
+  110_587, 110_589, 110_590, 110_592, 110_882, 110_898, 110_898, 110_928,
+  110_930, 110_933, 110_933, 110_948, 110_951, 110_960, 111_355, 119_552,
+  119_638, 119_648, 119_670, 126_980, 126_980, 127_183, 127_183, 127_374,
+  127_374, 127_377, 127_386, 127_488, 127_490, 127_504, 127_547, 127_552,
+  127_560, 127_568, 127_569, 127_584, 127_589, 127_744, 127_776, 127_789,
+  127_797, 127_799, 127_868, 127_870, 127_891, 127_904, 127_946, 127_951,
+  127_955, 127_968, 127_984, 127_988, 127_988, 127_992, 128_062, 128_064,
+  128_064, 128_066, 128_252, 128_255, 128_317, 128_331, 128_334, 128_336,
+  128_359, 128_378, 128_378, 128_405, 128_406, 128_420, 128_420, 128_507,
+  128_591, 128_640, 128_709, 128_716, 128_716, 128_720, 128_722, 128_725,
+  128_728, 128_732, 128_735, 128_747, 128_748, 128_756, 128_764, 128_992,
+  129_003, 129_008, 129_008, 129_292, 129_338, 129_340, 129_349, 129_351,
+  129_535, 129_648, 129_660, 129_664, 129_674, 129_678, 129_734, 129_736,
+  129_736, 129_741, 129_756, 129_759, 129_770, 129_775, 129_784, 131_072,
+  196_605, 196_608, 262_141,
+];
+
+const isWide = (codePoint: number): boolean => {
+  for (let index = 0; index < EAST_ASIAN_WIDE_RANGES.length; index += 2) {
+    const lower = EAST_ASIAN_WIDE_RANGES[index];
+    const upper = EAST_ASIAN_WIDE_RANGES[index + 1];
+    if (lower !== undefined && upper !== undefined) {
+      if (codePoint >= lower && codePoint <= upper) return true;
+    }
+  }
+  return false;
+};
+
+const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+const graphemes = (value: string): string[] =>
+  [...segmenter.segment(value)].map(({ segment }) => segment);
+
+const graphemeWidth = (grapheme: string): number => {
+  if (ZERO_WIDTH_GRAPHEME.test(grapheme)) return 0;
+  if (couldBeEmoji(grapheme) && RGI_EMOJI.test(grapheme)) return 2;
+
+  const base = grapheme.replace(LEADING_NON_PRINTING, "");
+  const codePoint = base.codePointAt(0);
+  if (codePoint === undefined) return 0;
+  if (codePoint >= 0x1f1e6 && codePoint <= 0x1f1ff) return 2;
+
+  let width = isWide(codePoint) ? 2 : 1;
+  if (grapheme.length > 1) {
+    for (const character of grapheme.slice(1)) {
+      const trailing = character.codePointAt(0) ?? 0;
+      if (trailing >= 0xff00 && trailing <= 0xffef) {
+        width += isWide(trailing) ? 2 : 1;
+      } else if (trailing === 0x0e33 || trailing === 0x0eb3) {
+        width += 1;
+      }
+    }
+  }
+  return width;
+};
+
+export const visibleStatuslineWidth = (value: string): number =>
+  graphemes(value).reduce(
+    (width, grapheme) => width + graphemeWidth(grapheme),
+    0,
+  );
+
+const appendSpan = (spans: Span[], span: Span): void => {
+  if (span.text === "") return;
+  const previous = spans.at(-1);
+  if (previous !== undefined && previous.tone === span.tone) {
+    previous.text += span.text;
+  } else {
+    spans.push({ ...span });
+  }
+};
+
+const truncateSpans = (spans: Span[], width: number): Span[] => {
+  if (width <= 0) return [];
+  const totalWidth = spans.reduce(
+    (total, span) => total + visibleStatuslineWidth(span.text),
+    0,
+  );
+  if (totalWidth <= width) return spans;
+
+  const truncated: Span[] = [];
+  const contentWidth = Math.max(0, width - 1);
+  let used = 0;
+
+  let complete = false;
+  for (const span of spans) {
+    if (complete) break;
+    let text = "";
+    for (const grapheme of graphemes(span.text)) {
+      const nextWidth = graphemeWidth(grapheme);
+      if (used + nextWidth > contentWidth) {
+        complete = true;
+        break;
+      }
+      text += grapheme;
+      used += nextWidth;
+    }
+    appendSpan(truncated, { text, tone: span.tone });
+  }
+
+  appendSpan(truncated, { text: "…", tone: "dim" });
+  return truncated;
+};
+
+const flattenFields = (fields: Span[][]): Span[] => {
+  const spans: Span[] = [];
+  fields.forEach((field, index) => {
+    if (index > 0) appendSpan(spans, { text: " | ", tone: "muted" });
+    for (const span of field) appendSpan(spans, span);
+  });
+  return spans;
+};
 
 export const parseStatuslineCache = (
   raw: string,
@@ -49,25 +242,109 @@ export const parseStatuslineCache = (
   }
 };
 
+export const formatModelName = (
+  model: ModelLike | undefined,
+): string | undefined => {
+  const name = model?.name ?? model?.id;
+  if (name === undefined || name === "") return undefined;
+  return singleLine(name).replace(/ *\([^)]*context[^)]*\)$/i, "");
+};
+
+const roundTiesToEven = (value: number): number => {
+  const lower = Math.floor(value);
+  const fraction = value - lower;
+  if (fraction < 0.5) return lower;
+  if (fraction > 0.5) return lower + 1;
+  return lower % 2 === 0 ? lower : lower + 1;
+};
+
+export const remainingContextPercent = (
+  usage: ContextUsageLike | undefined,
+): number | undefined => {
+  if (usage?.percent === null || usage?.percent === undefined) return undefined;
+  if (!Number.isFinite(usage.percent)) return undefined;
+  const bounded = Math.min(100, Math.max(0, usage.percent));
+  return 100 - roundTiesToEven(bounded);
+};
+
+const contextTone = (remaining: number): ThemeColorLike => {
+  if (remaining >= 30) return "success";
+  if (remaining >= 10) return "warning";
+  return "error";
+};
+
+/**
+ * Render the Claude-compatible one-line footer. Every field is kept as plain
+ * spans until after width truncation, so theme escape sequences never affect
+ * the terminal-width calculation.
+ */
 export const renderStatusline = (
-  cache: StatuslineCache | undefined,
-  branch: string | undefined,
-): string[] | undefined => {
-  const parts: string[] = [];
-  if (cache !== undefined) {
-    if (typeof cache.label === "string" && cache.label !== "") {
-      parts.push(cache.label);
-    }
-    if (isRecord(cache.checks)) {
-      const checks = cache.checks;
-      parts.push(
-        SLOTS.map(([slot, display]) => {
-          const state = checks[slot];
-          return `${display}:${glyph(isRecord(state) ? state.status : undefined)}`;
-        }).join(" "),
-      );
-    }
+  snapshot: StatuslineSnapshot,
+  runtime: StatuslineRuntime,
+  width: number,
+  theme: ThemeLike,
+): string[] => {
+  const fields: Span[][] = [];
+  const directory = singleLine(snapshot.directory);
+
+  if (snapshot.git.isRepository && snapshot.git.repository !== undefined) {
+    fields.push([{ text: singleLine(snapshot.git.repository) }]);
   }
-  if (branch !== undefined && branch !== "") parts.push(`(${branch})`);
-  return parts.length === 0 ? undefined : [parts.join(" ")];
+  // Claude always starts with the current directory, even when its basename
+  // is empty (for example, the filesystem root).
+  fields.push([{ text: directory }]);
+
+  const branch =
+    runtime.branch === undefined || runtime.branch === null
+      ? ""
+      : singleLine(runtime.branch);
+  if (branch !== "" && branch !== "detached") {
+    fields.push([{ text: branch }]);
+  }
+
+  if (
+    snapshot.git.isRepository &&
+    (snapshot.git.additions > 0 || snapshot.git.deletions > 0)
+  ) {
+    fields.push([
+      { text: `+${snapshot.git.additions}`, tone: "success" },
+      { text: " " },
+      { text: `-${snapshot.git.deletions}`, tone: "error" },
+    ]);
+  }
+
+  const cachedLabel =
+    typeof snapshot.cache?.label === "string"
+      ? singleLine(snapshot.cache.label)
+      : "";
+  const projectLabel = cachedLabel || singleLine(snapshot.projectLabel ?? "");
+  if (projectLabel !== "") {
+    const checks: Span[] = [{ text: projectLabel }];
+    for (const [slot, display] of SLOTS) {
+      const status = checkStatus(snapshot.cache, slot);
+      const [glyph, tone] = STATUS_STYLES.get(status) ?? ["?", "dim"];
+      checks.push({ text: ` ${display}` }, { text: glyph, tone });
+    }
+    fields.push(checks);
+  }
+
+  const modelName = singleLine(runtime.modelName ?? "");
+  if (modelName !== "") fields.push([{ text: modelName, tone: "accent" }]);
+
+  if (runtime.remainingContext !== undefined) {
+    const remaining = Math.min(
+      100,
+      Math.max(0, Math.round(runtime.remainingContext)),
+    );
+    fields.push([{ text: `${remaining}%`, tone: contextTone(remaining) }]);
+  }
+
+  const spans = truncateSpans(flattenFields(fields), Math.max(0, width));
+  return [
+    spans
+      .map((span) =>
+        span.tone === undefined ? span.text : theme.fg(span.tone, span.text),
+      )
+      .join(""),
+  ];
 };

--- a/pi/extensions/pi-harness/lib/pi-like.ts
+++ b/pi/extensions/pi-harness/lib/pi-like.ts
@@ -98,6 +98,50 @@ export interface PiEventResultMap {
 
 export type NotifyLevel = "info" | "warning" | "error";
 
+export type ThemeColorLike =
+  | "accent"
+  | "success"
+  | "error"
+  | "warning"
+  | "muted"
+  | "dim";
+
+export interface ThemeLike {
+  fg(color: ThemeColorLike, text: string): string;
+}
+
+export interface TuiLike {
+  requestRender(): void;
+}
+
+export interface FooterDataLike {
+  getGitBranch(): string | null;
+  onBranchChange(callback: () => void): () => void;
+}
+
+export interface FooterComponentLike {
+  render(width: number): string[];
+  invalidate(): void;
+  dispose?(): void;
+}
+
+export type FooterFactoryLike = (
+  tui: TuiLike,
+  theme: ThemeLike,
+  footerData: FooterDataLike,
+) => FooterComponentLike;
+
+export interface ModelLike {
+  id: string;
+  name?: string;
+}
+
+export interface ContextUsageLike {
+  percent: number | null;
+}
+
+export type PiModeLike = "tui" | "rpc" | "json" | "print";
+
 export interface DialogOptionsLike {
   signal?: AbortSignal;
   timeout?: number;
@@ -121,13 +165,16 @@ export interface UiLike {
   ): Promise<string | undefined>;
   notify(message: string, level?: NotifyLevel): void;
   setWidget?(key: string, lines: string[] | undefined): void;
-  setFooter?(text: string | undefined): void;
+  setFooter?(factory: FooterFactoryLike | undefined): void;
 }
 
 export interface CtxLike {
   hasUI: boolean;
   ui: UiLike;
+  mode?: PiModeLike;
   cwd?: string;
+  model?: ModelLike;
+  getContextUsage?(): ContextUsageLike | undefined;
 }
 
 export type PiEventHandler<K extends PiEventName> = (

--- a/tests/pi-harness/fake-pi.ts
+++ b/tests/pi-harness/fake-pi.ts
@@ -18,11 +18,18 @@
 import type {
   AgentStartInjection,
   BeforeAgentStartEvent,
+  ContextUsageLike,
   CtxLike,
   DialogOptionsLike,
+  FooterComponentLike,
+  FooterDataLike,
   GenericEvent,
+  ModelLike,
   NotifyLevel,
   PiEventHandler,
+  PiModeLike,
+  ThemeLike,
+  TuiLike,
   PiEventName,
   PiLike,
   SessionStartEvent,
@@ -82,6 +89,14 @@ export interface FakePi extends PiLike {
   readonly notifications: Notification[];
   /** Widget lines captured from ctx.ui.setWidget, keyed by widget id. */
   readonly widgets: Map<string, string[] | undefined>;
+  /** Render the currently installed custom footer with the identity theme. */
+  renderFooter(width: number): string[] | undefined;
+  /** Notify footer branch subscribers, matching FooterDataProvider behavior. */
+  setGitBranch(branch: string | null): void;
+  /** Replace the context-usage result returned by the handler context. */
+  setContextUsage(usage: ContextUsageLike | undefined): void;
+  /** Number of renders requested through the fake TUI. */
+  readonly footerRenderRequests: number;
   /** Queue a response for the next ctx.ui.confirm call (defaults to false). */
   queueConfirm(answer: boolean): void;
   /** Select the zero-based option on the next ctx.ui.select call. */
@@ -96,7 +111,14 @@ export interface FakePi extends PiLike {
 }
 
 export function createFakePi(
-  options: { hasUI?: boolean; cwd?: string } = {},
+  options: {
+    hasUI?: boolean;
+    mode?: PiModeLike;
+    cwd?: string;
+    gitBranch?: string | null;
+    model?: ModelLike;
+    contextUsage?: ContextUsageLike;
+  } = {},
 ): FakePi {
   const store: HandlerStore = {
     session_start: [],
@@ -116,10 +138,32 @@ export function createFakePi(
   const inputQueue: { answer: string | undefined }[] = [];
   const selectDialogs: SelectDialog[] = [];
   const inputDialogs: InputDialog[] = [];
+  const branchCallbacks = new Set<() => void>();
+  let gitBranch = options.gitBranch ?? null;
+  let { contextUsage } = options;
+  let footerComponent: FooterComponentLike | undefined;
+  let footerRenderRequests = 0;
+
+  const tui: TuiLike = {
+    requestRender: () => {
+      footerRenderRequests += 1;
+    },
+  };
+  const theme: ThemeLike = { fg: (_color, text) => text };
+  const footerData: FooterDataLike = {
+    getGitBranch: () => gitBranch,
+    onBranchChange: (callback) => {
+      branchCallbacks.add(callback);
+      return () => branchCallbacks.delete(callback);
+    },
+  };
 
   const ctx: CtxLike & { hasUI: boolean } = {
     hasUI: options.hasUI ?? true,
+    mode: options.mode ?? "tui",
     cwd: options.cwd,
+    model: options.model,
+    getContextUsage: () => contextUsage,
     ui: {
       select: async (title, choices, dialogOptions) => {
         selectDialogs.push({
@@ -140,6 +184,10 @@ export function createFakePi(
       },
       setWidget: (key, lines) => {
         widgets.set(key, lines);
+      },
+      setFooter: (factory) => {
+        footerComponent?.dispose?.();
+        footerComponent = factory?.(tui, theme, footerData);
       },
     },
   };
@@ -218,6 +266,19 @@ export function createFakePi(
     tools,
     notifications,
     widgets,
+    renderFooter(width) {
+      return footerComponent?.render(width);
+    },
+    setGitBranch(branch) {
+      gitBranch = branch;
+      for (const callback of branchCallbacks) callback();
+    },
+    setContextUsage(usage) {
+      contextUsage = usage;
+    },
+    get footerRenderRequests() {
+      return footerRenderRequests;
+    },
     queueConfirm(answer) {
       confirmQueue.push(answer);
     },

--- a/tests/pi-harness/statusline.test.ts
+++ b/tests/pi-harness/statusline.test.ts
@@ -1,22 +1,46 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { visibleWidth as piVisibleWidth } from "@earendil-works/pi-tui";
 import { createHash } from "node:crypto";
 import { promises as fs } from "node:fs";
 import { dirname, join } from "node:path";
 import type { HarnessConfig } from "../../pi/extensions/pi-harness/config";
-import setupStatusline from "../../pi/extensions/pi-harness/features/statusline/index";
+import setupStatusline, {
+  parseNumstat,
+  parseOriginRepository,
+} from "../../pi/extensions/pi-harness/features/statusline/index";
 import {
+  formatModelName,
+  type GitStatus,
   parseStatuslineCache,
+  remainingContextPercent,
   renderStatusline,
   STATUSLINE_WIDGET_KEY,
+  type StatuslineSnapshot,
+  visibleStatuslineWidth,
 } from "../../pi/extensions/pi-harness/features/statusline/render";
 import type { DetachedSpawnFunction } from "../../pi/extensions/pi-harness/lib/detached";
 import { resolvePaths } from "../../pi/extensions/pi-harness/lib/paths";
+import type { ThemeLike } from "../../pi/extensions/pi-harness/lib/pi-like";
 import { cleanupTestDirectory, setupTestDirectory } from "../test-helpers";
 import { createFakePi } from "./fake-pi";
 
 const tempDirectories: string[] = [];
+const identityTheme: ThemeLike = { fg: (_color, text) => text };
+const ansiTheme: ThemeLike = {
+  fg: (color, text) => {
+    const code = {
+      accent: 36,
+      success: 32,
+      error: 31,
+      warning: 33,
+      muted: 90,
+      dim: 90,
+    }[color];
+    return `\u001B[${code}m${text}\u001B[0m`;
+  },
+};
 
-const makeTempDirectory = async (prefix: string): Promise<string> => {
+const tempDirectory = async (prefix: string): Promise<string> => {
   const directory = await setupTestDirectory(prefix);
   tempDirectories.push(directory);
   return directory;
@@ -53,7 +77,7 @@ const waitFor = async (condition: () => Promise<boolean>): Promise<void> => {
   throw new Error("Timed out waiting for condition");
 };
 
-const sampleCache = (label = "ts") => ({
+const sampleCache = (label = "TS") => ({
   project_root: "/repo",
   language: "ts",
   label,
@@ -65,7 +89,23 @@ const sampleCache = (label = "ts") => ({
   },
 });
 
-/** Seed a cache file exactly where the bash runner would write it. */
+const gitStatus = (overrides: Partial<GitStatus> = {}): GitStatus => ({
+  isRepository: true,
+  repository: "ushironoko/dotfiles",
+  additions: 0,
+  deletions: 0,
+  ...overrides,
+});
+
+const snapshot = (
+  overrides: Partial<StatuslineSnapshot> = {},
+): StatuslineSnapshot => ({
+  directory: "dotfiles",
+  git: gitStatus(),
+  ...overrides,
+});
+
+/** Seed a cache file exactly where the bash runner writes it. */
 const seedCache = async (
   cacheDir: string,
   projectRoot: string,
@@ -76,45 +116,287 @@ const seedCache = async (
   await fs.writeFile(join(cacheDir, `${hash}.json`), JSON.stringify(payload));
 };
 
-/** Make a directory look like a ts project so the root detector accepts it. */
+/** Make a directory look like a TS project so the root detector accepts it. */
 const markAsProject = async (root: string): Promise<void> => {
   await fs.writeFile(join(root, "package.json"), "{}");
   await fs.writeFile(join(root, "tsconfig.json"), "{}");
 };
 
-describe("renderStatusline", () => {
-  test("renders label, one glyph per check slot, and the branch", () => {
-    const lines = renderStatusline(sampleCache(), "feat/x");
-    expect(lines).toEqual(["ts lint:✓ type:… test:✗ (feat/x)"]);
+const runGit = async (cwd: string, args: string[]): Promise<void> => {
+  const process = Bun.spawn(["git", ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [exitCode, stderr] = await Promise.all([
+    process.exited,
+    new Response(process.stderr).text(),
+  ]);
+  if (exitCode !== 0) throw new Error(`git ${args.join(" ")}: ${stderr}`);
+};
+
+describe("Claude-compatible statusline rendering", () => {
+  test("renders every Claude field in the same order", () => {
+    const lines = renderStatusline(
+      snapshot({
+        git: gitStatus({ additions: 12, deletions: 3 }),
+        projectLabel: "TS",
+        cache: sampleCache(),
+      }),
+      {
+        branch: "feat/pi",
+        modelName: "Opus 4.8",
+        remainingContext: 42,
+      },
+      200,
+      identityTheme,
+    );
+
+    expect(lines).toEqual([
+      "ushironoko/dotfiles | dotfiles | feat/pi | +12 -3 | TS L✓ T… X✗ | Opus 4.8 | 42%",
+    ]);
   });
 
-  test("unknown statuses render as ?", () => {
-    const cache = {
-      label: "rust",
-      checks: { lint: { status: "weird" }, typecheck: {}, test: undefined },
-    };
-    const lines = renderStatusline(cache, undefined);
-    expect(lines).toEqual(["rust lint:? type:? test:?"]);
+  test("renders pending checks before the first cache file exists", () => {
+    expect(
+      renderStatusline(
+        snapshot({
+          git: {
+            isRepository: false,
+            additions: 0,
+            deletions: 0,
+          },
+          projectLabel: "TS",
+        }),
+        {},
+        100,
+        identityTheme,
+      ),
+    ).toEqual(["dotfiles | TS L? T? X?"]);
   });
 
-  test("branch-only rendering works without a cache", () => {
-    expect(renderStatusline(undefined, "main")).toEqual(["(main)"]);
+  test("uses Claude-equivalent colors for diffs, checks, model, and context", () => {
+    const [line = ""] = renderStatusline(
+      snapshot({
+        git: gitStatus({ additions: 2, deletions: 1 }),
+        projectLabel: "TS",
+        cache: sampleCache(),
+      }),
+      { modelName: "Sonnet", remainingContext: 9 },
+      200,
+      ansiTheme,
+    );
+
+    expect(line).toContain("\u001B[32m+2\u001B[0m");
+    expect(line).toContain("\u001B[31m-1\u001B[0m");
+    expect(line).toContain("L\u001B[32m✓\u001B[0m");
+    expect(line).toContain("T\u001B[33m…\u001B[0m");
+    expect(line).toContain("X\u001B[31m✗\u001B[0m");
+    expect(line).toContain("\u001B[36mSonnet\u001B[0m");
+    expect(line).toContain("\u001B[31m9%\u001B[0m");
   });
 
-  test("nothing to show clears the widget", () => {
-    expect(renderStatusline(undefined, undefined)).toBeUndefined();
+  test("omits detached HEAD like git branch --show-current", () => {
+    expect(
+      renderStatusline(snapshot(), { branch: "detached" }, 100, identityTheme),
+    ).toEqual(["ushironoko/dotfiles | dotfiles"]);
   });
 
-  test("parseStatuslineCache rejects malformed JSON and non-objects", () => {
+  test("sanitizes controls and truncates CJK fields to the component width", () => {
+    const [line = ""] = renderStatusline(
+      snapshot({
+        directory: "日本語-project\nspoofed",
+        git: {
+          isRepository: false,
+          additions: 0,
+          deletions: 0,
+        },
+      }),
+      {},
+      8,
+      identityTheme,
+    );
+
+    expect(line).not.toContain("\n");
+    expect(line.endsWith("…")).toBe(true);
+    expect(visibleStatuslineWidth(line)).toBeLessThanOrEqual(8);
+  });
+
+  test("matches pi-tui width for emoji and East Asian wide graphemes", () => {
+    for (const directory of ["☕abcde", "\uA960abcde", "\u{17000}abcde"]) {
+      const [line = ""] = renderStatusline(
+        snapshot({
+          directory,
+          git: {
+            isRepository: false,
+            additions: 0,
+            deletions: 0,
+          },
+        }),
+        {},
+        5,
+        identityTheme,
+      );
+
+      expect(piVisibleWidth(line)).toBeLessThanOrEqual(5);
+    }
+  });
+
+  test("matches pi-tui for text emoji and multi-code-point graphemes", () => {
+    for (const grapheme of ["❤", "❤️", "가"]) {
+      expect(visibleStatuslineWidth(grapheme)).toBe(piVisibleWidth(grapheme));
+    }
+
+    const [line = ""] = renderStatusline(
+      snapshot({
+        directory: "가a",
+        git: { isRepository: false, additions: 0, deletions: 0 },
+      }),
+      {},
+      3,
+      identityTheme,
+    );
+    expect(line).toBe("가a");
+  });
+
+  test("normalizes model names and reports full-window remaining context", () => {
+    expect(
+      formatModelName({ id: "claude-opus", name: "Opus 4.8 (1M context)" }),
+    ).toBe("Opus 4.8");
+    expect(remainingContextPercent({ percent: 70.4 })).toBe(30);
+    expect(remainingContextPercent({ percent: 70.5 })).toBe(30);
+    expect(remainingContextPercent({ percent: 71.5 })).toBe(28);
+    expect(remainingContextPercent({ percent: 110 })).toBe(0);
+    expect(remainingContextPercent({ percent: null })).toBeUndefined();
+  });
+
+  test("malformed inherited status names fall back without reaching the theme", () => {
+    const [line = ""] = renderStatusline(
+      snapshot({
+        projectLabel: "TS",
+        cache: {
+          checks: {
+            lint: { status: "__proto__" },
+            typecheck: { status: "constructor" },
+            test: { status: "toString" },
+          },
+        },
+      }),
+      {},
+      100,
+      ansiTheme,
+    );
+
+    expect(line).toContain(
+      "L\u001B[90m?\u001B[0m T\u001B[90m?\u001B[0m X\u001B[90m?\u001B[0m",
+    );
+  });
+
+  test("parses cache, remote, and numstat inputs defensively", () => {
     expect(parseStatuslineCache("not json")).toBeUndefined();
     expect(parseStatuslineCache('"string"')).toBeUndefined();
-    expect(parseStatuslineCache('{"label":"ts"}')).toEqual({ label: "ts" });
+    expect(parseStatuslineCache('{"label":"TS"}')).toEqual({ label: "TS" });
+    expect(parseOriginRepository("git@github.com:org/repo.git\n")).toBe(
+      "org/repo",
+    );
+    expect(parseOriginRepository("https://github.com/org/repo.git")).toBe(
+      "org/repo",
+    );
+    expect(parseNumstat("3\t2\ta.ts\n-\t-\timage.png\n4\t0\tb.ts\n")).toEqual({
+      additions: 7,
+      deletions: 2,
+    });
   });
 });
 
-describe("pi-harness statusline feature", () => {
+describe("pi-harness statusline lifecycle", () => {
+  test("session_start installs a dynamic custom footer from cache", async () => {
+    const home = await tempDirectory("pi-statusline-render");
+    const project = join(home, "repo");
+    await fs.mkdir(project, { recursive: true });
+    await markAsProject(project);
+    const cacheDir = join(home, "cache");
+    await seedCache(cacheDir, project, sampleCache("BUN"));
+
+    const pi = createFakePi({
+      cwd: project,
+      gitBranch: "feat/pi",
+      model: { id: "claude-opus", name: "Opus 4.8 (1M context)" },
+      contextUsage: { percent: 58.2 },
+    });
+    setupStatusline(pi, makeConfig(home, [project]), {
+      cacheDir,
+      getGitStatus: async () =>
+        gitStatus({ repository: "acme/repo", additions: 5, deletions: 2 }),
+    });
+
+    await pi.emitSessionStart({ type: "session_start", reason: "startup" });
+    expect(pi.renderFooter(200)).toEqual([
+      "acme/repo | repo | feat/pi | +5 -2 | BUN L✓ T… X✗ | Opus 4.8 | 42%",
+    ]);
+    expect(pi.widgets.get(STATUSLINE_WIDGET_KEY)).toBeUndefined();
+    expect(pi.footerRenderRequests).toBeGreaterThan(0);
+  });
+
+  test("branch, model, and context updates are reflected without reinstalling", async () => {
+    const home = await tempDirectory("pi-statusline-dynamic");
+    const plainDirectory = join(home, "plain");
+    await fs.mkdir(plainDirectory, { recursive: true });
+    const pi = createFakePi({
+      cwd: plainDirectory,
+      gitBranch: "main",
+      model: { id: "model-a", name: "Model A" },
+      contextUsage: { percent: 20 },
+    });
+    setupStatusline(pi, makeConfig(home, [plainDirectory]), {
+      getGitStatus: async () => gitStatus({ repository: undefined }),
+    });
+    await pi.emitSessionStart({ type: "session_start", reason: "startup" });
+    const requestsBeforeBranchChange = pi.footerRenderRequests;
+
+    pi.setGitBranch("topic");
+    pi.ctx.model = { id: "model-b", name: "Model B" };
+    pi.setContextUsage({ percent: 91 });
+
+    expect(pi.footerRenderRequests).toBeGreaterThan(requestsBeforeBranchChange);
+    expect(pi.renderFooter(100)).toEqual(["plain | topic | Model B | 9%"]);
+  });
+
+  test("default git collection renders origin and tracked diff totals", async () => {
+    const home = await tempDirectory("pi-statusline-git");
+    const project = join(home, "repo");
+    await fs.mkdir(project, { recursive: true });
+    await markAsProject(project);
+    await fs.writeFile(join(project, "source.txt"), "one\ntwo\n");
+    await runGit(project, ["init", "-b", "main"]);
+    await runGit(project, ["config", "user.email", "test@example.com"]);
+    await runGit(project, ["config", "user.name", "Status Test"]);
+    await runGit(project, ["add", "."]);
+    await runGit(project, ["commit", "-m", "initial"]);
+    await runGit(project, [
+      "remote",
+      "add",
+      "origin",
+      "git@github.com:owner/project.git",
+    ]);
+    await fs.writeFile(
+      join(project, "source.txt"),
+      "one changed\ntwo\nthree\n",
+    );
+
+    const pi = createFakePi({ cwd: project, gitBranch: "main" });
+    setupStatusline(pi, makeConfig(home, [project]), {
+      cacheDir: join(home, "cache"),
+    });
+    await pi.emitSessionStart({ type: "session_start", reason: "startup" });
+
+    expect(pi.renderFooter(200)).toEqual([
+      "owner/project | repo | main | +2 -1 | TS L? T? X?",
+    ]);
+  });
+
   test("agent_settled launches the checks runner detached for a trusted root", async () => {
-    const home = await makeTempDirectory("pi-statusline-run");
+    const home = await tempDirectory("pi-statusline-run");
     const project = join(home, "repo");
     await fs.mkdir(project, { recursive: true });
     await markAsProject(project);
@@ -124,7 +406,6 @@ describe("pi-harness statusline feature", () => {
       "lib/statusline_checks_run.sh",
     );
     await fs.mkdir(dirname(runner), { recursive: true });
-    // Temp-then-rename so the poller never observes a half-written capture.
     await fs.writeFile(
       runner,
       [
@@ -138,7 +419,11 @@ describe("pi-harness statusline feature", () => {
     const pi = createFakePi({ cwd: project });
     setupStatusline(pi, makeConfig(home, [project]), {
       cacheDir: join(home, "cache"),
-      getBranch: async () => undefined,
+      getGitStatus: async () => ({
+        isRepository: false,
+        additions: 0,
+        deletions: 0,
+      }),
     });
 
     await pi.emitAgentSettled();
@@ -150,12 +435,11 @@ describe("pi-harness statusline feature", () => {
         return false;
       }
     });
-    const captured = (await fs.readFile(captureFile, "utf8")).trim();
-    expect(captured).toBe(project);
+    expect((await fs.readFile(captureFile, "utf8")).trim()).toBe(project);
   });
 
   test("passes the canonical trusted root to the runner as a boundary", async () => {
-    const home = await makeTempDirectory("pi-statusline-boundary");
+    const home = await tempDirectory("pi-statusline-boundary");
     const project = join(home, "repo");
     await fs.mkdir(project, { recursive: true });
     await markAsProject(project);
@@ -178,7 +462,11 @@ describe("pi-harness statusline feature", () => {
     const pi = createFakePi({ cwd: project });
     setupStatusline(pi, makeConfig(home, [project]), {
       cacheDir: join(home, "cache"),
-      getBranch: async () => undefined,
+      getGitStatus: async () => ({
+        isRepository: false,
+        additions: 0,
+        deletions: 0,
+      }),
     });
 
     await pi.emitAgentSettled();
@@ -190,18 +478,19 @@ describe("pi-harness statusline feature", () => {
         return false;
       }
     });
-    const [cwdArg, boundaryArg] = (await fs.readFile(captureFile, "utf8"))
+    const [cwdArgument, boundaryArgument] = (
+      await fs.readFile(captureFile, "utf8")
+    )
       .trim()
       .split("\n");
-    expect(cwdArg).toBe(project);
-    // The boundary is the canonical (realpath'd) trusted root containing cwd.
-    expect(await fs.realpath(boundaryArg ?? "")).toBe(
+    expect(cwdArgument).toBe(project);
+    expect(await fs.realpath(boundaryArgument ?? "")).toBe(
       await fs.realpath(project),
     );
   });
 
   test("an untrusted root never launches the runner but still renders", async () => {
-    const home = await makeTempDirectory("pi-statusline-untrusted");
+    const home = await tempDirectory("pi-statusline-untrusted");
     const project = join(home, "repo");
     await fs.mkdir(project, { recursive: true });
     await markAsProject(project);
@@ -212,81 +501,87 @@ describe("pi-harness statusline feature", () => {
       launches.push(command);
     };
 
-    const pi = createFakePi({ cwd: project });
-    setupStatusline(pi, makeConfig(home, []), {
+    let gitReads = 0;
+    const pi = createFakePi({ cwd: project, gitBranch: "main" });
+    setupStatusline(pi, makeConfig(home), {
       cacheDir,
       spawnDetached,
-      getBranch: async () => "main",
+      getGitStatus: async () => {
+        gitReads += 1;
+        return gitStatus({ repository: undefined });
+      },
     });
 
     await pi.emitAgentSettled();
     expect(launches).toHaveLength(0);
-    expect(pi.widgets.get(STATUSLINE_WIDGET_KEY)).toEqual([
-      "ts lint:✓ type:… test:✗ (main)",
-    ]);
+    expect(gitReads).toBe(0);
+    expect(pi.renderFooter(100)).toEqual(["repo | main | TS L✓ T… X✗"]);
   });
 
-  test("session_start renders the widget from the cache", async () => {
-    const home = await makeTempDirectory("pi-statusline-render");
+  test("directory-valued project markers are ignored like the shell -f test", async () => {
+    const home = await tempDirectory("pi-statusline-dirmarker");
     const project = join(home, "repo");
-    await fs.mkdir(project, { recursive: true });
-    await markAsProject(project);
-    const cacheDir = join(home, "cache");
-    await seedCache(cacheDir, project, sampleCache("bun"));
-    const spawnDetached: DetachedSpawnFunction = () => {};
-
-    const pi = createFakePi({ cwd: project });
-    setupStatusline(pi, makeConfig(home, []), {
-      cacheDir,
-      spawnDetached,
-      getBranch: async () => "feat/pi",
-    });
-
-    await pi.emitSessionStart({ type: "session_start", reason: "startup" });
-    expect(pi.widgets.get(STATUSLINE_WIDGET_KEY)).toEqual([
-      "bun lint:✓ type:… test:✗ (feat/pi)",
-    ]);
-  });
-
-  test("directory-valued project markers are ignored like the shell's -f test", async () => {
-    const home = await makeTempDirectory("pi-statusline-dirmarker");
-    const project = join(home, "repo");
-    // Markers exist but as DIRECTORIES; statusline_checks_lib.sh uses [ -f ]
-    // so it walks past this root — the TS port must agree or the two
-    // harnesses would read different cache files for the same cwd.
     await fs.mkdir(join(project, "package.json"), { recursive: true });
     await fs.mkdir(join(project, "tsconfig.json"), { recursive: true });
     await fs.mkdir(join(project, "Cargo.toml"), { recursive: true });
     const cacheDir = join(home, "cache");
     await seedCache(cacheDir, project, sampleCache());
-    const spawnDetached: DetachedSpawnFunction = () => {};
 
-    const pi = createFakePi({ cwd: project });
-    setupStatusline(pi, makeConfig(home, []), {
+    const pi = createFakePi({ cwd: project, gitBranch: "main" });
+    setupStatusline(pi, makeConfig(home), {
       cacheDir,
-      spawnDetached,
-      getBranch: async () => "main",
+      getGitStatus: async () => gitStatus({ repository: undefined }),
     });
-
     await pi.emitSessionStart({ type: "session_start", reason: "startup" });
-    // No project root detected → the seeded cache must NOT be read.
-    expect(pi.widgets.get(STATUSLINE_WIDGET_KEY)).toEqual(["(main)"]);
+
+    expect(pi.renderFooter(100)).toEqual(["repo | main"]);
   });
 
-  test("outside a detected project the widget falls back to the branch", async () => {
-    const home = await makeTempDirectory("pi-statusline-noproject");
-    const plainDir = join(home, "plain");
-    await fs.mkdir(plainDir, { recursive: true });
-    const spawnDetached: DetachedSpawnFunction = () => {};
+  test("skips git and UI collection in print and JSON modes", async () => {
+    const home = await tempDirectory("pi-statusline-headless");
+    const project = join(home, "repo");
+    await fs.mkdir(project, { recursive: true });
+    await markAsProject(project);
 
-    const pi = createFakePi({ cwd: plainDir });
-    setupStatusline(pi, makeConfig(home, []), {
+    for (const mode of ["print", "json"] as const) {
+      let gitReads = 0;
+      let branchReads = 0;
+      const pi = createFakePi({ cwd: project, mode });
+      setupStatusline(pi, makeConfig(home, [project]), {
+        getGitStatus: async () => {
+          gitReads += 1;
+          return gitStatus();
+        },
+        getBranch: async () => {
+          branchReads += 1;
+          return "main";
+        },
+      });
+
+      await pi.emitSessionStart({ type: "session_start", reason: "startup" });
+      await pi.emitAgentSettled();
+      expect(gitReads).toBe(0);
+      expect(branchReads).toBe(0);
+      expect(pi.renderFooter(100)).toBeUndefined();
+      expect(pi.widgets.size).toBe(0);
+    }
+  });
+
+  test("uses the widget fallback in RPC mode", async () => {
+    const home = await tempDirectory("pi-statusline-fallback");
+    const project = join(home, "repo");
+    await fs.mkdir(project, { recursive: true });
+    await markAsProject(project);
+    const pi = createFakePi({ cwd: project, mode: "rpc" });
+    setupStatusline(pi, makeConfig(home, [project]), {
       cacheDir: join(home, "cache"),
-      spawnDetached,
+      getGitStatus: async () => gitStatus({ repository: undefined }),
       getBranch: async () => "main",
     });
 
     await pi.emitSessionStart({ type: "session_start", reason: "startup" });
-    expect(pi.widgets.get(STATUSLINE_WIDGET_KEY)).toEqual(["(main)"]);
+    expect(pi.widgets.get(STATUSLINE_WIDGET_KEY)).toEqual([
+      "repo | main | TS L? T? X?",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- replace the checks-only widget with a Claude-compatible footer showing repository, directory, branch, tracked diff, quality checks, model, and remaining context
- use a custom footer in TUI mode and a widget in RPC mode while skipping headless UI work and trust-gating repository Git/check commands
- keep rendering within pi-tui width limits and cover lifecycle, trust, RPC, Unicode, and malformed-cache behavior

## Testing

- `bun run run-all` (814 passed, 2 gated skips)