### PR TITLE
Improve multi-select keyboard navigation

### DIFF
--- a/pi/extensions/pi-harness/features/ask-user-question/index.ts
+++ b/pi/extensions/pi-harness/features/ask-user-question/index.ts
@@ -38,12 +38,91 @@ interface OtherInputResult {
   value?: string;
 }
 
+interface AbortEventSignal {
+  addEventListener(
+    type: "abort",
+    listener: () => void,
+    options?: { once?: boolean },
+  ): void;
+  removeEventListener(type: "abort", listener: () => void): void;
+}
+
+type MultiSelectAction = "submit" | "other" | "cancel" | "aborted";
+
+interface MultiSelectState {
+  selectedIndices: Set<number>;
+  cursorIndex: number;
+  otherText?: string;
+}
+
+type SelectKeybinding =
+  | "tui.select.up"
+  | "tui.select.down"
+  | "tui.select.pageUp"
+  | "tui.select.pageDown"
+  | "tui.select.confirm"
+  | "tui.select.cancel";
+
+interface KeybindingsLike {
+  matches(data: string, keybinding: SelectKeybinding): boolean;
+}
+
+interface TuiLike {
+  readonly terminal?: { readonly rows: number };
+  requestRender(): void;
+}
+
+interface ThemeLike {
+  fg(
+    color: "accent" | "success" | "error" | "warning" | "muted" | "dim",
+    text: string,
+  ): string;
+}
+
+interface CustomComponentLike {
+  render(width: number): string[];
+  invalidate(): void;
+  handleInput?(data: string): void;
+  dispose?(): void;
+}
+
+type CustomUiFactory<T> = (
+  tui: TuiLike,
+  theme: ThemeLike,
+  keybindings: KeybindingsLike,
+  done: (result: T) => void,
+) => CustomComponentLike | Promise<CustomComponentLike>;
+
+type AskUiLike = CtxLike["ui"] & {
+  custom?<T>(factory: CustomUiFactory<T>): Promise<T>;
+};
+
+interface AskCtxLike extends CtxLike {
+  mode?: "tui" | "rpc" | "json" | "print";
+  ui: AskUiLike;
+}
+
 const OTHER_ACTION =
   "Other — type, edit, or submit empty text to clear a custom answer";
 const DONE_ACTION = "Done — submit these selections";
+const KITTY_CODEPOINT_PATTERN =
+  /^\[(\d+)(?::\d*)?(?::\d+)?(?:;(\d+))?(?::(\d+))?u$/;
+const KITTY_ARROW_PATTERN = /^\[1;(\d+)(?::(\d+))?([AB])$/;
+const KITTY_LOCK_MODIFIER_MASK = 64 | 128;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
+
+const asAbortEventSignal = (
+  signal: AbortSignal | undefined,
+): AbortEventSignal | undefined => {
+  if (!isRecord(signal)) return undefined;
+  const add = signal.addEventListener;
+  const remove = signal.removeEventListener;
+  return typeof add === "function" && typeof remove === "function"
+    ? (signal as unknown as AbortEventSignal)
+    : undefined;
+};
 
 const requireParameters = (params: unknown): AskUserQuestionInput => {
   if (!isRecord(params) || !Array.isArray(params.questions)) {
@@ -184,6 +263,85 @@ const sanitizeForMenu = (value: string): string =>
 const sanitizeForResult = (value: string): string =>
   stripTerminalControls(value, "\n");
 
+const hasOnlyKittyLockModifiers = (encodedModifier: number): boolean =>
+  ((encodedModifier - 1) & ~KITTY_LOCK_MODIFIER_MASK) === 0;
+
+const isKittyCodepoint = (data: string, expectedCodepoint: number): boolean => {
+  if (!data.startsWith("\u001b")) return false;
+  const match = KITTY_CODEPOINT_PATTERN.exec(data.slice(1));
+  if (match === null) return false;
+  const encodedModifier = match[2] === undefined ? 1 : Number(match[2]);
+  const event = match[3] === undefined ? 1 : Number(match[3]);
+  return (
+    hasOnlyKittyLockModifiers(encodedModifier) &&
+    event !== 3 &&
+    Number(match[1]) === expectedCodepoint
+  );
+};
+
+const isArrowKey = (data: string, direction: "up" | "down"): boolean => {
+  const final = direction === "up" ? "A" : "B";
+  const keypadCodepoint = direction === "up" ? 57_419 : 57_420;
+  if (data === `\u001b[${final}` || data === `\u001bO${final}`) return true;
+  const match = data.startsWith("\u001b")
+    ? KITTY_ARROW_PATTERN.exec(data.slice(1))
+    : null;
+  if (match !== null) {
+    const event = match[2] === undefined ? 1 : Number(match[2]);
+    return (
+      hasOnlyKittyLockModifiers(Number(match[1])) &&
+      event !== 3 &&
+      match[3] === final
+    );
+  }
+  return isKittyCodepoint(data, keypadCodepoint);
+};
+
+const isSpaceKey = (data: string): boolean =>
+  data === " " || isKittyCodepoint(data, 32);
+
+const isEnterKey = (data: string): boolean =>
+  data === "\r" ||
+  data === "\n" ||
+  data === "\u001bOM" ||
+  isKittyCodepoint(data, 13) ||
+  isKittyCodepoint(data, 57_414);
+
+const isEscapeKey = (data: string): boolean =>
+  data === "\u001b" || data === "\u0003" || isKittyCodepoint(data, 27);
+
+const terminalCellWidth = (character: string): number => {
+  const codepoint = character.codePointAt(0) ?? 0;
+  if (
+    (codepoint >= 768 && codepoint <= 879) ||
+    (codepoint >= 65_024 && codepoint <= 65_039)
+  ) {
+    return 0;
+  }
+  return codepoint <= 126 ? 1 : 2;
+};
+
+const wrapForWidth = (value: string, width: number): string[] => {
+  if (width <= 0) return [""];
+  const lines: string[] = [];
+  let current = "";
+  let used = 0;
+  for (const character of value) {
+    const characterWidth = terminalCellWidth(character);
+    if (used + characterWidth > width && current !== "") {
+      lines.push(current);
+      current = "";
+      used = 0;
+    }
+    if (characterWidth <= width) {
+      current += character;
+      used += characterWidth;
+    }
+  }
+  lines.push(current);
+  return lines;
+};
+
 const optionLine = (
   option: QuestionOption,
   index: number,
@@ -267,7 +425,29 @@ const askSingle = async (
   }
 };
 
-const askMultiple = async (
+const buildMultipleAnswer = (
+  question: Question,
+  selectedIndices: ReadonlySet<number>,
+  otherText: string | undefined,
+): QuestionAnswer => {
+  const orderedOptions = question.options.filter((_option, index) =>
+    selectedIndices.has(index),
+  );
+  const labels = orderedOptions.map((option) => option.label);
+  const previewMode = usesPreviewMode(question);
+  if (!previewMode && otherText !== undefined) labels.push(otherText);
+  const previews = orderedOptions
+    .map((option) => option.preview)
+    .filter((preview): preview is string => preview !== undefined);
+  return {
+    value: labels.length === 0 ? "(notes only)" : labels.join(", "),
+    labels,
+    preview: previews.length === 0 ? undefined : previews.join("\n\n"),
+    notes: previewMode ? otherText : undefined,
+  };
+};
+
+const askMultipleWithDialogs = async (
   question: Question,
   signal: AbortSignal | undefined,
   ctx: CtxLike,
@@ -313,25 +493,243 @@ const askMultiple = async (
       continue;
     }
     if (canSubmit && selectedIndex === question.options.length + 1) {
-      const orderedOptions = question.options.filter((_option, index) =>
-        selectedIndices.has(index),
-      );
-      const labels = orderedOptions.map((option) => option.label);
-      const previewMode = usesPreviewMode(question);
-      if (!previewMode && otherText !== undefined) labels.push(otherText);
-      const previews = orderedOptions
-        .map((option) => option.preview)
-        .filter((preview): preview is string => preview !== undefined);
-      return {
-        value: labels.length === 0 ? "(notes only)" : labels.join(", "),
-        labels,
-        preview: previews.length === 0 ? undefined : previews.join("\n\n"),
-        notes: previewMode ? otherText : undefined,
-      };
+      return buildMultipleAnswer(question, selectedIndices, otherText);
     }
     throw new Error("AskUserQuestion received an unknown selection");
   }
 };
+
+const showTuiMultiSelect = async (
+  question: Question,
+  state: MultiSelectState,
+  signal: AbortSignal | undefined,
+  ctx: AskCtxLike,
+): Promise<MultiSelectAction> => {
+  if (ctx.ui.custom === undefined) {
+    throw new Error("AskUserQuestion multi-select TUI is unavailable");
+  }
+
+  return ctx.ui.custom<MultiSelectAction>((tui, theme, keybindings, done) => {
+    const eventSignal = asAbortEventSignal(signal);
+    let settled = false;
+    let cachedWidth: number | undefined;
+    let cachedRows: number | undefined;
+    let cachedLines: string[] | undefined;
+    let manualViewportStart: number | undefined;
+    let lastViewportStart = 0;
+    let lastContentRows = 1;
+
+    const finish = (action: MultiSelectAction): void => {
+      if (settled) return;
+      settled = true;
+      eventSignal?.removeEventListener("abort", abort);
+      done(action);
+    };
+    const abort = (): void => finish("aborted");
+    eventSignal?.addEventListener("abort", abort, { once: true });
+
+    const refresh = (): void => {
+      cachedWidth = undefined;
+      cachedRows = undefined;
+      cachedLines = undefined;
+      tui.requestRender();
+    };
+
+    const handleInput = (data: string): void => {
+      const optionCount = question.options.length;
+      const itemCount = optionCount + 1;
+      if (isSpaceKey(data)) {
+        if (state.cursorIndex === optionCount) {
+          finish("other");
+          return;
+        }
+        if (state.selectedIndices.has(state.cursorIndex)) {
+          state.selectedIndices.delete(state.cursorIndex);
+        } else {
+          state.selectedIndices.add(state.cursorIndex);
+        }
+        refresh();
+        return;
+      }
+      if (isEnterKey(data)) {
+        if (state.selectedIndices.size > 0 || state.otherText !== undefined) {
+          finish("submit");
+        }
+        return;
+      }
+      if (isEscapeKey(data)) {
+        finish("cancel");
+        return;
+      }
+      if (
+        isArrowKey(data, "up") ||
+        keybindings.matches(data, "tui.select.up")
+      ) {
+        state.cursorIndex = Math.max(0, state.cursorIndex - 1);
+        manualViewportStart = undefined;
+        refresh();
+        return;
+      }
+      if (
+        isArrowKey(data, "down") ||
+        keybindings.matches(data, "tui.select.down")
+      ) {
+        state.cursorIndex = Math.min(itemCount - 1, state.cursorIndex + 1);
+        manualViewportStart = undefined;
+        refresh();
+        return;
+      }
+      if (keybindings.matches(data, "tui.select.pageUp")) {
+        manualViewportStart = Math.max(0, lastViewportStart - lastContentRows);
+        refresh();
+        return;
+      }
+      if (keybindings.matches(data, "tui.select.pageDown")) {
+        manualViewportStart = lastViewportStart + lastContentRows;
+        refresh();
+        return;
+      }
+      if (keybindings.matches(data, "tui.select.confirm")) {
+        if (state.selectedIndices.size > 0 || state.otherText !== undefined) {
+          finish("submit");
+        }
+        return;
+      }
+      if (keybindings.matches(data, "tui.select.cancel")) {
+        finish("cancel");
+      }
+    };
+
+    const render = (width: number): string[] => {
+      const terminalRows = tui.terminal?.rows ?? 24;
+      if (
+        cachedWidth === width &&
+        cachedRows === terminalRows &&
+        cachedLines !== undefined
+      ) {
+        return cachedLines;
+      }
+      const contentLines = wrapForWidth(
+        `${questionTitle(question)} (select all that apply)`,
+        width,
+      ).map((line) => theme.fg("accent", line));
+      contentLines.push("");
+      let activeLine = contentLines.length;
+      for (const [index, option] of question.options.entries()) {
+        const cursor = state.cursorIndex === index ? "> " : "  ";
+        const content = `${cursor}${optionLine(
+          option,
+          index,
+          state.selectedIndices.has(index),
+        )}`;
+        if (state.cursorIndex === index) activeLine = contentLines.length;
+        contentLines.push(
+          ...wrapForWidth(content, width).map((line) =>
+            state.cursorIndex === index ? theme.fg("accent", line) : line,
+          ),
+        );
+      }
+      const otherSelected = state.otherText !== undefined;
+      const otherCursor = state.cursorIndex === question.options.length;
+      const otherContent = `${otherCursor ? "> " : "  "}${
+        otherSelected ? "[x]" : "[ ]"
+      } ${OTHER_ACTION}${otherSelected ? " (set)" : ""}`;
+      if (otherCursor) activeLine = contentLines.length;
+      contentLines.push(
+        ...wrapForWidth(otherContent, width).map((line) =>
+          otherCursor ? theme.fg("accent", line) : line,
+        ),
+      );
+
+      const maxRows = Math.max(1, terminalRows - 2);
+      const allHelpLines = wrapForWidth(
+        "↑↓ move • Space toggle/edit • Enter done • Esc cancel • PgUp/PgDn scroll",
+        width,
+      ).map((line) => theme.fg("dim", line));
+      const helpRows =
+        maxRows < 3
+          ? 0
+          : Math.min(allHelpLines.length, Math.max(1, Math.floor(maxRows / 3)));
+      const helpLines = allHelpLines.slice(0, helpRows);
+      const separatorRows = helpRows > 0 && maxRows - helpRows > 1 ? 1 : 0;
+      const contentRows = Math.max(1, maxRows - helpRows - separatorRows);
+      const maxStart = Math.max(0, contentLines.length - contentRows);
+      const automaticStart = Math.min(
+        maxStart,
+        Math.max(0, activeLine - Math.floor(contentRows / 2)),
+      );
+      const viewportStart = Math.min(
+        maxStart,
+        Math.max(0, manualViewportStart ?? automaticStart),
+      );
+      lastViewportStart = viewportStart;
+      lastContentRows = contentRows;
+      const lines = contentLines.slice(
+        viewportStart,
+        viewportStart + contentRows,
+      );
+      if (separatorRows > 0) lines.push("");
+      lines.push(...helpLines);
+      cachedWidth = width;
+      cachedRows = terminalRows;
+      cachedLines = lines;
+      return lines;
+    };
+
+    return {
+      render,
+      handleInput,
+      invalidate: () => {
+        cachedWidth = undefined;
+        cachedRows = undefined;
+        cachedLines = undefined;
+      },
+      dispose: () => eventSignal?.removeEventListener("abort", abort),
+    };
+  });
+};
+
+const askMultipleInTui = async (
+  question: Question,
+  signal: AbortSignal | undefined,
+  ctx: AskCtxLike,
+): Promise<QuestionAnswer> => {
+  const state: MultiSelectState = {
+    selectedIndices: new Set<number>(),
+    cursorIndex: 0,
+  };
+
+  while (true) {
+    ensureNotAborted(signal);
+    const action = await showTuiMultiSelect(question, state, signal, ctx);
+    ensureNotAborted(signal);
+    if (action === "cancel") {
+      throw new Error("AskUserQuestion cancelled by the user");
+    }
+    if (action === "aborted") {
+      throw new Error("AskUserQuestion aborted");
+    }
+    if (action === "other") {
+      const other = await askForOther(question, signal, ctx);
+      if (other.submitted) state.otherText = other.value;
+      continue;
+    }
+    return buildMultipleAnswer(
+      question,
+      state.selectedIndices,
+      state.otherText,
+    );
+  }
+};
+
+const askMultiple = async (
+  question: Question,
+  signal: AbortSignal | undefined,
+  ctx: AskCtxLike,
+): Promise<QuestionAnswer> =>
+  ctx.mode === "tui"
+    ? askMultipleInTui(question, signal, ctx)
+    : askMultipleWithDialogs(question, signal, ctx);
 
 const annotationFor = (
   answer: QuestionAnswer,
@@ -400,7 +798,7 @@ const setupAskUserQuestion = (pi: PiLike): void => {
       const answered: { question: Question; answer: QuestionAnswer }[] = [];
       for (const item of input.questions) {
         const answer = item.multiSelect
-          ? await askMultiple(item, signal, ctx)
+          ? await askMultiple(item, signal, ctx as AskCtxLike)
           : await askSingle(item, signal, ctx);
         answered.push({ question: item, answer });
       }

--- a/tests/pi-harness/ask-user-question.test.ts
+++ b/tests/pi-harness/ask-user-question.test.ts
@@ -44,7 +44,65 @@ interface AskResult {
   };
 }
 
+type UiModeLike = "tui" | "rpc" | "json" | "print";
+type SelectKeybinding =
+  | "tui.select.up"
+  | "tui.select.down"
+  | "tui.select.pageUp"
+  | "tui.select.pageDown"
+  | "tui.select.confirm"
+  | "tui.select.cancel";
+
+interface KeybindingsLike {
+  matches(data: string, keybinding: SelectKeybinding): boolean;
+}
+
+interface CustomComponentLike {
+  render(width: number): string[];
+  invalidate(): void;
+  handleInput?(data: string): void;
+  dispose?(): void;
+}
+
+type CustomUiFactoryLike<T> = (
+  tui: {
+    terminal?: { rows: number };
+    requestRender(): void;
+  },
+  theme: {
+    fg(color: string, text: string): string;
+  },
+  keybindings: KeybindingsLike,
+  done: (result: T) => void,
+) => CustomComponentLike | Promise<CustomComponentLike>;
+
+type AskUiLike = CtxLike["ui"] & {
+  custom?<T>(factory: CustomUiFactoryLike<T>): Promise<T>;
+};
+
+interface AskCtxLike extends CtxLike {
+  mode?: UiModeLike;
+  ui: AskUiLike;
+}
+
+interface CustomDialog {
+  keys: string[];
+  renders: string[][];
+}
+
+type AskFakePi = FakePi & {
+  readonly keybindings: KeybindingsLike;
+  queueCustomKeys(...keys: string[]): void;
+  readonly customDialogs: CustomDialog[];
+  readonly ctx: AskCtxLike & { hasUI: boolean };
+};
+
 const tempDirectories: string[] = [];
+const KEY_UP = "\u001b[A";
+const KEY_DOWN = "\u001b[B";
+const KEY_SPACE = " ";
+const KEY_ENTER = "\r";
+const KEY_ESCAPE = "\u001b";
 
 afterEach(async () => {
   await Promise.all(
@@ -129,8 +187,60 @@ const execute = async (
   return result as AskResult;
 };
 
-const setup = (options: { hasUI?: boolean } = {}): FakePi => {
-  const pi = createFakePi(options);
+const setup = (
+  options: {
+    hasUI?: boolean;
+    mode?: UiModeLike;
+    terminalRows?: number;
+  } = {},
+): AskFakePi => {
+  const pi = createFakePi({ hasUI: options.hasUI }) as AskFakePi;
+  const customQueue: { keys: string[] }[] = [];
+  const customDialogs: CustomDialog[] = [];
+  const keybindings: KeybindingsLike = {
+    matches: (data, keybinding) => {
+      if (keybinding === "tui.select.up") return data === KEY_UP;
+      if (keybinding === "tui.select.down") return data === KEY_DOWN;
+      if (keybinding === "tui.select.pageUp") return data === "\u001b[5~";
+      if (keybinding === "tui.select.pageDown") return data === "\u001b[6~";
+      if (keybinding === "tui.select.confirm") return data === KEY_ENTER;
+      return data === KEY_ESCAPE || data === "\u0003";
+    },
+  };
+  const tui = {
+    terminal: { rows: options.terminalRows ?? 24 },
+    requestRender: () => {},
+  };
+  const theme = { fg: (_color: string, text: string): string => text };
+
+  pi.ctx.mode = options.mode ?? "tui";
+  pi.ctx.ui.custom = async <T>(factory: CustomUiFactoryLike<T>): Promise<T> => {
+    const queued = customQueue.shift() ?? { keys: [] };
+    const dialog: CustomDialog = { keys: [...queued.keys], renders: [] };
+    customDialogs.push(dialog);
+    let settled = false;
+    let result: T | undefined;
+    const component = await factory(tui, theme, keybindings, (value) => {
+      settled = true;
+      result = value;
+    });
+    dialog.renders.push(component.render(120));
+    for (const key of queued.keys) {
+      if (settled) break;
+      component.handleInput?.(key);
+      dialog.renders.push(component.render(120));
+    }
+    component.dispose?.();
+    if (!settled) {
+      throw new Error("fake custom dialog did not receive a finishing key");
+    }
+    return result as T;
+  };
+  Object.assign(pi, {
+    keybindings,
+    queueCustomKeys: (...keys: string[]) => customQueue.push({ keys }),
+    customDialogs,
+  });
   setupAskUserQuestion(pi);
   return pi;
 };
@@ -330,14 +440,17 @@ describe("pi-harness AskUserQuestion answers", () => {
     expect(pi.inputDialogs).toHaveLength(2);
   });
 
-  test("toggles multi-select choices collision-safely and emits schema order", async () => {
+  test("toggles multi-select choices with Space without moving the cursor", async () => {
     const pi = setup();
-    // Select option label "Done", then option label "Other", deselect "Done",
-    // then select the adapter's Done action.
-    pi.queueSelectIndex(1);
-    pi.queueSelectIndex(0);
-    pi.queueSelectIndex(1);
-    pi.queueSelectIndex(3);
+    pi.queueCustomKeys(
+      KEY_DOWN,
+      KEY_SPACE,
+      KEY_UP,
+      KEY_SPACE,
+      KEY_DOWN,
+      KEY_SPACE,
+      KEY_ENTER,
+    );
     const input = question({
       multiSelect: true,
       options: [
@@ -351,16 +464,108 @@ describe("pi-harness AskUserQuestion answers", () => {
     expect(result.details.answers).toEqual({
       "Which path should we take?": "Other",
     });
-    expect(pi.selectDialogs[0]?.options).toHaveLength(3);
-    expect(pi.selectDialogs.at(-1)?.options).toHaveLength(4);
+    expect(pi.selectDialogs).toHaveLength(0);
+    expect(pi.customDialogs).toHaveLength(1);
+    expect(pi.customDialogs[0]?.renders[2]).toContain(
+      "> [x] 2. Done — A real option named Done",
+    );
+  });
+
+  test("honors remapped selector navigation and confirmation keys", async () => {
+    const pi = setup();
+    pi.keybindings.matches = (data, keybinding) =>
+      (keybinding === "tui.select.down" && data === "j") ||
+      (keybinding === "tui.select.confirm" && data === "y") ||
+      (keybinding === "tui.select.cancel" && data === "q");
+    pi.queueCustomKeys("j", KEY_SPACE, "y");
+
+    const result = await execute(pi, [question({ multiSelect: true })]);
+
+    expect(result.details.answers).toEqual({
+      "Which path should we take?": "Fast",
+    });
+  });
+
+  test("keeps fixed Space and Enter usable when remapped bindings conflict", async () => {
+    const pi = setup();
+    pi.keybindings.matches = (data, keybinding) =>
+      keybinding === "tui.select.confirm" && data === KEY_SPACE;
+    pi.queueCustomKeys(KEY_SPACE, KEY_ENTER);
+
+    const result = await execute(pi, [question({ multiSelect: true })]);
+
+    expect(result.details.answers).toEqual({
+      "Which path should we take?": "Safe",
+    });
+  });
+
+  test("accepts Kitty navigation, Space, and Enter with lock modifiers", async () => {
+    const pi = setup();
+    pi.queueCustomKeys("\u001b[1;65B", "\u001b[32;65u", "\u001b[13;65u");
+
+    const result = await execute(pi, [question({ multiSelect: true })]);
+
+    expect(result.details.answers).toEqual({
+      "Which path should we take?": "Fast",
+    });
+  });
+
+  test("wraps long multi-select content without dropping its tail", async () => {
+    const pi = setup();
+    pi.queueCustomKeys(KEY_SPACE, KEY_ENTER);
+    const tail = "TAIL-MUST-STAY-VISIBLE";
+    const input = question({
+      multiSelect: true,
+      options: [
+        {
+          label: "Long",
+          description: `${"detail ".repeat(30)}${tail}`,
+        },
+        {
+          label: "Huge inactive option",
+          description: "offscreen detail ".repeat(500),
+        },
+      ],
+    });
+
+    await execute(pi, [input]);
+
+    const initialRender = pi.customDialogs[0]?.renders[0];
+    expect(initialRender?.join("")).toContain(tail);
+    expect(
+      initialRender?.some((line) => line.startsWith("> [ ] 1. Long —")),
+    ).toBe(true);
+    expect(initialRender?.length).toBeLessThanOrEqual(22);
+  });
+
+  test("keeps the active option visible in a short terminal", async () => {
+    const pi = setup({ terminalRows: 5 });
+    pi.queueCustomKeys(KEY_SPACE, KEY_ENTER);
+    const input = question({
+      multiSelect: true,
+      options: [
+        { label: "Visible", description: "active choice" },
+        {
+          label: "Huge inactive option",
+          description: "offscreen detail ".repeat(500),
+        },
+      ],
+    });
+
+    await execute(pi, [input]);
+
+    const initialRender = pi.customDialogs[0]?.renders[0];
+    expect(initialRender?.length).toBeLessThanOrEqual(3);
+    expect(
+      initialRender?.some((line) => line.startsWith("> [ ] 1. Visible —")),
+    ).toBe(true);
   });
 
   test("combines selected multi options with a custom Other answer", async () => {
     const pi = setup();
-    pi.queueSelectIndex(0);
-    pi.queueSelectIndex(2);
+    pi.queueCustomKeys(KEY_SPACE, KEY_DOWN, KEY_DOWN, KEY_SPACE);
     pi.queueInput("Keep logs for 30 days");
-    pi.queueSelectIndex(3);
+    pi.queueCustomKeys(KEY_ENTER);
 
     const result = await execute(pi, [question({ multiSelect: true })]);
 
@@ -371,13 +576,22 @@ describe("pi-harness AskUserQuestion answers", () => {
     expect(result.content[0]?.text).toContain(
       '"Which path should we take?"="Safe, Keep logs for 30 days"',
     );
+    expect(pi.customDialogs[1]?.renders[0]).toContain(
+      "> [x] Other — type, edit, or submit empty text to clear a custom answer (set)",
+    );
   });
 
   test("emits multi-select labels and previews in schema order", async () => {
     const pi = setup();
-    pi.queueSelectIndex(2);
-    pi.queueSelectIndex(0);
-    pi.queueSelectIndex(4);
+    pi.queueCustomKeys(
+      KEY_DOWN,
+      KEY_DOWN,
+      KEY_SPACE,
+      KEY_UP,
+      KEY_UP,
+      KEY_SPACE,
+      KEY_ENTER,
+    );
     const input = question({
       multiSelect: true,
       options: [
@@ -404,12 +618,11 @@ describe("pi-harness AskUserQuestion answers", () => {
 
   test("allows multi-select Other text to be cleared before submission", async () => {
     const pi = setup();
-    pi.queueSelectIndex(2);
+    pi.queueCustomKeys(KEY_DOWN, KEY_DOWN, KEY_SPACE);
     pi.queueInput("temporary note");
-    pi.queueSelectIndex(2);
+    pi.queueCustomKeys(KEY_SPACE);
     pi.queueInput("   ");
-    pi.queueSelectIndex(0);
-    pi.queueSelectIndex(3);
+    pi.queueCustomKeys(KEY_UP, KEY_UP, KEY_SPACE, KEY_ENTER);
 
     const result = await execute(pi, [question({ multiSelect: true })]);
 
@@ -417,7 +630,34 @@ describe("pi-harness AskUserQuestion answers", () => {
       "Which path should we take?": "Safe",
     });
     expect(result.details.annotations).toEqual({});
-    expect(pi.selectDialogs[2]?.options).toHaveLength(3);
+    expect(pi.customDialogs).toHaveLength(3);
+    expect(pi.customDialogs[2]?.renders[0]).toContain(
+      "> [ ] Other — type, edit, or submit empty text to clear a custom answer",
+    );
+  });
+
+  test("keeps the portable selector flow for RPC multi-select", async () => {
+    const pi = setup({ mode: "rpc" });
+    pi.queueSelectIndex(1);
+    pi.queueSelectIndex(0);
+    pi.queueSelectIndex(1);
+    pi.queueSelectIndex(3);
+    const input = question({
+      multiSelect: true,
+      options: [
+        { label: "Other", description: "A real option named Other" },
+        { label: "Done", description: "A real option named Done" },
+      ],
+    });
+
+    const result = await execute(pi, [input]);
+
+    expect(result.details.answers).toEqual({
+      "Which path should we take?": "Other",
+    });
+    expect(pi.customDialogs).toHaveLength(0);
+    expect(pi.selectDialogs[0]?.options).toHaveLength(3);
+    expect(pi.selectDialogs.at(-1)?.options).toHaveLength(4);
   });
 
   test("asks multiple questions sequentially", async () => {
@@ -450,6 +690,18 @@ describe("pi-harness AskUserQuestion termination", () => {
     ).rejects.toThrow("cancelled by the user");
   });
 
+  test.each([KEY_ESCAPE, "\u0003"])(
+    "cancels a TUI multi-select with a configured cancel key",
+    async (key) => {
+      const pi = setup();
+      pi.queueCustomKeys(key);
+
+      await expect(
+        execute(pi, [question({ multiSelect: true })]),
+      ).rejects.toThrow("cancelled by the user");
+    },
+  );
+
   test("throws before opening UI when already aborted", async () => {
     const pi = setup();
     const controller = createTestAbortController();
@@ -475,6 +727,34 @@ describe("pi-harness AskUserQuestion termination", () => {
       execute(pi, [question()], { signal: controller.signal }),
     ).rejects.toThrow("aborted");
     expect(observed).toBe(controller.signal);
+  });
+
+  test("closes a TUI multi-select when its signal aborts", async () => {
+    const pi = setup();
+    const controller = createTestAbortController();
+    pi.ctx.ui.custom = async <T>(
+      factory: CustomUiFactoryLike<T>,
+    ): Promise<T> => {
+      let answer: T | undefined;
+      const component = await factory(
+        { requestRender: () => {} },
+        { fg: (_color, text) => text },
+        pi.keybindings,
+        (value) => {
+          answer = value;
+        },
+      );
+      controller.abort();
+      component.dispose?.();
+      if (answer === undefined) throw new Error("custom dialog did not close");
+      return answer;
+    };
+
+    await expect(
+      execute(pi, [question({ multiSelect: true })], {
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow("aborted");
   });
 
   test("passes the signal to Other input and distinguishes its abort", async () => {


### PR DESCRIPTION
## Summary

- toggle multi-select choices with Space without resetting the cursor
- keep Enter submission, custom answers, cancellation, and RPC behavior intact
- handle remapped keys, Kitty modifier states, wrapped content, and short terminal viewports
- add focused regression coverage for interaction and rendering behavior

## Testing

- `bun run run-all` (815 passed, 2 gated skips)