### PR TITLE
feat(pi): add live child session browser

### DIFF
--- a/pi/extensions/pi-harness/features/child-runs/README.md
+++ b/pi/extensions/pi-harness/features/child-runs/README.md
@@ -1,0 +1,58 @@
+# Child-session browser
+
+The pi-harness `subagent` and `workflow` tools expose their child runs in a
+resident TUI browser.
+
+## Behavior
+
+- The first child invocation mounts a non-capturing overlay on the right.
+- The overlay is visible at terminal widths of 120 columns or more and never
+  steals focus from the main editor.
+- `/subagents` or `Ctrl+Alt+S` shows and focuses the browser.
+- `Esc` returns focus to the main session while leaving the overlay visible.
+- `q` hides the overlay. A new child run, `/subagents`, or the shortcut shows
+  it again.
+- Arrow keys select runs and scroll transcripts. Enter opens a run, Left or
+  `b` returns to the list, and End resumes live-follow mode.
+- On narrow terminals the normal subagent/workflow tool row remains the live
+  status fallback.
+
+Closing, hiding, or unfocusing the browser never cancels child execution.
+
+## Retention and privacy
+
+Children still run with `--no-session`; browser entries are view-only and
+cannot be resumed or forked as native pi sessions.
+
+The parent tool-result details persist a versioned, bounded transcript so
+completed runs remain inspectable after resuming the parent session. The
+persisted browser payload contains only:
+
+- child identity, task/stage metadata, status, and timestamps;
+- finalized assistant text;
+- local tool ordinals, tool names, and success/failure status;
+- synthetic truncation markers.
+
+It does **not** retain live drafts, thinking blocks, tool arguments,
+tool-result bodies, stderr, images, signatures, provider/response IDs, raw
+tool-call IDs, working directories, or `{previous}`-expanded prompts.
+
+Limits:
+
+- 16 KiB per finalized assistant item;
+- 256 items and 64 KiB per run;
+- 512 KiB per invocation, divided fairly across runs;
+- the newest 32 invocations / 2 MiB when replaying browser history.
+
+Malformed or oversized child-stream diagnostics are live-only and never echo
+raw source data.
+
+## Interactive smoke check
+
+1. Start pi in a terminal at least 120 columns wide.
+2. Launch a parallel `subagent` call or a multi-task `workflow`.
+3. Confirm the right overlay appears without taking editor focus.
+4. Press `Ctrl+Alt+S`, select a running child, and verify live updates.
+5. Press `Esc` and confirm normal editor input continues.
+6. Press `q`, then run `/subagents` and confirm the same browser reappears.
+7. Resume the parent session and confirm completed transcripts are restored.

--- a/pi/extensions/pi-harness/features/child-runs/README.md
+++ b/pi/extensions/pi-harness/features/child-runs/README.md
@@ -42,7 +42,8 @@ Limits:
 - 16 KiB per finalized assistant item;
 - 256 items and 64 KiB per run;
 - 512 KiB per invocation, divided fairly across runs;
-- the newest 32 invocations / 2 MiB when replaying browser history.
+- the newest 32 completed invocations / 2 MiB in both live and replayed
+  browser history; active invocations are retained until completion.
 
 Malformed or oversized child-stream diagnostics are live-only and never echo
 raw source data.

--- a/pi/extensions/pi-harness/features/child-runs/index.ts
+++ b/pi/extensions/pi-harness/features/child-runs/index.ts
@@ -1,0 +1,123 @@
+import type { CtxLike, PiLike } from "../../lib/pi-like";
+import {
+  attachChildRunsDetails,
+  extractPersistedChildRuns,
+} from "./persistence";
+import { ChildRunRegistry } from "./registry";
+import { ChildRunsOverlayController, type BrowserContextLike } from "./ui";
+
+interface RuntimeContextLike extends BrowserContextLike {
+  sessionManager?: {
+    getBranch(): unknown[];
+  };
+}
+
+interface RuntimeToolResultEvent {
+  type: "tool_result";
+  toolName: string;
+  toolCallId?: string;
+  details?: unknown;
+  isError?: boolean;
+}
+
+interface RuntimePiLike {
+  on(
+    event: string,
+    handler: (event: unknown, ctx: RuntimeContextLike) => unknown,
+  ): void;
+  registerCommand(
+    name: string,
+    options: {
+      description?: string;
+      handler: (args: string, ctx: RuntimeContextLike) => Promise<void>;
+    },
+  ): void;
+  registerShortcut(
+    shortcut: string,
+    options: {
+      description?: string;
+      handler: (ctx: RuntimeContextLike) => Promise<void> | void;
+    },
+  ): void;
+}
+
+export interface ChildRunsIntegration {
+  registry: ChildRunRegistry;
+  ensureVisible(ctx: CtxLike): void;
+}
+
+const replayBranch = (
+  registry: ChildRunRegistry,
+  ctx: RuntimeContextLike,
+): void => {
+  const branch = ctx.sessionManager?.getBranch();
+  if (branch === undefined) return;
+  registry.replacePersistedHistory(extractPersistedChildRuns(branch));
+};
+
+const setupChildRuns = (pi: PiLike): ChildRunsIntegration => {
+  const runtime = pi as unknown as RuntimePiLike;
+  const registry = new ChildRunRegistry();
+  const overlay = new ChildRunsOverlayController(registry);
+
+  runtime.registerCommand("subagents", {
+    description: "Show and focus the live child-session browser",
+    handler: async (_args, ctx) => {
+      if (ctx.mode !== "tui") {
+        if (ctx.hasUI) {
+          ctx.ui.notify(
+            "The child-session browser requires TUI mode.",
+            "warning",
+          );
+        }
+        return;
+      }
+      await overlay.showAndFocus(ctx);
+    },
+  });
+
+  runtime.registerShortcut("ctrl+alt+s", {
+    description: "Show and focus child sessions",
+    handler: async (ctx) => {
+      await overlay.showAndFocus(ctx);
+    },
+  });
+
+  runtime.on("tool_result", (rawEvent) => {
+    const event = rawEvent as RuntimeToolResultEvent;
+    if (
+      (event.toolName !== "subagent" && event.toolName !== "workflow") ||
+      typeof event.toolCallId !== "string"
+    ) {
+      return undefined;
+    }
+    const invocationId = registry.getInvocationIdForToolCall(event.toolCallId);
+    if (invocationId === undefined) return undefined;
+    registry.terminalizeInvocation(
+      invocationId,
+      { status: "skipped", reason: "dependency-failed" },
+      { status: "failed", reason: "setup-error" },
+    );
+    const childRuns = registry.completeToolCall(event.toolCallId);
+    if (childRuns === undefined) return undefined;
+    return {
+      details: attachChildRunsDetails(event.details, childRuns),
+    };
+  });
+
+  runtime.on("session_start", (_event, ctx) => replayBranch(registry, ctx));
+  runtime.on("session_tree", (_event, ctx) => replayBranch(registry, ctx));
+  runtime.on("session_shutdown", () => {
+    overlay.dispose();
+    registry.dispose();
+  });
+
+  return {
+    registry,
+    ensureVisible(ctx) {
+      overlay.ensureVisible(ctx as RuntimeContextLike);
+    },
+  };
+};
+
+export default setupChildRuns;

--- a/pi/extensions/pi-harness/features/child-runs/model.ts
+++ b/pi/extensions/pi-harness/features/child-runs/model.ts
@@ -8,6 +8,8 @@ export const MAX_RUN_TRANSCRIPT_ITEMS = 256;
 export const MAX_PERSISTED_INVOCATION_BYTES = 512 * 1024;
 export const MAX_REPLAY_INVOCATIONS = 32;
 export const MAX_REPLAY_BYTES = 2 * 1024 * 1024;
+export const MAX_LIVE_INVOCATIONS = MAX_REPLAY_INVOCATIONS;
+export const MAX_LIVE_HISTORY_BYTES = MAX_REPLAY_BYTES;
 
 export type ChildRunSource = "subagent" | "workflow";
 export type ChildRunMode = "single" | "parallel" | "chain";

--- a/pi/extensions/pi-harness/features/child-runs/model.ts
+++ b/pi/extensions/pi-harness/features/child-runs/model.ts
@@ -1,0 +1,190 @@
+export const CHILD_RUNS_SCHEMA = "pi-harness/child-runs";
+export const CHILD_RUNS_VERSION = 1;
+
+export const MAX_ASSISTANT_ITEM_BYTES = 16 * 1024;
+export const MAX_LIVE_DRAFT_BYTES = 16 * 1024;
+export const MAX_RUN_TRANSCRIPT_BYTES = 64 * 1024;
+export const MAX_RUN_TRANSCRIPT_ITEMS = 256;
+export const MAX_PERSISTED_INVOCATION_BYTES = 512 * 1024;
+export const MAX_REPLAY_INVOCATIONS = 32;
+export const MAX_REPLAY_BYTES = 2 * 1024 * 1024;
+
+export type ChildRunSource = "subagent" | "workflow";
+export type ChildRunMode = "single" | "parallel" | "chain";
+export type ChildRunStatus =
+  | "queued"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "aborted"
+  | "skipped";
+
+export type ChildRunTerminalReason =
+  | "completed"
+  | "model-error"
+  | "model-aborted"
+  | "length"
+  | "spawn-error"
+  | "setup-error"
+  | "fail-fast"
+  | "parent-abort"
+  | "shutdown"
+  | "dependency-failed";
+
+export type ToolTranscriptStatus =
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "interrupted";
+
+export type TranscriptItem =
+  | { type: "assistant"; text: string }
+  | {
+      type: "tool";
+      localId: number;
+      name: string;
+      status: ToolTranscriptStatus;
+    }
+  | {
+      type: "truncated";
+      omittedItems: number;
+      omittedBytes: number;
+    };
+
+export type ChildObservation =
+  | { type: "process_started"; at: number }
+  | { type: "assistant_draft"; text: string }
+  | {
+      type: "assistant_final";
+      text: string;
+      at: number;
+      model?: string;
+      stopReason?: string;
+    }
+  | {
+      type: "tool_started";
+      localId: number;
+      name: string;
+      at: number;
+    }
+  | {
+      type: "tool_finished";
+      localId: number;
+      name: string;
+      failed: boolean;
+      at: number;
+    }
+  | { type: "protocol_warning"; code: "malformed" | "oversized" }
+  | {
+      type: "process_exit";
+      at: number;
+      exitCode: number | null;
+      signal?: string;
+    };
+
+export interface ChildRunSpec {
+  agent: string;
+  task: string;
+  taskIndex: number;
+  stageIndex?: number;
+  stageName?: string;
+  worktree?: string;
+}
+
+export interface ChildInvocationSpec {
+  toolCallId: string;
+  source: ChildRunSource;
+  mode?: ChildRunMode;
+  label: string;
+  runs: ChildRunSpec[];
+}
+
+export interface LiveChildRun extends ChildRunSpec {
+  invocationId: string;
+  runId: string;
+  source: ChildRunSource;
+  mode?: ChildRunMode;
+  status: ChildRunStatus;
+  terminalReason?: ChildRunTerminalReason;
+  startedAt?: number;
+  endedAt?: number;
+  exitCode?: number | null;
+  signal?: string;
+  model?: string;
+  stopReason?: string;
+  liveDraft?: string;
+  protocolWarnings: number;
+  transcript: TranscriptItem[];
+  transcriptBytes: number;
+  omittedItems: number;
+  omittedBytes: number;
+}
+
+export interface ChildInvocationSnapshot {
+  invocationId: string;
+  toolCallId?: string;
+  source: ChildRunSource;
+  mode?: ChildRunMode;
+  label: string;
+  createdAt: number;
+  runs: LiveChildRun[];
+}
+
+export interface ChildRunRenderSummary {
+  runId: string;
+  agent: string;
+  taskPreview: string;
+  taskIndex: number;
+  stageIndex?: number;
+  stageName?: string;
+  status: ChildRunStatus;
+  terminalReason?: ChildRunTerminalReason;
+}
+
+export interface ChildRunUpdateDetails {
+  childRuns: {
+    schema: typeof CHILD_RUNS_SCHEMA;
+    version: typeof CHILD_RUNS_VERSION;
+    kind: "summary";
+    invocationId: string;
+    source: ChildRunSource;
+    mode?: ChildRunMode;
+    label: string;
+    runs: ChildRunRenderSummary[];
+  };
+}
+
+export interface PersistedChildRunV1 {
+  runId: string;
+  agent: string;
+  task: string;
+  taskIndex: number;
+  stageIndex?: number;
+  stageName?: string;
+  status: Exclude<ChildRunStatus, "queued" | "running">;
+  terminalReason?: ChildRunTerminalReason;
+  startedAt?: number;
+  endedAt?: number;
+  transcript: TranscriptItem[];
+}
+
+export interface PersistedChildRunsV1 {
+  schema: typeof CHILD_RUNS_SCHEMA;
+  version: typeof CHILD_RUNS_VERSION;
+  kind: "transcript";
+  invocationId: string;
+  source: ChildRunSource;
+  mode?: ChildRunMode;
+  label: string;
+  createdAt: number;
+  runs: PersistedChildRunV1[];
+}
+
+export interface ChildRunsDetailsEnvelope {
+  childRuns: PersistedChildRunsV1;
+}
+
+export const isTerminalStatus = (
+  status: ChildRunStatus,
+): status is Exclude<ChildRunStatus, "queued" | "running"> =>
+  status !== "queued" && status !== "running";

--- a/pi/extensions/pi-harness/features/child-runs/persistence.ts
+++ b/pi/extensions/pi-harness/features/child-runs/persistence.ts
@@ -1,0 +1,278 @@
+import { capUtf8, stripTerminalControls } from "../../lib/terminal-text";
+import {
+  CHILD_RUNS_SCHEMA,
+  CHILD_RUNS_VERSION,
+  MAX_ASSISTANT_ITEM_BYTES,
+  MAX_PERSISTED_INVOCATION_BYTES,
+  MAX_REPLAY_BYTES,
+  MAX_REPLAY_INVOCATIONS,
+  MAX_RUN_TRANSCRIPT_BYTES,
+  MAX_RUN_TRANSCRIPT_ITEMS,
+  type ChildRunMode,
+  type ChildRunSource,
+  type ChildRunStatus,
+  type ChildRunTerminalReason,
+  type PersistedChildRunsV1,
+  type PersistedChildRunV1,
+  type ToolTranscriptStatus,
+  type TranscriptItem,
+} from "./model";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const byteLength = (value: unknown): number =>
+  Buffer.byteLength(JSON.stringify(value), "utf8");
+
+const finiteInteger = (value: unknown): number | undefined =>
+  typeof value === "number" && Number.isSafeInteger(value) && value >= 0
+    ? value
+    : undefined;
+
+const finiteTimestamp = (value: unknown): number | undefined =>
+  typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : undefined;
+
+const optionalText = (
+  value: unknown,
+  maxBytes: number,
+  lineFeedReplacement: string = "\n",
+): string | undefined =>
+  typeof value === "string"
+    ? capUtf8(stripTerminalControls(value, lineFeedReplacement), maxBytes)
+    : undefined;
+
+const terminalStatuses: ReadonlySet<string> = new Set([
+  "succeeded",
+  "failed",
+  "aborted",
+  "skipped",
+]);
+const terminalReasons: ReadonlySet<string> = new Set([
+  "completed",
+  "model-error",
+  "model-aborted",
+  "length",
+  "spawn-error",
+  "setup-error",
+  "fail-fast",
+  "parent-abort",
+  "shutdown",
+  "dependency-failed",
+]);
+const toolStatuses: ReadonlySet<string> = new Set([
+  "running",
+  "succeeded",
+  "failed",
+  "interrupted",
+]);
+
+const decodeTranscriptItem = (value: unknown): TranscriptItem | undefined => {
+  if (!isRecord(value)) return undefined;
+  if (value.type === "assistant") {
+    const text = optionalText(value.text, MAX_ASSISTANT_ITEM_BYTES);
+    return text === undefined ? undefined : { type: "assistant", text };
+  }
+  if (value.type === "tool") {
+    const localId = finiteInteger(value.localId);
+    const name = optionalText(value.name, 256, " ");
+    if (
+      localId === undefined ||
+      localId < 1 ||
+      name === undefined ||
+      typeof value.status !== "string" ||
+      !toolStatuses.has(value.status)
+    ) {
+      return undefined;
+    }
+    return {
+      type: "tool",
+      localId,
+      name,
+      status: value.status as ToolTranscriptStatus,
+    };
+  }
+  if (value.type === "truncated") {
+    const omittedItems = finiteInteger(value.omittedItems);
+    const omittedBytes = finiteInteger(value.omittedBytes);
+    if (omittedItems === undefined || omittedBytes === undefined) {
+      return undefined;
+    }
+    return { type: "truncated", omittedItems, omittedBytes };
+  }
+  return undefined;
+};
+
+const decodeRun = (
+  value: unknown,
+  perRunBudget: number,
+): PersistedChildRunV1 | undefined => {
+  if (!isRecord(value)) return undefined;
+  const runId = optionalText(value.runId, 256, " ");
+  const agent = optionalText(value.agent, 256, " ");
+  const task = optionalText(value.task, 4 * 1024);
+  const taskIndex = finiteInteger(value.taskIndex);
+  if (
+    runId === undefined ||
+    agent === undefined ||
+    task === undefined ||
+    taskIndex === undefined ||
+    typeof value.status !== "string" ||
+    !terminalStatuses.has(value.status)
+  ) {
+    return undefined;
+  }
+  const stageIndex =
+    value.stageIndex === undefined
+      ? undefined
+      : finiteInteger(value.stageIndex);
+  if (value.stageIndex !== undefined && stageIndex === undefined)
+    return undefined;
+  const stageName = optionalText(value.stageName, 512, " ");
+  const reason =
+    typeof value.terminalReason === "string" &&
+    terminalReasons.has(value.terminalReason)
+      ? (value.terminalReason as ChildRunTerminalReason)
+      : undefined;
+  const run: PersistedChildRunV1 = {
+    runId,
+    agent,
+    task,
+    taskIndex,
+    stageIndex,
+    stageName,
+    status: value.status as Exclude<ChildRunStatus, "queued" | "running">,
+    terminalReason: reason,
+    startedAt: finiteTimestamp(value.startedAt),
+    endedAt: finiteTimestamp(value.endedAt),
+    transcript: [],
+  };
+  if (!Array.isArray(value.transcript)) return run;
+  let dropped = 0;
+  let droppedBytes = 0;
+  for (const rawItem of value.transcript.slice(0, MAX_RUN_TRANSCRIPT_ITEMS)) {
+    const item = decodeTranscriptItem(rawItem);
+    if (item === undefined) continue;
+    run.transcript.push(item);
+    if (byteLength(run) > perRunBudget) {
+      run.transcript.pop();
+      dropped += 1;
+      droppedBytes += byteLength(item);
+    }
+  }
+  dropped += Math.max(0, value.transcript.length - MAX_RUN_TRANSCRIPT_ITEMS);
+  if (dropped > 0) {
+    run.transcript.push({
+      type: "truncated",
+      omittedItems: dropped,
+      omittedBytes: droppedBytes,
+    });
+    while (byteLength(run) > perRunBudget && run.transcript.length > 1) {
+      const [removed] = run.transcript.splice(-2, 1);
+      const marker = run.transcript.at(-1);
+      if (removed === undefined || marker?.type !== "truncated") break;
+      marker.omittedItems += 1;
+      marker.omittedBytes += byteLength(removed);
+    }
+  }
+  return run;
+};
+
+export const decodePersistedChildRuns = (
+  value: unknown,
+): PersistedChildRunsV1 | undefined => {
+  if (
+    !isRecord(value) ||
+    value.schema !== CHILD_RUNS_SCHEMA ||
+    value.version !== CHILD_RUNS_VERSION ||
+    value.kind !== "transcript" ||
+    (value.source !== "subagent" && value.source !== "workflow") ||
+    !Array.isArray(value.runs) ||
+    value.runs.length > 64
+  ) {
+    return undefined;
+  }
+  const invocationId = optionalText(value.invocationId, 256, " ");
+  const label = optionalText(value.label, 512, " ");
+  const createdAt = finiteTimestamp(value.createdAt);
+  if (
+    invocationId === undefined ||
+    label === undefined ||
+    createdAt === undefined
+  ) {
+    return undefined;
+  }
+  const mode: ChildRunMode | undefined =
+    value.mode === "single" ||
+    value.mode === "parallel" ||
+    value.mode === "chain"
+      ? value.mode
+      : undefined;
+  const perRunBudget = Math.max(
+    1024,
+    Math.floor(
+      (MAX_PERSISTED_INVOCATION_BYTES - 4096) / Math.max(1, value.runs.length),
+    ),
+  );
+  const runs = value.runs.flatMap((rawRun) => {
+    const run = decodeRun(
+      rawRun,
+      Math.min(perRunBudget, MAX_RUN_TRANSCRIPT_BYTES),
+    );
+    return run === undefined ? [] : [run];
+  });
+  if (runs.length !== value.runs.length) return undefined;
+  const decoded: PersistedChildRunsV1 = {
+    schema: CHILD_RUNS_SCHEMA,
+    version: CHILD_RUNS_VERSION,
+    kind: "transcript",
+    invocationId,
+    source: value.source as ChildRunSource,
+    mode,
+    label,
+    createdAt,
+    runs,
+  };
+  return byteLength(decoded) <= MAX_PERSISTED_INVOCATION_BYTES
+    ? decoded
+    : undefined;
+};
+
+/** Read only the active branch's finalized tool-result details. */
+export const extractPersistedChildRuns = (
+  entries: readonly unknown[],
+): PersistedChildRunsV1[] => {
+  const byId = new Map<string, PersistedChildRunsV1>();
+  const order: string[] = [];
+  for (const entry of entries) {
+    if (!isRecord(entry) || entry.type !== "message") continue;
+    const message = isRecord(entry.message) ? entry.message : undefined;
+    if (message?.role !== "toolResult") continue;
+    const details = isRecord(message.details) ? message.details : undefined;
+    const decoded = decodePersistedChildRuns(details?.childRuns);
+    if (decoded === undefined) continue;
+    if (!byId.has(decoded.invocationId)) order.push(decoded.invocationId);
+    byId.set(decoded.invocationId, decoded);
+  }
+
+  const selected: PersistedChildRunsV1[] = [];
+  let bytes = 0;
+  for (const invocationId of order.slice(-MAX_REPLAY_INVOCATIONS).reverse()) {
+    const payload = byId.get(invocationId);
+    if (payload === undefined) continue;
+    const nextBytes = byteLength(payload);
+    if (bytes + nextBytes > MAX_REPLAY_BYTES) continue;
+    selected.push(payload);
+    bytes += nextBytes;
+  }
+  return selected.reverse();
+};
+
+export const attachChildRunsDetails = (
+  currentDetails: unknown,
+  childRuns: PersistedChildRunsV1,
+): Record<string, unknown> => ({
+  ...(isRecord(currentDetails) ? currentDetails : {}),
+  childRuns,
+});

--- a/pi/extensions/pi-harness/features/child-runs/persistence.ts
+++ b/pi/extensions/pi-harness/features/child-runs/persistence.ts
@@ -268,7 +268,7 @@ export const extractPersistedChildRuns = (
     const payload = byId.get(invocationId);
     if (payload === undefined) continue;
     const nextBytes = byteLength(payload);
-    if (bytes + nextBytes > MAX_REPLAY_BYTES) continue;
+    if (bytes + nextBytes > MAX_REPLAY_BYTES) break;
     selected.push(payload);
     bytes += nextBytes;
   }

--- a/pi/extensions/pi-harness/features/child-runs/persistence.ts
+++ b/pi/extensions/pi-harness/features/child-runs/persistence.ts
@@ -163,6 +163,12 @@ const decodeRun = (
   }
   dropped += Math.max(0, value.transcript.length - MAX_RUN_TRANSCRIPT_ITEMS);
   if (dropped > 0) {
+    while (run.transcript.length >= MAX_RUN_TRANSCRIPT_ITEMS) {
+      const removed = run.transcript.pop();
+      if (removed === undefined) break;
+      dropped += 1;
+      droppedBytes += byteLength(removed);
+    }
     run.transcript.push({
       type: "truncated",
       omittedItems: dropped,

--- a/pi/extensions/pi-harness/features/child-runs/presentation.ts
+++ b/pi/extensions/pi-harness/features/child-runs/presentation.ts
@@ -1,0 +1,152 @@
+import {
+  stripTerminalControls,
+  truncateToWidth,
+  wrapPlainText,
+} from "../../lib/terminal-text";
+import type {
+  ChildRunRenderSummary,
+  ChildRunStatus,
+  PersistedChildRunV1,
+  PersistedChildRunsV1,
+} from "./model";
+import { decodePersistedChildRuns } from "./persistence";
+
+export interface ComponentLike {
+  render(width: number): string[];
+  invalidate(): void;
+  handleInput?(data: string): void;
+  dispose?(): void;
+}
+
+interface ToolResultLike {
+  content?: unknown;
+  details?: unknown;
+}
+
+interface RenderOptionsLike {
+  expanded?: boolean;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const contentText = (content: unknown): string => {
+  if (!Array.isArray(content)) return "(no output)";
+  return content
+    .flatMap((part) =>
+      isRecord(part) && part.type === "text" && typeof part.text === "string"
+        ? [part.text]
+        : [],
+    )
+    .join("\n");
+};
+
+export const statusIcon = (status: ChildRunStatus): string => {
+  switch (status) {
+    case "queued":
+      return "○";
+    case "running":
+      return "◌";
+    case "succeeded":
+      return "✓";
+    case "failed":
+      return "✗";
+    case "aborted":
+      return "■";
+    case "skipped":
+      return "–";
+  }
+};
+
+const summaryFromDetails = (
+  details: unknown,
+):
+  | {
+      label: string;
+      runs: ChildRunRenderSummary[];
+    }
+  | undefined => {
+  if (!isRecord(details) || !isRecord(details.childRuns)) return undefined;
+  const childRuns = details.childRuns;
+  if (childRuns.kind === "summary" && Array.isArray(childRuns.runs)) {
+    const runs = childRuns.runs.filter((run): run is ChildRunRenderSummary =>
+      isRecord(run),
+    );
+    return {
+      label:
+        typeof childRuns.label === "string" ? childRuns.label : "child runs",
+      runs,
+    };
+  }
+  const persisted = decodePersistedChildRuns(childRuns);
+  if (persisted === undefined) return undefined;
+  return {
+    label: persisted.label,
+    runs: persisted.runs.map((run) => ({
+      runId: run.runId,
+      agent: run.agent,
+      taskPreview: run.task.replace(/\s+/g, " ").trim(),
+      taskIndex: run.taskIndex,
+      stageIndex: run.stageIndex,
+      stageName: run.stageName,
+      status: run.status,
+      terminalReason: run.terminalReason,
+    })),
+  };
+};
+
+export const persistedRows = (
+  payload: PersistedChildRunsV1,
+): PersistedChildRunV1[] => payload.runs;
+
+class PlainLinesComponent implements ComponentLike {
+  constructor(private readonly lines: string[]) {}
+
+  render(width: number): string[] {
+    if (width <= 0) return [""];
+    return this.lines.flatMap((line) =>
+      wrapPlainText(stripTerminalControls(line), width).map((wrapped) =>
+        truncateToWidth(wrapped, width, ""),
+      ),
+    );
+  }
+
+  invalidate(): void {}
+}
+
+export const renderChildRunsResult = (
+  result: ToolResultLike,
+  options: RenderOptionsLike = {},
+): ComponentLike => {
+  const summary = summaryFromDetails(result.details);
+  if (summary === undefined) {
+    return new PlainLinesComponent([contentText(result.content)]);
+  }
+  const completed = summary.runs.filter(
+    (run) => run.status !== "queued" && run.status !== "running",
+  ).length;
+  const lines = [
+    `${summary.label}: ${completed}/${summary.runs.length} finished`,
+  ];
+  const visibleRuns = options.expanded
+    ? summary.runs
+    : summary.runs.slice(0, 8);
+  for (const run of visibleRuns) {
+    const stage =
+      run.stageIndex === undefined
+        ? `${run.taskIndex + 1}`
+        : `S${run.stageIndex + 1}/T${run.taskIndex + 1}`;
+    lines.push(
+      `${statusIcon(run.status)} ${stage} ${run.agent} — ${run.taskPreview}`,
+    );
+  }
+  if (visibleRuns.length < summary.runs.length) {
+    lines.push(`… ${summary.runs.length - visibleRuns.length} more`);
+  }
+  if (options.expanded) {
+    const original = contentText(result.content);
+    if (original !== "") lines.push("", "Result:", original);
+  }
+  lines.push("/subagents to inspect transcripts");
+  return new PlainLinesComponent(lines);
+};

--- a/pi/extensions/pi-harness/features/child-runs/protocol.ts
+++ b/pi/extensions/pi-harness/features/child-runs/protocol.ts
@@ -1,0 +1,167 @@
+import { capUtf8, stripTerminalControls } from "../../lib/terminal-text";
+import {
+  MAX_ASSISTANT_ITEM_BYTES,
+  MAX_LIVE_DRAFT_BYTES,
+  type ChildObservation,
+} from "./model";
+
+export interface LegacyMessageProjection {
+  text?: string;
+  stopReason?: string;
+  errorMessage?: string;
+}
+
+export interface ChildProtocolParser {
+  processLine(line: string): LegacyMessageProjection | undefined;
+  oversizedLine(): void;
+}
+
+interface ProtocolOptions {
+  observe?: (observation: ChildObservation) => void;
+  now?: () => number;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const getString = (
+  primary: Record<string, unknown>,
+  secondary: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined => {
+  const primaryValue = primary[key];
+  if (typeof primaryValue === "string") return primaryValue;
+  const secondaryValue = secondary?.[key];
+  return typeof secondaryValue === "string" ? secondaryValue : undefined;
+};
+
+const textParts = (message: Record<string, unknown> | undefined): string[] => {
+  if (!Array.isArray(message?.content)) return [];
+  return message.content.flatMap((part) => {
+    if (
+      !isRecord(part) ||
+      part.type !== "text" ||
+      typeof part.text !== "string"
+    ) {
+      return [];
+    }
+    return [part.text];
+  });
+};
+
+/**
+ * Normalize the child JSON stream at its trust boundary. Raw events, raw tool
+ * ids, thinking blocks, arguments and tool-result bodies never leave here.
+ */
+export const createChildProtocolParser = (
+  options: ProtocolOptions = {},
+): ChildProtocolParser => {
+  const now = options.now ?? Date.now;
+  const toolIds = new Map<string, { localId: number; name: string }>();
+  let nextToolId = 1;
+
+  const observe = (observation: ChildObservation): void => {
+    try {
+      options.observe?.(observation);
+    } catch {
+      // Observability must never change child execution behavior.
+    }
+  };
+
+  const localTool = (rawId: unknown, rawName: unknown) => {
+    const key = typeof rawId === "string" ? rawId : `anonymous-${nextToolId}`;
+    const existing = toolIds.get(key);
+    if (existing !== undefined) return existing;
+    const item = {
+      localId: nextToolId++,
+      name: capUtf8(
+        stripTerminalControls(
+          typeof rawName === "string" ? rawName : "unknown-tool",
+          " ",
+        ),
+        256,
+      ),
+    };
+    toolIds.set(key, item);
+    return item;
+  };
+
+  return {
+    processLine(line) {
+      if (line.trim() === "") return undefined;
+      let value: unknown;
+      try {
+        value = JSON.parse(line);
+      } catch {
+        observe({ type: "protocol_warning", code: "malformed" });
+        return undefined;
+      }
+      if (!isRecord(value) || typeof value.type !== "string") {
+        observe({ type: "protocol_warning", code: "malformed" });
+        return undefined;
+      }
+
+      if (value.type === "message_update") {
+        const message = isRecord(value.message) ? value.message : undefined;
+        if (message?.role === "assistant") {
+          const draft = textParts(message).join("\n");
+          if (draft !== "") {
+            observe({
+              type: "assistant_draft",
+              text: capUtf8(stripTerminalControls(draft), MAX_LIVE_DRAFT_BYTES),
+            });
+          }
+        }
+        return undefined;
+      }
+
+      if (value.type === "tool_execution_start") {
+        const tool = localTool(value.toolCallId, value.toolName);
+        observe({ type: "tool_started", ...tool, at: now() });
+        return undefined;
+      }
+
+      if (value.type === "tool_execution_end") {
+        const tool = localTool(value.toolCallId, value.toolName);
+        observe({
+          type: "tool_finished",
+          ...tool,
+          failed: value.isError === true,
+          at: now(),
+        });
+        return undefined;
+      }
+
+      if (value.type !== "message_end") return undefined;
+      const message = isRecord(value.message) ? value.message : undefined;
+      const projection: LegacyMessageProjection = {
+        stopReason: getString(value, message, "stopReason"),
+        errorMessage: getString(value, message, "errorMessage"),
+      };
+
+      if (message?.role !== "assistant") return projection;
+      const parts = textParts(message);
+      if (parts.length > 0) {
+        // Preserve the legacy contract: latest assistant message, first block.
+        projection.text = parts[0];
+        const transcriptText = stripTerminalControls(parts.join("\n"));
+        if (transcriptText !== "") {
+          observe({
+            type: "assistant_final",
+            text: capUtf8(transcriptText, MAX_ASSISTANT_ITEM_BYTES),
+            at: now(),
+            model:
+              typeof message.model === "string"
+                ? capUtf8(stripTerminalControls(message.model, " "), 256)
+                : undefined,
+            stopReason: projection.stopReason,
+          });
+        }
+      }
+      return projection;
+    },
+    oversizedLine() {
+      observe({ type: "protocol_warning", code: "oversized" });
+    },
+  };
+};

--- a/pi/extensions/pi-harness/features/child-runs/protocol.ts
+++ b/pi/extensions/pi-harness/features/child-runs/protocol.ts
@@ -2,6 +2,8 @@ import { capUtf8, stripTerminalControls } from "../../lib/terminal-text";
 import {
   MAX_ASSISTANT_ITEM_BYTES,
   MAX_LIVE_DRAFT_BYTES,
+  MAX_RUN_TRANSCRIPT_BYTES,
+  MAX_RUN_TRANSCRIPT_ITEMS,
   type ChildObservation,
 } from "./model";
 
@@ -58,6 +60,7 @@ export const createChildProtocolParser = (
 ): ChildProtocolParser => {
   const now = options.now ?? Date.now;
   const toolIds = new Map<string, { localId: number; name: string }>();
+  let toolIdBytes = 0;
   let nextToolId = 1;
 
   const observe = (observation: ChildObservation): void => {
@@ -82,7 +85,14 @@ export const createChildProtocolParser = (
         256,
       ),
     };
-    toolIds.set(key, item);
+    const keyBytes = Buffer.byteLength(key, "utf8");
+    if (
+      toolIds.size < MAX_RUN_TRANSCRIPT_ITEMS &&
+      toolIdBytes + keyBytes <= MAX_RUN_TRANSCRIPT_BYTES
+    ) {
+      toolIds.set(key, item);
+      toolIdBytes += keyBytes;
+    }
     return item;
   };
 

--- a/pi/extensions/pi-harness/features/child-runs/registry.ts
+++ b/pi/extensions/pi-harness/features/child-runs/registry.ts
@@ -301,9 +301,8 @@ export class ChildRunRegistry {
           Math.max(1, invocation.runs.length),
       ),
     );
-    const runs = invocation.runs.map((run) =>
-      this.persistRun(run, perRunBudget),
-    );
+    const runBudget = Math.min(perRunBudget, MAX_RUN_TRANSCRIPT_BYTES);
+    const runs = invocation.runs.map((run) => this.persistRun(run, runBudget));
     const payload: PersistedChildRunsV1 = {
       schema: CHILD_RUNS_SCHEMA,
       version: CHILD_RUNS_VERSION,

--- a/pi/extensions/pi-harness/features/child-runs/registry.ts
+++ b/pi/extensions/pi-harness/features/child-runs/registry.ts
@@ -5,6 +5,8 @@ import {
   CHILD_RUNS_VERSION,
   MAX_ASSISTANT_ITEM_BYTES,
   MAX_LIVE_DRAFT_BYTES,
+  MAX_LIVE_HISTORY_BYTES,
+  MAX_LIVE_INVOCATIONS,
   MAX_PERSISTED_INVOCATION_BYTES,
   MAX_RUN_TRANSCRIPT_BYTES,
   MAX_RUN_TRANSCRIPT_ITEMS,
@@ -64,6 +66,27 @@ const cloneInvocation = (
   runs: invocation.runs.map(cloneRun),
 });
 
+const historicalInvocation = (
+  payload: PersistedChildRunsV1,
+): InternalInvocation => ({
+  invocationId: payload.invocationId,
+  source: payload.source,
+  mode: payload.mode,
+  label: payload.label,
+  createdAt: payload.createdAt,
+  runs: payload.runs.map<LiveChildRun>((run) => ({
+    ...run,
+    invocationId: payload.invocationId,
+    source: payload.source,
+    mode: payload.mode,
+    protocolWarnings: 0,
+    transcript: cloneTranscript(run.transcript),
+    transcriptBytes: byteLength(run.transcript),
+    omittedItems: 0,
+    omittedBytes: 0,
+  })),
+});
+
 const taskPreview = (task: string): string => {
   const oneLine = stripTerminalControls(task, " ").replace(/\s+/g, " ").trim();
   return capUtf8(oneLine, 240);
@@ -85,6 +108,7 @@ export class ChildRunRegistry {
   private readonly invocationOrder: string[] = [];
   private readonly runToInvocation = new Map<string, string>();
   private readonly toolCallToInvocation = new Map<string, string>();
+  private readonly historicalBytes = new Map<string, number>();
   private readonly subscribers = new Set<() => void>();
   private disposed = false;
 
@@ -335,51 +359,62 @@ export class ChildRunRegistry {
     if (invocationId === undefined) return undefined;
     const payload = this.toPersisted(invocationId);
     this.toolCallToInvocation.delete(toolCallId);
-    const invocation = this.invocations.get(invocationId);
-    if (invocation !== undefined) invocation.toolCallId = undefined;
+    if (payload === undefined) return undefined;
+
+    this.invocations.set(invocationId, historicalInvocation(payload));
+    this.historicalBytes.set(invocationId, byteLength(payload));
+    const orderIndex = this.invocationOrder.indexOf(invocationId);
+    if (orderIndex !== -1) this.invocationOrder.splice(orderIndex, 1);
+    this.invocationOrder.push(invocationId);
+    this.pruneHistoricalInvocations();
+    this.publish();
     return payload;
   }
 
   replacePersistedHistory(payloads: readonly PersistedChildRunsV1[]): void {
+    const activeInvocationIds = new Set<string>();
+    const occupiedRunIds = new Set<string>();
+    for (const invocationId of this.invocationOrder) {
+      const invocation = this.invocations.get(invocationId);
+      if (invocation?.toolCallId === undefined) continue;
+      activeInvocationIds.add(invocationId);
+      for (const run of invocation.runs) occupiedRunIds.add(run.runId);
+    }
+
+    const accepted: PersistedChildRunsV1[] = [];
+    const occupiedInvocationIds = new Set(activeInvocationIds);
+    for (const payload of payloads) {
+      const runIds = payload.runs.map((run) => run.runId);
+      if (
+        occupiedInvocationIds.has(payload.invocationId) ||
+        new Set(runIds).size !== runIds.length ||
+        runIds.some((runId) => occupiedRunIds.has(runId))
+      ) {
+        continue;
+      }
+      accepted.push(payload);
+      occupiedInvocationIds.add(payload.invocationId);
+      for (const runId of runIds) occupiedRunIds.add(runId);
+    }
+
     const historicalIds = this.invocationOrder.filter(
       (invocationId) =>
         this.invocations.get(invocationId)?.toolCallId === undefined,
     );
     for (const invocationId of historicalIds) {
-      const invocation = this.invocations.get(invocationId);
-      this.invocations.delete(invocationId);
-      for (const run of invocation?.runs ?? []) {
-        this.runToInvocation.delete(run.runId);
-      }
-      const index = this.invocationOrder.indexOf(invocationId);
-      if (index !== -1) this.invocationOrder.splice(index, 1);
+      this.removeInvocation(invocationId);
     }
 
-    for (const payload of payloads) {
-      const runs = payload.runs.map<LiveChildRun>((run) => ({
-        ...run,
-        invocationId: payload.invocationId,
-        source: payload.source,
-        mode: payload.mode,
-        protocolWarnings: 0,
-        transcript: cloneTranscript(run.transcript),
-        transcriptBytes: byteLength(run.transcript),
-        omittedItems: 0,
-        omittedBytes: 0,
-      }));
-      const invocation: InternalInvocation = {
-        invocationId: payload.invocationId,
-        source: payload.source,
-        mode: payload.mode,
-        label: payload.label,
-        createdAt: payload.createdAt,
-        runs,
-      };
+    for (const payload of accepted) {
+      const invocation = historicalInvocation(payload);
       this.invocations.set(payload.invocationId, invocation);
       this.invocationOrder.push(payload.invocationId);
-      for (const run of runs)
+      this.historicalBytes.set(payload.invocationId, byteLength(payload));
+      for (const run of invocation.runs) {
         this.runToInvocation.set(run.runId, payload.invocationId);
+      }
     }
+    this.pruneHistoricalInvocations();
     this.publish();
   }
 
@@ -401,6 +436,40 @@ export class ChildRunRegistry {
     this.disposed = true;
     this.subscribers.clear();
     this.toolCallToInvocation.clear();
+  }
+
+  private pruneHistoricalInvocations(): void {
+    const historicalIds = this.invocationOrder.filter(
+      (invocationId) =>
+        this.invocations.get(invocationId)?.toolCallId === undefined,
+    );
+    let totalBytes = historicalIds.reduce(
+      (total, invocationId) =>
+        total + (this.historicalBytes.get(invocationId) ?? 0),
+      0,
+    );
+    while (
+      historicalIds.length > MAX_LIVE_INVOCATIONS ||
+      totalBytes > MAX_LIVE_HISTORY_BYTES
+    ) {
+      const oldest = historicalIds.shift();
+      if (oldest === undefined) break;
+      totalBytes -= this.historicalBytes.get(oldest) ?? 0;
+      this.removeInvocation(oldest);
+    }
+  }
+
+  private removeInvocation(invocationId: string): void {
+    const invocation = this.invocations.get(invocationId);
+    this.invocations.delete(invocationId);
+    this.historicalBytes.delete(invocationId);
+    for (const run of invocation?.runs ?? []) {
+      if (this.runToInvocation.get(run.runId) === invocationId) {
+        this.runToInvocation.delete(run.runId);
+      }
+    }
+    const orderIndex = this.invocationOrder.indexOf(invocationId);
+    if (orderIndex !== -1) this.invocationOrder.splice(orderIndex, 1);
   }
 
   private findRun(runId: string): LiveChildRun | undefined {

--- a/pi/extensions/pi-harness/features/child-runs/registry.ts
+++ b/pi/extensions/pi-harness/features/child-runs/registry.ts
@@ -1,0 +1,569 @@
+import { randomUUID } from "node:crypto";
+import { capUtf8, stripTerminalControls } from "../../lib/terminal-text";
+import {
+  CHILD_RUNS_SCHEMA,
+  CHILD_RUNS_VERSION,
+  MAX_ASSISTANT_ITEM_BYTES,
+  MAX_LIVE_DRAFT_BYTES,
+  MAX_PERSISTED_INVOCATION_BYTES,
+  MAX_RUN_TRANSCRIPT_BYTES,
+  MAX_RUN_TRANSCRIPT_ITEMS,
+  type ChildInvocationSnapshot,
+  type ChildInvocationSpec,
+  type ChildObservation,
+  type ChildRunRenderSummary,
+  type ChildRunStatus,
+  type ChildRunTerminalReason,
+  type ChildRunUpdateDetails,
+  type LiveChildRun,
+  type PersistedChildRunsV1,
+  type PersistedChildRunV1,
+  type TranscriptItem,
+  isTerminalStatus,
+} from "./model";
+
+interface RegistryOptions {
+  now?: () => number;
+  idFactory?: () => string;
+}
+
+interface FinishRunOptions {
+  status: Exclude<ChildRunStatus, "queued" | "running">;
+  reason: ChildRunTerminalReason;
+  endedAt?: number;
+  exitCode?: number | null;
+  signal?: string;
+  stopReason?: string;
+  model?: string;
+}
+
+interface InternalInvocation extends ChildInvocationSnapshot {
+  toolCallId?: string;
+}
+
+const byteLength = (value: unknown): number =>
+  Buffer.byteLength(JSON.stringify(value), "utf8");
+
+const cloneTranscript = (items: readonly TranscriptItem[]): TranscriptItem[] =>
+  items.map((item) => ({ ...item }));
+
+const cloneRun = (run: LiveChildRun): LiveChildRun => ({
+  ...run,
+  transcript: cloneTranscript(run.transcript),
+});
+
+const cloneInvocation = (
+  invocation: InternalInvocation,
+): ChildInvocationSnapshot => ({
+  invocationId: invocation.invocationId,
+  toolCallId: invocation.toolCallId,
+  source: invocation.source,
+  mode: invocation.mode,
+  label: invocation.label,
+  createdAt: invocation.createdAt,
+  runs: invocation.runs.map(cloneRun),
+});
+
+const taskPreview = (task: string): string => {
+  const oneLine = stripTerminalControls(task, " ").replace(/\s+/g, " ").trim();
+  return capUtf8(oneLine, 240);
+};
+
+const persistedTask = (task: string): string =>
+  capUtf8(stripTerminalControls(task), 4 * 1024);
+
+const persistedAgent = (agent: string): string =>
+  capUtf8(stripTerminalControls(agent, " "), 256);
+
+const persistedLabel = (label: string): string =>
+  capUtf8(stripTerminalControls(label, " "), 512);
+
+export class ChildRunRegistry {
+  private readonly now: () => number;
+  private readonly idFactory: () => string;
+  private readonly invocations = new Map<string, InternalInvocation>();
+  private readonly invocationOrder: string[] = [];
+  private readonly runToInvocation = new Map<string, string>();
+  private readonly toolCallToInvocation = new Map<string, string>();
+  private readonly subscribers = new Set<() => void>();
+  private disposed = false;
+
+  constructor(options: RegistryOptions = {}) {
+    this.now = options.now ?? Date.now;
+    this.idFactory = options.idFactory ?? randomUUID;
+  }
+
+  beginInvocation(spec: ChildInvocationSpec): {
+    invocationId: string;
+    runIds: string[];
+  } {
+    if (this.disposed) throw new Error("Child-run registry is disposed");
+    const invocationId = this.idFactory();
+    const createdAt = this.now();
+    const runs = spec.runs.map<LiveChildRun>((runSpec) => {
+      const runId = this.idFactory();
+      this.runToInvocation.set(runId, invocationId);
+      return {
+        ...runSpec,
+        agent: capUtf8(stripTerminalControls(runSpec.agent, " "), 256),
+        task: capUtf8(stripTerminalControls(runSpec.task), 16 * 1024),
+        invocationId,
+        runId,
+        source: spec.source,
+        mode: spec.mode,
+        status: "queued",
+        protocolWarnings: 0,
+        transcript: [],
+        transcriptBytes: 0,
+        omittedItems: 0,
+        omittedBytes: 0,
+      };
+    });
+    const invocation: InternalInvocation = {
+      invocationId,
+      toolCallId: spec.toolCallId,
+      source: spec.source,
+      mode: spec.mode,
+      label: persistedLabel(spec.label),
+      createdAt,
+      runs,
+    };
+    this.invocations.set(invocationId, invocation);
+    this.invocationOrder.push(invocationId);
+    this.toolCallToInvocation.set(spec.toolCallId, invocationId);
+    this.publish();
+    return { invocationId, runIds: runs.map((run) => run.runId) };
+  }
+
+  observe(runId: string, observation: ChildObservation): void {
+    const run = this.findRun(runId);
+    if (run === undefined || isTerminalStatus(run.status)) return;
+
+    switch (observation.type) {
+      case "process_started":
+        if (run.status === "queued") {
+          run.status = "running";
+          run.startedAt = observation.at;
+        }
+        break;
+      case "assistant_draft":
+        run.liveDraft = capUtf8(observation.text, MAX_LIVE_DRAFT_BYTES);
+        break;
+      case "assistant_final":
+        run.liveDraft = undefined;
+        run.model = observation.model;
+        run.stopReason = observation.stopReason;
+        this.appendTranscript(run, {
+          type: "assistant",
+          text: capUtf8(observation.text, MAX_ASSISTANT_ITEM_BYTES),
+        });
+        break;
+      case "tool_started":
+        this.appendTranscript(run, {
+          type: "tool",
+          localId: observation.localId,
+          name: observation.name,
+          status: "running",
+        });
+        break;
+      case "tool_finished": {
+        const existingIndex = run.transcript.findIndex(
+          (item) =>
+            item.type === "tool" && item.localId === observation.localId,
+        );
+        const existing = run.transcript[existingIndex];
+        if (existing?.type === "tool") {
+          const previousBytes = byteLength(existing);
+          existing.status = observation.failed ? "failed" : "succeeded";
+          existing.name = observation.name;
+          run.transcriptBytes += byteLength(existing) - previousBytes;
+          if (run.transcriptBytes > MAX_RUN_TRANSCRIPT_BYTES) {
+            const [removed] = run.transcript.splice(existingIndex, 1);
+            if (removed !== undefined) {
+              const removedBytes = byteLength(removed);
+              run.transcriptBytes -= removedBytes;
+              run.omittedItems += 1;
+              run.omittedBytes += removedBytes;
+              this.finalizeTruncation(run);
+            }
+          }
+        } else {
+          this.appendTranscript(run, {
+            type: "tool",
+            localId: observation.localId,
+            name: observation.name,
+            status: observation.failed ? "failed" : "succeeded",
+          });
+        }
+        break;
+      }
+      case "protocol_warning":
+        run.protocolWarnings += 1;
+        break;
+      case "process_exit":
+        run.exitCode = observation.exitCode;
+        run.signal = observation.signal;
+        run.endedAt = observation.at;
+        break;
+    }
+    this.publish();
+  }
+
+  finishRun(runId: string, options: FinishRunOptions): void {
+    const run = this.findRun(runId);
+    if (run === undefined || isTerminalStatus(run.status)) return;
+    if (run.status === "running" && options.status === "skipped") return;
+    run.status = options.status;
+    run.terminalReason = options.reason;
+    run.endedAt = options.endedAt ?? run.endedAt ?? this.now();
+    run.exitCode = options.exitCode ?? run.exitCode;
+    run.signal = options.signal ?? run.signal;
+    run.stopReason = options.stopReason ?? run.stopReason;
+    run.model = options.model ?? run.model;
+    run.liveDraft = undefined;
+    this.interruptOpenTools(run);
+    this.finalizeTruncation(run);
+    this.publish();
+  }
+
+  terminalizeInvocation(
+    invocationId: string,
+    queued: Pick<FinishRunOptions, "status" | "reason">,
+    running: Pick<FinishRunOptions, "status" | "reason">,
+  ): void {
+    const invocation = this.invocations.get(invocationId);
+    if (invocation === undefined) return;
+    for (const run of invocation.runs) {
+      if (run.status === "queued") this.finishRun(run.runId, queued);
+      else if (run.status === "running") this.finishRun(run.runId, running);
+    }
+  }
+
+  getInvocationIdForToolCall(toolCallId: string): string | undefined {
+    return this.toolCallToInvocation.get(toolCallId);
+  }
+
+  getRunIds(invocationId: string): string[] {
+    return (
+      this.invocations.get(invocationId)?.runs.map((run) => run.runId) ?? []
+    );
+  }
+
+  getRunStatus(runId: string): ChildRunStatus | undefined {
+    return this.findRun(runId)?.status;
+  }
+
+  getSnapshots(): ChildInvocationSnapshot[] {
+    return this.invocationOrder.flatMap((id) => {
+      const invocation = this.invocations.get(id);
+      return invocation === undefined ? [] : [cloneInvocation(invocation)];
+    });
+  }
+
+  getInvocation(invocationId: string): ChildInvocationSnapshot | undefined {
+    const invocation = this.invocations.get(invocationId);
+    return invocation === undefined ? undefined : cloneInvocation(invocation);
+  }
+
+  getUpdateDetails(invocationId: string): ChildRunUpdateDetails | undefined {
+    const invocation = this.invocations.get(invocationId);
+    if (invocation === undefined) return undefined;
+    return {
+      childRuns: {
+        schema: CHILD_RUNS_SCHEMA,
+        version: CHILD_RUNS_VERSION,
+        kind: "summary",
+        invocationId,
+        source: invocation.source,
+        mode: invocation.mode,
+        label: invocation.label,
+        runs: invocation.runs.map<ChildRunRenderSummary>((run) => ({
+          runId: run.runId,
+          agent: run.agent,
+          taskPreview: taskPreview(run.task),
+          taskIndex: run.taskIndex,
+          stageIndex: run.stageIndex,
+          stageName: run.stageName,
+          status: run.status,
+          terminalReason: run.terminalReason,
+        })),
+      },
+    };
+  }
+
+  toPersisted(invocationId: string): PersistedChildRunsV1 | undefined {
+    const invocation = this.invocations.get(invocationId);
+    if (invocation === undefined) return undefined;
+    const perRunBudget = Math.max(
+      1024,
+      Math.floor(
+        (MAX_PERSISTED_INVOCATION_BYTES - 4096) /
+          Math.max(1, invocation.runs.length),
+      ),
+    );
+    const runs = invocation.runs.map((run) =>
+      this.persistRun(run, perRunBudget),
+    );
+    const payload: PersistedChildRunsV1 = {
+      schema: CHILD_RUNS_SCHEMA,
+      version: CHILD_RUNS_VERSION,
+      kind: "transcript",
+      invocationId: invocation.invocationId,
+      source: invocation.source,
+      mode: invocation.mode,
+      label: persistedLabel(invocation.label),
+      createdAt: invocation.createdAt,
+      runs,
+    };
+
+    // Metadata itself can exceed the fair estimate with many long tasks.
+    // Tighten task text from the end until the hard serialized cap is met.
+    while (byteLength(payload) > MAX_PERSISTED_INVOCATION_BYTES) {
+      const candidate = [...payload.runs]
+        .reverse()
+        .find((run) => Buffer.byteLength(run.task, "utf8") > 64);
+      if (candidate === undefined) break;
+      candidate.task = capUtf8(
+        candidate.task,
+        Math.max(64, Math.floor(Buffer.byteLength(candidate.task, "utf8") / 2)),
+      );
+    }
+    return payload;
+  }
+
+  completeToolCall(toolCallId: string): PersistedChildRunsV1 | undefined {
+    const invocationId = this.toolCallToInvocation.get(toolCallId);
+    if (invocationId === undefined) return undefined;
+    const payload = this.toPersisted(invocationId);
+    this.toolCallToInvocation.delete(toolCallId);
+    const invocation = this.invocations.get(invocationId);
+    if (invocation !== undefined) invocation.toolCallId = undefined;
+    return payload;
+  }
+
+  replacePersistedHistory(payloads: readonly PersistedChildRunsV1[]): void {
+    const historicalIds = this.invocationOrder.filter(
+      (invocationId) =>
+        this.invocations.get(invocationId)?.toolCallId === undefined,
+    );
+    for (const invocationId of historicalIds) {
+      const invocation = this.invocations.get(invocationId);
+      this.invocations.delete(invocationId);
+      for (const run of invocation?.runs ?? []) {
+        this.runToInvocation.delete(run.runId);
+      }
+      const index = this.invocationOrder.indexOf(invocationId);
+      if (index !== -1) this.invocationOrder.splice(index, 1);
+    }
+
+    for (const payload of payloads) {
+      const runs = payload.runs.map<LiveChildRun>((run) => ({
+        ...run,
+        invocationId: payload.invocationId,
+        source: payload.source,
+        mode: payload.mode,
+        protocolWarnings: 0,
+        transcript: cloneTranscript(run.transcript),
+        transcriptBytes: byteLength(run.transcript),
+        omittedItems: 0,
+        omittedBytes: 0,
+      }));
+      const invocation: InternalInvocation = {
+        invocationId: payload.invocationId,
+        source: payload.source,
+        mode: payload.mode,
+        label: payload.label,
+        createdAt: payload.createdAt,
+        runs,
+      };
+      this.invocations.set(payload.invocationId, invocation);
+      this.invocationOrder.push(payload.invocationId);
+      for (const run of runs)
+        this.runToInvocation.set(run.runId, payload.invocationId);
+    }
+    this.publish();
+  }
+
+  subscribe(listener: () => void): () => void {
+    if (this.disposed) return () => {};
+    this.subscribers.add(listener);
+    return () => this.subscribers.delete(listener);
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    for (const invocationId of this.invocationOrder) {
+      this.terminalizeInvocation(
+        invocationId,
+        { status: "aborted", reason: "shutdown" },
+        { status: "aborted", reason: "shutdown" },
+      );
+    }
+    this.disposed = true;
+    this.subscribers.clear();
+    this.toolCallToInvocation.clear();
+  }
+
+  private findRun(runId: string): LiveChildRun | undefined {
+    const invocationId = this.runToInvocation.get(runId);
+    return invocationId === undefined
+      ? undefined
+      : this.invocations
+          .get(invocationId)
+          ?.runs.find((run) => run.runId === runId);
+  }
+
+  private appendTranscript(run: LiveChildRun, item: TranscriptItem): void {
+    const bytes = byteLength(item);
+    if (
+      run.transcript.length >= MAX_RUN_TRANSCRIPT_ITEMS ||
+      run.transcriptBytes + bytes > MAX_RUN_TRANSCRIPT_BYTES
+    ) {
+      run.omittedItems += 1;
+      run.omittedBytes += bytes;
+      this.finalizeTruncation(run);
+      return;
+    }
+    run.transcript.push(item);
+    run.transcriptBytes += bytes;
+  }
+
+  private interruptOpenTools(run: LiveChildRun): void {
+    for (const item of run.transcript) {
+      if (item.type === "tool" && item.status === "running") {
+        item.status = "interrupted";
+      }
+    }
+    run.transcriptBytes = run.transcript.reduce(
+      (total, item) => total + byteLength(item),
+      0,
+    );
+    while (run.transcriptBytes > MAX_RUN_TRANSCRIPT_BYTES) {
+      let index = run.transcript.length - 1;
+      while (index >= 0 && run.transcript[index]?.type === "truncated") {
+        index -= 1;
+      }
+      if (index === -1) break;
+      const [removed] = run.transcript.splice(index, 1);
+      if (removed === undefined) break;
+      const removedBytes = byteLength(removed);
+      run.transcriptBytes -= removedBytes;
+      run.omittedItems += 1;
+      run.omittedBytes += removedBytes;
+    }
+  }
+
+  private finalizeTruncation(run: LiveChildRun): void {
+    if (run.omittedItems === 0) return;
+    const marker = run.transcript.find(
+      (item): item is Extract<TranscriptItem, { type: "truncated" }> =>
+        item.type === "truncated",
+    );
+    if (marker !== undefined) {
+      marker.omittedItems = run.omittedItems;
+      marker.omittedBytes = run.omittedBytes;
+      return;
+    }
+    const item: TranscriptItem = {
+      type: "truncated",
+      omittedItems: run.omittedItems,
+      omittedBytes: run.omittedBytes,
+    };
+    while (
+      run.transcript.length >= MAX_RUN_TRANSCRIPT_ITEMS ||
+      run.transcriptBytes + byteLength(item) > MAX_RUN_TRANSCRIPT_BYTES
+    ) {
+      const removed = run.transcript.pop();
+      if (removed === undefined) break;
+      run.transcriptBytes -= byteLength(removed);
+      run.omittedItems += 1;
+      run.omittedBytes += byteLength(removed);
+      item.omittedItems = run.omittedItems;
+      item.omittedBytes = run.omittedBytes;
+    }
+    run.transcript.push(item);
+    run.transcriptBytes += byteLength(item);
+  }
+
+  private persistRun(run: LiveChildRun, budget: number): PersistedChildRunV1 {
+    const status = isTerminalStatus(run.status) ? run.status : "aborted";
+    const persisted: PersistedChildRunV1 = {
+      runId: run.runId,
+      agent: persistedAgent(run.agent),
+      task: persistedTask(run.task),
+      taskIndex: run.taskIndex,
+      stageIndex: run.stageIndex,
+      stageName:
+        run.stageName === undefined ? undefined : persistedLabel(run.stageName),
+      status,
+      terminalReason:
+        run.terminalReason ?? (status === "aborted" ? "shutdown" : undefined),
+      startedAt: run.startedAt,
+      endedAt: run.endedAt,
+      transcript: [],
+    };
+    let omittedItems = 0;
+    let omittedBytes = 0;
+    for (const item of run.transcript) {
+      const safeItem: TranscriptItem =
+        item.type === "assistant"
+          ? {
+              type: "assistant",
+              text: capUtf8(
+                stripTerminalControls(item.text),
+                MAX_ASSISTANT_ITEM_BYTES,
+              ),
+            }
+          : item.type === "tool"
+            ? {
+                type: "tool",
+                localId: item.localId,
+                name: persistedAgent(item.name),
+                status: item.status,
+              }
+            : { ...item };
+      persisted.transcript.push(safeItem);
+      if (byteLength(persisted) > budget) {
+        persisted.transcript.pop();
+        omittedItems += 1;
+        omittedBytes += byteLength(safeItem);
+      }
+    }
+    if (omittedItems > 0) {
+      persisted.transcript.push({
+        type: "truncated",
+        omittedItems,
+        omittedBytes,
+      });
+      while (
+        byteLength(persisted) > budget &&
+        persisted.transcript.length > 1
+      ) {
+        const removed = persisted.transcript.splice(
+          persisted.transcript.length - 2,
+          1,
+        )[0];
+        if (removed === undefined) break;
+        const marker = persisted.transcript.at(-1);
+        if (marker?.type === "truncated") {
+          marker.omittedItems += 1;
+          marker.omittedBytes += byteLength(removed);
+        }
+      }
+    }
+    return persisted;
+  }
+
+  private publish(): void {
+    if (this.disposed) return;
+    for (const subscriber of this.subscribers) {
+      try {
+        subscriber();
+      } catch {
+        // One renderer must not prevent state from reaching others.
+      }
+    }
+  }
+}
+
+export type { FinishRunOptions };

--- a/pi/extensions/pi-harness/features/child-runs/ui.ts
+++ b/pi/extensions/pi-harness/features/child-runs/ui.ts
@@ -1,0 +1,480 @@
+import type { CtxLike } from "../../lib/pi-like";
+import {
+  stripTerminalControls,
+  truncateToWidth,
+  visibleWidth,
+  wrapPlainText,
+} from "../../lib/terminal-text";
+import type {
+  ChildInvocationSnapshot,
+  ChildRunStatus,
+  LiveChildRun,
+  TranscriptItem,
+} from "./model";
+import { statusIcon, type ComponentLike } from "./presentation";
+import { ChildRunRegistry } from "./registry";
+
+interface TuiLike {
+  terminal: { rows: number };
+  requestRender(force?: boolean): void;
+}
+
+interface KeybindingsLike {
+  matches(data: string, keybinding: string): boolean;
+}
+
+interface OverlayHandleLike {
+  hide(): void;
+  setHidden(hidden: boolean): void;
+  isHidden(): boolean;
+  focus(): void;
+  unfocus(options?: { target: ComponentLike | null }): void;
+  isFocused(): boolean;
+}
+
+interface OverlayOptionsLike {
+  width?: number | `${number}%`;
+  maxHeight?: number | `${number}%`;
+  anchor?: string;
+  margin?: number;
+  nonCapturing?: boolean;
+  visible?: (termWidth: number, termHeight: number) => boolean;
+}
+
+interface CustomUiLike {
+  custom<T>(
+    factory: (
+      tui: TuiLike,
+      theme: unknown,
+      keybindings: KeybindingsLike,
+      done: (result: T) => void,
+    ) => ComponentLike,
+    options: {
+      overlay: true;
+      overlayOptions: OverlayOptionsLike | (() => OverlayOptionsLike);
+      onHandle: (handle: OverlayHandleLike) => void;
+    },
+  ): Promise<T>;
+  notify(message: string, level?: "info" | "warning" | "error"): void;
+}
+
+export type BrowserContextLike = CtxLike;
+
+type BrowserMode = "list" | "detail";
+
+type FlatRun = {
+  invocation: ChildInvocationSnapshot;
+  run: LiveChildRun;
+};
+
+const statusLabel = (status: ChildRunStatus): string =>
+  `${statusIcon(status)} ${status}`;
+
+const flattenRuns = (snapshots: ChildInvocationSnapshot[]): FlatRun[] =>
+  snapshots.flatMap((invocation) =>
+    invocation.runs.map((run) => ({ invocation, run })),
+  );
+
+const line = (value: string, width: number): string =>
+  truncateToWidth(stripTerminalControls(value), Math.max(0, width), "");
+
+const taskOneLine = (task: string): string =>
+  stripTerminalControls(task, " ").replace(/\s+/g, " ").trim();
+
+const transcriptLines = (item: TranscriptItem, width: number): string[] => {
+  if (item.type === "assistant") {
+    return ["assistant:"].concat(
+      wrapPlainText(item.text, Math.max(1, width - 2)).map(
+        (part) => `  ${part}`,
+      ),
+    );
+  }
+  if (item.type === "tool") {
+    let runStatus: ChildRunStatus = "succeeded";
+    if (item.status === "running") runStatus = "running";
+    else if (item.status === "failed") runStatus = "failed";
+    else if (item.status === "interrupted") runStatus = "aborted";
+    return [
+      `${statusIcon(runStatus)} tool-${item.localId} ${item.name} (${item.status})`,
+    ];
+  }
+  return [
+    `… transcript truncated (${item.omittedItems} items, ${item.omittedBytes} bytes omitted)`,
+  ];
+};
+
+export class ChildRunsBrowserComponent implements ComponentLike {
+  private mode: BrowserMode = "list";
+  private selectedRunId: string | undefined;
+  private listOffset = 0;
+  private detailOffset = 0;
+  private follow = true;
+  private lastDetailMaxOffset = 0;
+  private readonly unsubscribe: () => void;
+
+  constructor(
+    private readonly registry: ChildRunRegistry,
+    private readonly tui: TuiLike,
+    private readonly keybindings: KeybindingsLike,
+    private readonly onUnfocus: () => void,
+    private readonly onHide: () => void,
+  ) {
+    this.unsubscribe = registry.subscribe(() => this.tui.requestRender());
+  }
+
+  render(width: number): string[] {
+    const safeWidth = Math.max(1, width);
+    const height = Math.max(
+      6,
+      Math.min(Math.floor(this.tui.terminal.rows * 0.8), 30),
+    );
+    const snapshots = this.registry.getSnapshots();
+    const runs = flattenRuns(snapshots);
+    if (
+      this.selectedRunId === undefined ||
+      !runs.some(({ run }) => run.runId === this.selectedRunId)
+    ) {
+      this.selectedRunId = runs[0]?.run.runId;
+    }
+
+    const body =
+      this.mode === "detail"
+        ? this.renderDetail(runs, safeWidth, height - 3)
+        : this.renderList(snapshots, runs, safeWidth, height - 3);
+    const title =
+      this.mode === "detail" ? " Child session " : " Child sessions ";
+    const borderWidth = Math.max(1, safeWidth - visibleWidth(title));
+    return [
+      line(`${title}${"─".repeat(borderWidth)}`, safeWidth),
+      ...body,
+      line(
+        this.mode === "detail"
+          ? "←/b list  ↑↓ scroll  End live  Esc unfocus  q hide"
+          : "↑↓ select  Enter inspect  Esc unfocus  q hide",
+        safeWidth,
+      ),
+    ].slice(0, height);
+  }
+
+  handleInput(data: string): void {
+    const runs = flattenRuns(this.registry.getSnapshots());
+    if (data === "q") {
+      this.onHide();
+      return;
+    }
+    if (this.matches(data, "tui.select.cancel")) {
+      this.onUnfocus();
+      return;
+    }
+
+    if (this.mode === "list") {
+      const current = Math.max(
+        0,
+        runs.findIndex(({ run }) => run.runId === this.selectedRunId),
+      );
+      if (this.matches(data, "tui.select.up") || data === "k") {
+        this.selectedRunId = runs[Math.max(0, current - 1)]?.run.runId;
+      } else if (this.matches(data, "tui.select.down") || data === "j") {
+        this.selectedRunId =
+          runs[Math.min(runs.length - 1, current + 1)]?.run.runId;
+      } else if (this.matches(data, "tui.select.pageUp")) {
+        this.selectedRunId = runs[Math.max(0, current - 8)]?.run.runId;
+      } else if (this.matches(data, "tui.select.pageDown")) {
+        this.selectedRunId =
+          runs[Math.min(runs.length - 1, current + 8)]?.run.runId;
+      } else if (
+        this.matches(data, "tui.select.confirm") ||
+        this.matches(data, "tui.editor.cursorRight")
+      ) {
+        if (this.selectedRunId !== undefined) {
+          this.mode = "detail";
+          this.follow = true;
+          this.detailOffset = 0;
+        }
+      } else return;
+    } else {
+      if (data === "b" || this.matches(data, "tui.editor.cursorLeft")) {
+        this.mode = "list";
+      } else if (this.matches(data, "tui.select.up") || data === "k") {
+        this.follow = false;
+        this.detailOffset = Math.max(0, this.detailOffset - 1);
+      } else if (this.matches(data, "tui.select.pageUp")) {
+        this.follow = false;
+        this.detailOffset = Math.max(0, this.detailOffset - 8);
+      } else if (this.matches(data, "tui.select.down") || data === "j") {
+        this.detailOffset = Math.min(
+          this.lastDetailMaxOffset,
+          this.detailOffset + 1,
+        );
+        this.follow = this.detailOffset >= this.lastDetailMaxOffset;
+      } else if (this.matches(data, "tui.select.pageDown")) {
+        this.detailOffset = Math.min(
+          this.lastDetailMaxOffset,
+          this.detailOffset + 8,
+        );
+        this.follow = this.detailOffset >= this.lastDetailMaxOffset;
+      } else if (this.matches(data, "tui.editor.cursorLineEnd")) {
+        this.follow = true;
+        this.detailOffset = this.lastDetailMaxOffset;
+      } else return;
+    }
+    this.tui.requestRender();
+  }
+
+  invalidate(): void {}
+
+  dispose(): void {
+    this.unsubscribe();
+  }
+
+  getSelectedRunId(): string | undefined {
+    return this.selectedRunId;
+  }
+
+  getMode(): BrowserMode {
+    return this.mode;
+  }
+
+  private renderList(
+    snapshots: ChildInvocationSnapshot[],
+    runs: FlatRun[],
+    width: number,
+    viewport: number,
+  ): string[] {
+    if (runs.length === 0) {
+      return [
+        line("No child runs on this session branch.", width),
+        line("Start subagent or workflow to populate this view.", width),
+      ];
+    }
+    const rendered: { text: string; runId?: string }[] = [];
+    for (const invocation of snapshots) {
+      rendered.push({
+        text: `${invocation.label} · ${invocation.source} · ${invocation.runs.length} run(s)`,
+      });
+      for (const run of invocation.runs) {
+        const stage =
+          run.stageIndex === undefined
+            ? `${run.taskIndex + 1}`
+            : `S${run.stageIndex + 1}/T${run.taskIndex + 1}`;
+        rendered.push({
+          runId: run.runId,
+          text: `${run.runId === this.selectedRunId ? ">" : " "} ${statusIcon(run.status)} ${stage} ${run.agent} — ${taskOneLine(run.task)}`,
+        });
+      }
+    }
+    const selectedLine = Math.max(
+      0,
+      rendered.findIndex((item) => item.runId === this.selectedRunId),
+    );
+    this.listOffset = Math.max(
+      0,
+      Math.min(
+        this.listOffset,
+        Math.max(0, rendered.length - Math.max(1, viewport)),
+      ),
+    );
+    if (selectedLine < this.listOffset) this.listOffset = selectedLine;
+    if (selectedLine >= this.listOffset + viewport) {
+      this.listOffset = selectedLine - viewport + 1;
+    }
+    return rendered
+      .slice(this.listOffset, this.listOffset + viewport)
+      .map((item) => line(item.text, width));
+  }
+
+  private renderDetail(
+    runs: FlatRun[],
+    width: number,
+    viewport: number,
+  ): string[] {
+    const selected = runs.find(({ run }) => run.runId === this.selectedRunId);
+    if (selected === undefined) {
+      this.mode = "list";
+      return [line("Selected child run is no longer available.", width)];
+    }
+    const { invocation, run } = selected;
+    const allLines: string[] = [
+      `${run.agent} · ${statusLabel(run.status)}`,
+      `${invocation.label}${run.stageName ? ` · ${run.stageName}` : ""}`,
+      `task: ${taskOneLine(run.task)}`,
+      "",
+    ];
+    for (const item of run.transcript) {
+      allLines.push(...transcriptLines(item, width));
+    }
+    if (run.liveDraft) {
+      allLines.push("assistant [live]:");
+      allLines.push(
+        ...wrapPlainText(run.liveDraft, Math.max(1, width - 2)).map(
+          (part) => `  ${part}`,
+        ),
+      );
+    }
+    if (run.transcript.length === 0 && !run.liveDraft) {
+      allLines.push(
+        run.status === "queued" ? "(not launched)" : "(no assistant text yet)",
+      );
+    }
+    if (run.protocolWarnings > 0) {
+      allLines.push(`(${run.protocolWarnings} child stream warning(s))`);
+    }
+    this.lastDetailMaxOffset = Math.max(0, allLines.length - viewport);
+    if (this.follow) this.detailOffset = this.lastDetailMaxOffset;
+    else
+      this.detailOffset = Math.min(this.detailOffset, this.lastDetailMaxOffset);
+    const visible = allLines.slice(
+      this.detailOffset,
+      this.detailOffset + Math.max(1, viewport),
+    );
+    if (this.follow && run.status === "running") {
+      visible[0] = `[LIVE] ${visible[0] ?? ""}`;
+    } else if (!this.follow) {
+      visible[0] = `[PAUSED] ${visible[0] ?? ""}`;
+    }
+    return visible.map((item) => line(item, width));
+  }
+
+  private matches(data: string, keybinding: string): boolean {
+    try {
+      return this.keybindings.matches(data, keybinding);
+    } catch {
+      return false;
+    }
+  }
+}
+
+type MountState = "unmounted" | "mounting" | "mounted" | "disposed";
+
+export class ChildRunsOverlayController {
+  private state: MountState = "unmounted";
+  private handle: OverlayHandleLike | undefined;
+  private component: ChildRunsBrowserComponent | undefined;
+  private pendingFocus = false;
+  private explicitlyVisible = false;
+  private ready: Promise<boolean> | undefined;
+
+  constructor(private readonly registry: ChildRunRegistry) {}
+
+  ensureVisible(ctx: BrowserContextLike): void {
+    void this.show(ctx, false);
+  }
+
+  async showAndFocus(ctx: BrowserContextLike): Promise<void> {
+    await this.show(ctx, true);
+  }
+
+  dispose(): void {
+    if (this.state === "disposed") return;
+    this.state = "disposed";
+    this.component?.dispose();
+    this.component = undefined;
+    this.explicitlyVisible = false;
+    this.handle?.hide();
+    this.handle = undefined;
+  }
+
+  getMountState(): MountState {
+    return this.state;
+  }
+
+  getHandle(): OverlayHandleLike | undefined {
+    return this.handle;
+  }
+
+  private async show(
+    ctx: BrowserContextLike,
+    focus: boolean,
+  ): Promise<boolean> {
+    if (ctx.mode !== "tui" || this.state === "disposed") return false;
+    if (focus) this.explicitlyVisible = true;
+    if (this.state === "mounted" && this.handle !== undefined) {
+      this.handle.setHidden(false);
+      if (focus) this.handle.focus();
+      return true;
+    }
+    if (this.state === "mounting") {
+      this.pendingFocus ||= focus;
+      return (await this.ready) ?? false;
+    }
+
+    this.state = "mounting";
+    this.pendingFocus = focus;
+    let settleReady: (mounted: boolean) => void = () => {};
+    this.ready = new Promise<boolean>((resolve) => {
+      settleReady = resolve;
+    });
+    const ui = ctx.ui as unknown as CustomUiLike;
+    let localComponent: ChildRunsBrowserComponent | undefined;
+    const customPromise = ui.custom<void>(
+      (tui, _theme, keybindings) => {
+        localComponent = new ChildRunsBrowserComponent(
+          this.registry,
+          tui,
+          keybindings,
+          () => this.handle?.unfocus(),
+          () => this.hide(),
+        );
+        this.component = localComponent;
+        return localComponent;
+      },
+      {
+        overlay: true,
+        overlayOptions: () => ({
+          nonCapturing: true,
+          anchor: "right-center",
+          width: 48,
+          maxHeight: "80%",
+          margin: 1,
+          visible: (termWidth) =>
+            termWidth >= 120 ||
+            this.explicitlyVisible ||
+            this.handle?.isFocused() === true,
+        }),
+        onHandle: (handle) => {
+          if (this.state === "disposed") {
+            handle.hide();
+            settleReady(false);
+            return;
+          }
+          this.handle = handle;
+          this.state = "mounted";
+          handle.setHidden(false);
+          if (this.pendingFocus) handle.focus();
+          this.pendingFocus = false;
+          settleReady(true);
+        },
+      },
+    );
+    void customPromise
+      .then(() => {
+        if (this.state === "disposed") return;
+        localComponent?.dispose();
+        if (this.component === localComponent) this.component = undefined;
+        this.handle = undefined;
+        this.explicitlyVisible = false;
+        this.state = "unmounted";
+      })
+      .catch((error) => {
+        if (this.state !== "disposed") {
+          this.state = "unmounted";
+          this.handle = undefined;
+          this.explicitlyVisible = false;
+          this.component?.dispose();
+          this.component = undefined;
+          ui.notify(
+            `Child-session browser could not open: ${String(error)}`,
+            "warning",
+          );
+        }
+        settleReady(false);
+      });
+    return (await this.ready) ?? false;
+  }
+
+  private hide(): void {
+    this.explicitlyVisible = false;
+    this.handle?.unfocus();
+    this.handle?.setHidden(true);
+  }
+}

--- a/pi/extensions/pi-harness/features/subagent/index.ts
+++ b/pi/extensions/pi-harness/features/subagent/index.ts
@@ -1,6 +1,9 @@
 import type { CtxLike, PiLike } from "../../lib/pi-like";
 import type { HarnessConfig } from "../../config";
 import { replacePrevious } from "../../lib/placeholder";
+import type { ChildObservation } from "../child-runs/model";
+import { renderChildRunsResult } from "../child-runs/presentation";
+import { ChildRunRegistry } from "../child-runs/registry";
 import { findAgent, loadAgents } from "./loader";
 import { MAX_CHAIN_DEPTH, MAX_PARALLEL_TASKS } from "./limits";
 import { SubagentParameters } from "./parameters.generated";
@@ -27,9 +30,15 @@ interface SubagentParams {
   cwd?: string;
 }
 
+interface ChildRunsIntegration {
+  registry: ChildRunRegistry;
+  ensureVisible(ctx: CtxLike): void;
+}
+
 interface SetupSubagentOptions {
   spawnFn?: SpawnFunction;
   termGraceMs?: number;
+  childRuns?: ChildRunsIntegration;
 }
 
 interface SubagentDetails {
@@ -216,14 +225,14 @@ const setupSubagent = (
 ): void => {
   const semaphore = createSemaphore(MAX_CONCURRENCY);
 
-  pi.registerTool({
+  const tool = {
     name: "subagent",
     label: "Subagent",
     description:
       "Delegate work to a configured agent in single, parallel, or chain mode.",
     parameters: SubagentParameters,
     async execute(
-      _toolCallId: string,
+      toolCallId: string,
       params: SubagentParams,
       signal: AbortSignal | undefined,
       onUpdate: unknown,
@@ -240,139 +249,282 @@ const setupSubagent = (
         );
       }
 
+      if (params.chain !== undefined && params.chain.length > MAX_CHAIN_DEPTH) {
+        throw new Error(
+          `Too many chain steps (${params.chain.length}). Max is ${MAX_CHAIN_DEPTH}.`,
+        );
+      }
+      if (
+        params.tasks !== undefined &&
+        params.tasks.length > MAX_PARALLEL_TASKS
+      ) {
+        throw new Error(
+          `Too many parallel tasks (${params.tasks.length}). Max is ${MAX_PARALLEL_TASKS}.`,
+        );
+      }
+      if (params.tasks !== undefined) {
+        for (const task of params.tasks) findAgent(agents, task.agent);
+      }
+
       const defaultCwd = ctx.cwd ?? process.cwd();
+      const declaredItems: TaskItem[] =
+        params.chain && params.chain.length > 0
+          ? params.chain
+          : params.tasks && params.tasks.length > 0
+            ? params.tasks
+            : params.agent !== undefined && params.task !== undefined
+              ? [{ agent: params.agent, task: params.task, cwd: params.cwd }]
+              : [];
+      const mode = hasChain ? "chain" : hasTasks ? "parallel" : "single";
+      const childRuns = options.childRuns;
+      const started = childRuns?.registry.beginInvocation({
+        toolCallId,
+        source: "subagent",
+        mode,
+        label: `subagent ${mode}`,
+        runs: declaredItems.map((item, taskIndex) => ({
+          agent: item.agent,
+          task: item.task,
+          taskIndex,
+        })),
+      });
+      const invocationId = started?.invocationId;
+      const runIds = started?.runIds ?? [];
+      if (started !== undefined) childRuns?.ensureVisible(ctx);
+
+      let lastUpdateText = `Subagent ${mode} started`;
       const emitUpdate =
         typeof onUpdate === "function"
-          ? (text: string) =>
-              onUpdate({ content: [{ type: "text", text: capText(text) }] })
+          ? (text: string) => {
+              lastUpdateText = text;
+              const details =
+                invocationId === undefined
+                  ? undefined
+                  : childRuns?.registry.getUpdateDetails(invocationId);
+              onUpdate({
+                content: [{ type: "text", text: capText(text) }],
+                ...(details === undefined ? {} : { details }),
+              });
+            }
           : undefined;
+      emitUpdate?.(lastUpdateText);
+
+      const observeFor =
+        (runId: string | undefined) => (observation: ChildObservation) => {
+          if (runId === undefined || childRuns === undefined) return;
+          childRuns.registry.observe(runId, observation);
+          if (observation.type !== "assistant_draft") {
+            emitUpdate?.(lastUpdateText);
+          }
+        };
+
+      const finishSpawnResult = (
+        runId: string | undefined,
+        result: SpawnResult,
+      ): void => {
+        if (runId === undefined || childRuns === undefined) return;
+        let reason:
+          | "length"
+          | "model-error"
+          | "model-aborted"
+          | "spawn-error"
+          | "completed" = "completed";
+        if (result.stopReason === "length") reason = "length";
+        else if (result.stopReason === "aborted") reason = "model-aborted";
+        else if (result.stopReason === "error") reason = "model-error";
+        else if (result.failed) reason = "spawn-error";
+        childRuns.registry.finishRun(runId, {
+          status:
+            result.stopReason === "aborted"
+              ? "aborted"
+              : result.failed
+                ? "failed"
+                : "succeeded",
+          reason,
+          exitCode: result.exitCode,
+          signal: result.signal,
+          stopReason: result.stopReason,
+          model: result.model,
+        });
+      };
+
       const runTask = async (
         item: TaskItem,
+        runId: string | undefined,
         taskSignal: AbortSignal | undefined = signal,
       ): Promise<SpawnResult> => {
-        const release = await semaphore.acquire(taskSignal);
+        let release: (() => void) | undefined;
         try {
+          release = await semaphore.acquire(taskSignal);
           if (isAborted(taskSignal)) {
             throw new Error("Subagent was aborted");
           }
-          return await spawnAgent(findAgent(agents, item.agent), item.task, {
-            cwd: item.cwd ?? defaultCwd,
-            signal: taskSignal,
-            spawnFn: options.spawnFn,
-            onUpdate: emitUpdate,
-            termGraceMs: options.termGraceMs,
-          });
+          const result = await spawnAgent(
+            findAgent(agents, item.agent),
+            item.task,
+            {
+              cwd: item.cwd ?? defaultCwd,
+              signal: taskSignal,
+              spawnFn: options.spawnFn,
+              onUpdate: emitUpdate,
+              observe: observeFor(runId),
+              termGraceMs: options.termGraceMs,
+            },
+          );
+          finishSpawnResult(runId, result);
+          return result;
+        } catch (error) {
+          if (runId !== undefined && childRuns !== undefined) {
+            const status = childRuns.registry.getRunStatus(runId);
+            const parentAborted = isAborted(signal);
+            const taskAborted = isAborted(taskSignal);
+            let terminalStatus: "skipped" | "aborted" | "failed" = "failed";
+            if (taskAborted) {
+              terminalStatus =
+                status === "queued" && !parentAborted ? "skipped" : "aborted";
+            }
+            let reason:
+              | "parent-abort"
+              | "fail-fast"
+              | "spawn-error"
+              | "setup-error" =
+              status === "running" ? "spawn-error" : "setup-error";
+            if (parentAborted) reason = "parent-abort";
+            else if (taskAborted) reason = "fail-fast";
+            childRuns.registry.finishRun(runId, {
+              status: terminalStatus,
+              reason,
+            });
+          }
+          throw error;
         } finally {
-          release();
+          release?.();
         }
       };
 
-      if (params.chain !== undefined && params.chain.length > 0) {
-        if (params.chain.length > MAX_CHAIN_DEPTH) {
-          throw new Error(
-            `Too many chain steps (${params.chain.length}). Max is ${MAX_CHAIN_DEPTH}.`,
-          );
-        }
-        const results: SpawnResult[] = [];
-        let previous = "";
-        for (const step of params.chain) {
-          const result = await runTask({
-            ...step,
-            task: replacePrevious(step.task, previous),
-          });
-          assertSuccessful(result);
-          results.push(result);
-          previous = result.output;
-        }
-        return {
-          content: [{ type: "text", text: capText(previous || "(no output)") }],
-          details: { mode: "chain", results } satisfies SubagentDetails,
-        };
-      }
-
-      if (params.tasks !== undefined && params.tasks.length > 0) {
-        if (params.tasks.length > MAX_PARALLEL_TASKS) {
-          throw new Error(
-            `Too many parallel tasks (${params.tasks.length}). Max is ${MAX_PARALLEL_TASKS}.`,
-          );
-        }
-        for (const task of params.tasks) findAgent(agents, task.agent);
-
-        const controller = createAbortController();
-        const forwardAbort = () => controller.abort();
-        if (isAborted(signal)) {
-          controller.abort();
-        } else if (
-          signal !== undefined &&
-          "addEventListener" in signal &&
-          typeof signal.addEventListener === "function"
-        ) {
-          signal.addEventListener("abort", forwardAbort, { once: true });
-        }
-
-        let results: SpawnResult[];
-        try {
-          results = await mapWithConcurrencyLimit(
-            params.tasks,
-            MAX_CONCURRENCY,
-            async (task) => {
-              const result = await runTask(task, controller.signal);
-              assertSuccessful(result);
-              return result;
-            },
-            () => controller.abort(),
-          );
-        } finally {
-          if (
-            signal !== undefined &&
-            "removeEventListener" in signal &&
-            typeof signal.removeEventListener === "function"
-          ) {
-            signal.removeEventListener("abort", forwardAbort);
+      let incompleteReason: "dependency-failed" | "fail-fast" =
+        "dependency-failed";
+      try {
+        if (params.chain !== undefined && params.chain.length > 0) {
+          const results: SpawnResult[] = [];
+          let previous = "";
+          for (const [index, step] of params.chain.entries()) {
+            const result = await runTask(
+              { ...step, task: replacePrevious(step.task, previous) },
+              runIds[index],
+            );
+            assertSuccessful(result);
+            results.push(result);
+            previous = result.output;
           }
+          return {
+            content: [
+              { type: "text", text: capText(previous || "(no output)") },
+            ],
+            details: { mode: "chain", results } satisfies SubagentDetails,
+          };
         }
 
-        const summaries = results.map(
-          (result) =>
-            `### [${result.agent}] completed\n\n${getResultOutput(result)}`,
-        );
-        return {
-          content: [
-            {
-              type: "text",
-              text: capText(
-                `Parallel: ${results.length}/${results.length} succeeded\n\n${summaries.join("\n\n---\n\n")}`,
-              ),
-            },
-          ],
-          details: { mode: "parallel", results } satisfies SubagentDetails,
-        };
-      }
+        if (params.tasks !== undefined && params.tasks.length > 0) {
+          const controller = createAbortController();
+          const forwardAbort = () => controller.abort();
+          if (isAborted(signal)) controller.abort();
+          else if (
+            signal !== undefined &&
+            "addEventListener" in signal &&
+            typeof signal.addEventListener === "function"
+          ) {
+            signal.addEventListener("abort", forwardAbort, { once: true });
+          }
 
-      if (params.agent !== undefined && params.task !== undefined) {
-        const result = await runTask({
-          agent: params.agent,
-          task: params.task,
-          cwd: params.cwd,
-        });
-        assertSuccessful(result);
-        return {
-          content: [
-            {
-              type: "text",
-              text: capText(result.output || "(no output)"),
-            },
-          ],
-          details: {
-            mode: "single",
-            results: [result],
-          } satisfies SubagentDetails,
-        };
-      }
+          let results: SpawnResult[];
+          try {
+            results = await mapWithConcurrencyLimit(
+              params.tasks,
+              MAX_CONCURRENCY,
+              async (task, index) => {
+                const result = await runTask(
+                  task,
+                  runIds[index],
+                  controller.signal,
+                );
+                assertSuccessful(result);
+                return result;
+              },
+              () => {
+                incompleteReason = "fail-fast";
+                controller.abort();
+              },
+            );
+          } finally {
+            if (
+              signal !== undefined &&
+              "removeEventListener" in signal &&
+              typeof signal.removeEventListener === "function"
+            ) {
+              signal.removeEventListener("abort", forwardAbort);
+            }
+          }
 
-      throw new Error("Invalid subagent parameters.");
+          const summaries = results.map(
+            (result) =>
+              `### [${result.agent}] completed\n\n${getResultOutput(result)}`,
+          );
+          return {
+            content: [
+              {
+                type: "text",
+                text: capText(
+                  `Parallel: ${results.length}/${results.length} succeeded\n\n${summaries.join("\n\n---\n\n")}`,
+                ),
+              },
+            ],
+            details: { mode: "parallel", results } satisfies SubagentDetails,
+          };
+        }
+
+        if (params.agent !== undefined && params.task !== undefined) {
+          const result = await runTask(
+            { agent: params.agent, task: params.task, cwd: params.cwd },
+            runIds[0],
+          );
+          assertSuccessful(result);
+          return {
+            content: [
+              {
+                type: "text",
+                text: capText(result.output || "(no output)"),
+              },
+            ],
+            details: {
+              mode: "single",
+              results: [result],
+            } satisfies SubagentDetails,
+          };
+        }
+
+        throw new Error("Invalid subagent parameters.");
+      } finally {
+        if (invocationId !== undefined && childRuns !== undefined) {
+          const parentAborted = isAborted(signal);
+          childRuns.registry.terminalizeInvocation(
+            invocationId,
+            {
+              status: parentAborted ? "aborted" : "skipped",
+              reason: parentAborted ? "parent-abort" : incompleteReason,
+            },
+            {
+              status: "aborted",
+              reason: parentAborted ? "parent-abort" : "fail-fast",
+            },
+          );
+          emitUpdate?.(lastUpdateText);
+        }
+      }
     },
-  });
+    renderResult: renderChildRunsResult,
+  };
+  pi.registerTool(tool);
 };
 
 export default setupSubagent;

--- a/pi/extensions/pi-harness/features/subagent/spawn.ts
+++ b/pi/extensions/pi-harness/features/subagent/spawn.ts
@@ -2,8 +2,11 @@ import { spawn } from "node:child_process";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { StringDecoder } from "node:string_decoder";
 import type { AgentDefinition } from "../../lib/agent-md";
 import { sanitizeChildEnv } from "../../lib/child-env";
+import type { ChildObservation } from "../child-runs/model";
+import { createChildProtocolParser } from "../child-runs/protocol";
 
 const PER_TASK_OUTPUT_CAP = 50 * 1024;
 // Parser-protection ceiling: lines beyond this are dropped unparsed. Kept
@@ -23,7 +26,10 @@ const FAILED_STOP_REASONS: ReadonlySet<string> = new Set([
 ]);
 
 interface ReadableLike {
-  on(event: "data", listener: (chunk: string) => void): ReadableLike;
+  on(
+    event: "data",
+    listener: (chunk: string | Uint8Array) => void,
+  ): ReadableLike;
 }
 
 interface SpawnedProcess {
@@ -78,6 +84,7 @@ interface SpawnAgentOptions {
   signal?: AbortSignal;
   spawnFn?: SpawnFunction;
   onUpdate?: (text: string) => void;
+  observe?: (observation: ChildObservation) => void;
   termGraceMs?: number;
 }
 
@@ -92,12 +99,6 @@ interface SpawnResult {
   errorMessage?: string;
   signal?: string;
   failed: boolean;
-}
-
-interface MessageEndEvent {
-  text?: string;
-  stopReason?: string;
-  errorMessage?: string;
 }
 
 interface ProcessOutcome {
@@ -163,51 +164,6 @@ const writePromptToTempFile = async (
   return { directory, filePath };
 };
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
-const getString = (
-  primary: Record<string, unknown>,
-  secondary: Record<string, unknown> | undefined,
-  key: string,
-): string | undefined => {
-  const primaryValue = primary[key];
-  if (typeof primaryValue === "string") return capText(primaryValue);
-  const secondaryValue = secondary?.[key];
-  return typeof secondaryValue === "string"
-    ? capText(secondaryValue)
-    : undefined;
-};
-
-const parseMessageEndEvent = (line: string): MessageEndEvent | undefined => {
-  let event: unknown;
-  try {
-    event = JSON.parse(line);
-  } catch {
-    return undefined;
-  }
-  if (!isRecord(event) || event.type !== "message_end") return undefined;
-  const message = isRecord(event.message) ? event.message : undefined;
-  const parsed: MessageEndEvent = {
-    stopReason: getString(event, message, "stopReason"),
-    errorMessage: getString(event, message, "errorMessage"),
-  };
-
-  if (message?.role === "assistant" && Array.isArray(message.content)) {
-    for (const part of message.content) {
-      if (
-        isRecord(part) &&
-        part.type === "text" &&
-        typeof part.text === "string"
-      ) {
-        parsed.text = capText(part.text);
-        break;
-      }
-    }
-  }
-  return parsed;
-};
-
 const isAborted = (signal: AbortSignal | undefined): boolean =>
   signal !== undefined && "aborted" in signal && signal.aborted === true;
 
@@ -250,6 +206,15 @@ const spawnAgent = async (
     let output = "";
     let buffer = "";
     let skippingOversizedLine = false;
+    const decoder = new StringDecoder("utf8");
+    const observe = (observation: ChildObservation): void => {
+      try {
+        options.observe?.(observation);
+      } catch {
+        // Browser instrumentation must not affect child execution.
+      }
+    };
+    const protocol = createChildProtocolParser({ observe });
     let aborted = false;
     let abortHandler: (() => void) | undefined;
     let stopReason: string | undefined;
@@ -295,24 +260,24 @@ const spawnAgent = async (
           return;
         }
 
+        observe({ type: "process_started", at: Date.now() });
+
         const processLine = (line: string) => {
-          if (line.trim() === "") return;
-          const event = parseMessageEndEvent(line);
+          const event = protocol.processLine(line);
           if (event === undefined) return;
-          const {
-            stopReason: eventStopReason,
-            errorMessage: eventErrorMessage,
-            text,
-          } = event;
-          if (eventStopReason !== undefined) stopReason = eventStopReason;
-          if (eventErrorMessage !== undefined) errorMessage = eventErrorMessage;
-          if (text === undefined) return;
-          output = text;
-          options.onUpdate?.(text);
+          if (event.stopReason !== undefined) {
+            stopReason = capText(event.stopReason);
+          }
+          if (event.errorMessage !== undefined) {
+            errorMessage = capText(event.errorMessage);
+          }
+          if (event.text === undefined) return;
+          output = capText(event.text);
+          options.onUpdate?.(output);
         };
 
-        const processStdoutChunk = (chunk: string) => {
-          let remaining = chunk.toString();
+        const processDecodedChunk = (decoded: string) => {
+          let remaining = decoded;
           while (remaining !== "") {
             if (skippingOversizedLine) {
               const newlineIndex = remaining.indexOf("\n");
@@ -328,8 +293,8 @@ const spawnAgent = async (
               // Drop complete oversized lines before parsing so the cap
               // bounds transient allocations too, not just retained state.
               if (Buffer.byteLength(line, "utf8") <= LINE_DROP_CAP) {
-                processLine(line);
-              }
+                processLine(line.endsWith("\r") ? line.slice(0, -1) : line);
+              } else protocol.oversizedLine();
               buffer = "";
               remaining = remaining.slice(newlineIndex + 1);
               continue;
@@ -339,6 +304,7 @@ const spawnAgent = async (
             if (Buffer.byteLength(candidate, "utf8") > LINE_DROP_CAP) {
               buffer = "";
               skippingOversizedLine = true;
+              protocol.oversizedLine();
             } else {
               buffer = candidate;
             }
@@ -370,15 +336,29 @@ const spawnAgent = async (
           unrefTimer(termTimer);
         };
 
-        child.stdout.on("data", processStdoutChunk);
+        child.stdout.on("data", (chunk) => {
+          processDecodedChunk(
+            typeof chunk === "string"
+              ? chunk
+              : decoder.write(Buffer.from(chunk)),
+          );
+        });
         child.stderr.on("data", (chunk) => {
           stderrAccumulator.append(chunk.toString());
         });
         child.on("close", (code, signal) => {
           closed = true;
+          const finalDecoded = decoder.end();
+          if (finalDecoded !== "") processDecodedChunk(finalDecoded);
           if (!skippingOversizedLine && buffer.trim() !== "") {
-            processLine(buffer);
+            processLine(buffer.endsWith("\r") ? buffer.slice(0, -1) : buffer);
           }
+          observe({
+            type: "process_exit",
+            at: Date.now(),
+            exitCode: code,
+            signal: signal ?? undefined,
+          });
           // On abort the leader can exit while SIGTERM-ignoring grandchildren
           // linger in its process group; SIGKILL the group to reap them,
           // independent of the leader's close.
@@ -390,6 +370,11 @@ const spawnAgent = async (
         });
         child.on("error", (error) => {
           stderrAccumulator.append(error.message);
+          observe({
+            type: "process_exit",
+            at: Date.now(),
+            exitCode: 1,
+          });
           settle({ exitCode: 1 });
         });
 

--- a/pi/extensions/pi-harness/features/workflow/index.ts
+++ b/pi/extensions/pi-harness/features/workflow/index.ts
@@ -13,6 +13,9 @@
  */
 import { randomUUID } from "node:crypto";
 import type { HarnessConfig } from "../../config";
+import type { ChildObservation } from "../child-runs/model";
+import { renderChildRunsResult } from "../child-runs/presentation";
+import { ChildRunRegistry } from "../child-runs/registry";
 import type { CtxLike, PiLike } from "../../lib/pi-like";
 import {
   type CwdBoundaryResult,
@@ -40,6 +43,11 @@ import {
 
 const MAX_CONCURRENCY = 4;
 
+interface ChildRunsIntegration {
+  registry: ChildRunRegistry;
+  ensureVisible(ctx: CtxLike): void;
+}
+
 interface SetupWorkflowOptions {
   spawnFn?: SpawnFunction;
   termGraceMs?: number;
@@ -48,6 +56,7 @@ interface SetupWorkflowOptions {
     candidateCwd: string,
     rootCwd: string,
   ) => Promise<CwdBoundaryResult>;
+  childRuns?: ChildRunsIntegration;
 }
 
 interface SpawnFailure {
@@ -201,14 +210,14 @@ const setupWorkflow = (
   config: HarnessConfig,
   options: SetupWorkflowOptions = {},
 ): void => {
-  pi.registerTool({
+  const tool = {
     name: "workflow",
     label: "Workflow",
     description:
       'Run a staged multi-agent workflow (ultracode-equivalent). Fan-out stages default to the codex agent family; the engine enforces codex-poc worktree isolation and disjoint codex-runner writeScopes, and never merges or removes created worktrees. A task may reference prior stages with the reserved placeholder {previous}: at run time it expands to a digest of every already-completed stage in declaration order (including failures and any worktree paths), so e.g. a later review stage can read the paths a prior implement stage created. {previous} is a reserved token (no literal escape); tasks in the first stage expand it to "(no prior stages)".',
     parameters: WorkflowParameters,
     async execute(
-      _toolCallId: string,
+      toolCallId: string,
       params: unknown,
       signal: AbortSignal | undefined,
       onUpdate: unknown,
@@ -256,147 +265,272 @@ const setupWorkflow = (
         options.createWorktree ??
         ((cwd: string, name: string) =>
           createValidatedWorktree(makeWorktreeCreator(config), cwd, name));
+      const childRuns = options.childRuns;
+      const started = childRuns?.registry.beginInvocation({
+        toolCallId,
+        source: "workflow",
+        label: "workflow",
+        runs: validation.stages.flatMap((stage, stageIndex) =>
+          stage.tasks.map((task, taskIndex) => ({
+            agent: task.agentType,
+            task: task.task,
+            taskIndex,
+            stageIndex,
+            stageName: stage.name,
+          })),
+        ),
+      });
+      const invocationId = started?.invocationId;
+      const runIdsByStage: string[][] = [];
+      let flatRunIndex = 0;
+      for (const stage of validation.stages) {
+        runIdsByStage.push(
+          stage.tasks
+            .map(() => started?.runIds[flatRunIndex++])
+            .filter((runId): runId is string => runId !== undefined),
+        );
+      }
+      if (started !== undefined) childRuns?.ensureVisible(ctx);
+
+      let lastUpdateText = "Workflow started";
       const emitUpdate =
         typeof onUpdate === "function"
-          ? (text: string) =>
-              onUpdate({ content: [{ type: "text", text: capText(text) }] })
-          : undefined;
-
-      const stageReports: WorkflowStageReport[] = [];
-      for (const [stageIndex, stage] of validation.stages.entries()) {
-        if (isAborted(signal)) throw new Error("Workflow was aborted");
-
-        // Digest of every already-completed stage, spliced into this stage's
-        // tasks wherever they contain {previous}. Computed before this stage's
-        // reports are pushed, so a task never sees its own or its siblings'
-        // output — only prior stages, in declaration order, failures included.
-        const priorTaskCount = stageReports.reduce(
-          (count, report) => count + report.tasks.length,
-          0,
-        );
-        const previous =
-          stageReports.length === 0
-            ? "(no prior stages)"
-            : wrapUntrusted(
-                capText(
-                  renderStageDigest(
-                    stageReports,
-                    taskOutputBudget(priorTaskCount),
-                  ),
-                  MAX_PREVIOUS_DIGEST_BYTES,
-                ),
-              );
-
-        // Provision worktrees sequentially before the stage runs; a
-        // provisioning failure is an environment error, not a degradable
-        // task result.
-        const worktrees: (string | undefined)[] = [];
-        for (const [taskIndex, task] of stage.tasks.entries()) {
-          // A mid-flight abort must not provision worktrees for tasks that
-          // have not started; check before each (potentially slow) creation.
-          if (isAborted(signal)) throw new Error("Workflow was aborted");
-          worktrees[taskIndex] =
-            task.isolation === "worktree"
-              ? await createWorktree(
-                  defaultCwd,
-                  worktreeBranchName(stageIndex, taskIndex),
-                )
-              : undefined;
-        }
-        if (isAborted(signal)) throw new Error("Workflow was aborted");
-
-        const taskReports: WorkflowTaskReport[] = [];
-        const runTask = async (
-          task: WorkflowTaskPlan,
-          taskIndex: number,
-        ): Promise<void> => {
-          // Do not spawn a task that was cancelled before it started.
-          if (isAborted(signal)) throw new Error("Workflow was aborted");
-          const cwd = worktrees[taskIndex] ?? task.cwd ?? defaultCwd;
-          // Substitute {previous} for the injected prior-stage digest. The
-          // report keeps the original task.task (base.task); the expanded text
-          // is what the child receives (and is recorded on SpawnResult.task).
-          const taskText = replacePrevious(task.task, previous);
-          const base = {
-            agentType: task.agentType,
-            task: task.task,
-            cwd,
-            ...(worktrees[taskIndex] === undefined
-              ? {}
-              : { worktree: worktrees[taskIndex] }),
-          };
-          try {
-            const result = await spawnAgent(
-              findAgent(agents, task.agentType),
-              taskText,
-              {
-                cwd,
-                signal,
-                spawnFn: options.spawnFn,
-                onUpdate: emitUpdate,
-                termGraceMs: options.termGraceMs,
-              },
-            );
-            taskReports[taskIndex] = { ...base, result };
-          } catch (error) {
-            // An abort is a cancellation, not a degradable task failure: let it
-            // unwind the stage instead of recording a spurious FAILED report.
-            if (isAborted(signal)) {
-              throw error instanceof Error ? error : new Error(String(error));
+          ? (text: string) => {
+              lastUpdateText = text;
+              const details =
+                invocationId === undefined
+                  ? undefined
+                  : childRuns?.registry.getUpdateDetails(invocationId);
+              onUpdate({
+                content: [{ type: "text", text: capText(text) }],
+                ...(details === undefined ? {} : { details }),
+              });
             }
-            taskReports[taskIndex] = {
-              ...base,
-              result: { failed: true, errorMessage: errorMessage(error) },
-            };
+          : undefined;
+      emitUpdate?.(lastUpdateText);
+
+      const observeFor =
+        (runId: string | undefined) => (observation: ChildObservation) => {
+          if (runId === undefined || childRuns === undefined) return;
+          childRuns.registry.observe(runId, observation);
+          if (observation.type !== "assistant_draft") {
+            emitUpdate?.(lastUpdateText);
           }
         };
-        await runWithConcurrency(stage.tasks, MAX_CONCURRENCY, runTask, signal);
-        // A stage cancelled mid-flight leaves gaps in taskReports; do not
-        // record a partial stage — unwind instead.
+
+      const stageReports: WorkflowStageReport[] = [];
+      try {
+        for (const [stageIndex, stage] of validation.stages.entries()) {
+          if (isAborted(signal)) throw new Error("Workflow was aborted");
+
+          // Digest of every already-completed stage, spliced into this stage's
+          // tasks wherever they contain {previous}. Computed before this stage's
+          // reports are pushed, so a task never sees its own or its siblings'
+          // output — only prior stages, in declaration order, failures included.
+          const priorTaskCount = stageReports.reduce(
+            (count, report) => count + report.tasks.length,
+            0,
+          );
+          const previous =
+            stageReports.length === 0
+              ? "(no prior stages)"
+              : wrapUntrusted(
+                  capText(
+                    renderStageDigest(
+                      stageReports,
+                      taskOutputBudget(priorTaskCount),
+                    ),
+                    MAX_PREVIOUS_DIGEST_BYTES,
+                  ),
+                );
+
+          // Provision worktrees sequentially before the stage runs; a
+          // provisioning failure is an environment error, not a degradable
+          // task result.
+          const worktrees: (string | undefined)[] = [];
+          for (const [taskIndex, task] of stage.tasks.entries()) {
+            // A mid-flight abort must not provision worktrees for tasks that
+            // have not started; check before each (potentially slow) creation.
+            if (isAborted(signal)) throw new Error("Workflow was aborted");
+            try {
+              worktrees[taskIndex] =
+                task.isolation === "worktree"
+                  ? await createWorktree(
+                      defaultCwd,
+                      worktreeBranchName(stageIndex, taskIndex),
+                    )
+                  : undefined;
+            } catch (error) {
+              const runId = runIdsByStage[stageIndex]?.[taskIndex];
+              if (runId !== undefined) {
+                childRuns?.registry.finishRun(runId, {
+                  status: "failed",
+                  reason: "setup-error",
+                });
+              }
+              throw error;
+            }
+          }
+          if (isAborted(signal)) throw new Error("Workflow was aborted");
+
+          const taskReports: WorkflowTaskReport[] = [];
+          const runTask = async (
+            task: WorkflowTaskPlan,
+            taskIndex: number,
+          ): Promise<void> => {
+            // Do not spawn a task that was cancelled before it started.
+            if (isAborted(signal)) throw new Error("Workflow was aborted");
+            const cwd = worktrees[taskIndex] ?? task.cwd ?? defaultCwd;
+            const runId = runIdsByStage[stageIndex]?.[taskIndex];
+            // Substitute {previous} for the injected prior-stage digest. The
+            // report keeps the original task.task (base.task); the expanded text
+            // is what the child receives (and is recorded on SpawnResult.task).
+            const taskText = replacePrevious(task.task, previous);
+            const base = {
+              agentType: task.agentType,
+              task: task.task,
+              cwd,
+              ...(worktrees[taskIndex] === undefined
+                ? {}
+                : { worktree: worktrees[taskIndex] }),
+            };
+            try {
+              const result = await spawnAgent(
+                findAgent(agents, task.agentType),
+                taskText,
+                {
+                  cwd,
+                  signal,
+                  spawnFn: options.spawnFn,
+                  onUpdate: emitUpdate,
+                  observe: observeFor(runId),
+                  termGraceMs: options.termGraceMs,
+                },
+              );
+              if (runId !== undefined) {
+                let reason:
+                  | "length"
+                  | "model-error"
+                  | "model-aborted"
+                  | "spawn-error"
+                  | "completed" = "completed";
+                if (result.stopReason === "length") reason = "length";
+                else if (result.stopReason === "aborted") {
+                  reason = "model-aborted";
+                } else if (result.stopReason === "error") {
+                  reason = "model-error";
+                } else if (result.failed) reason = "spawn-error";
+                childRuns?.registry.finishRun(runId, {
+                  status:
+                    result.stopReason === "aborted"
+                      ? "aborted"
+                      : result.failed
+                        ? "failed"
+                        : "succeeded",
+                  reason,
+                  exitCode: result.exitCode,
+                  signal: result.signal,
+                  stopReason: result.stopReason,
+                  model: result.model,
+                });
+              }
+              taskReports[taskIndex] = { ...base, result };
+            } catch (error) {
+              // An abort is a cancellation, not a degradable task failure: let it
+              // unwind the stage instead of recording a spurious FAILED report.
+              if (isAborted(signal)) {
+                if (runId !== undefined) {
+                  childRuns?.registry.finishRun(runId, {
+                    status: "aborted",
+                    reason: "parent-abort",
+                  });
+                }
+                throw error instanceof Error ? error : new Error(String(error));
+              }
+              if (runId !== undefined) {
+                const status = childRuns?.registry.getRunStatus(runId);
+                childRuns?.registry.finishRun(runId, {
+                  status: "failed",
+                  reason: status === "running" ? "spawn-error" : "setup-error",
+                });
+              }
+              taskReports[taskIndex] = {
+                ...base,
+                result: { failed: true, errorMessage: errorMessage(error) },
+              };
+            }
+          };
+          await runWithConcurrency(
+            stage.tasks,
+            MAX_CONCURRENCY,
+            runTask,
+            signal,
+          );
+          // A stage cancelled mid-flight leaves gaps in taskReports; do not
+          // record a partial stage — unwind instead.
+          if (isAborted(signal)) throw new Error("Workflow was aborted");
+
+          stageReports.push({
+            ...(stage.name === undefined ? {} : { name: stage.name }),
+            mode: stage.mode,
+            tasks: taskReports,
+          });
+        }
+
         if (isAborted(signal)) throw new Error("Workflow was aborted");
 
-        stageReports.push({
-          ...(stage.name === undefined ? {} : { name: stage.name }),
-          mode: stage.mode,
-          tasks: taskReports,
-        });
+        const allReports = stageReports.flatMap((stage) => stage.tasks);
+        const total = allReports.length;
+        const succeeded = allReports.filter(
+          (report) => !isSpawnFailure(report.result) && !report.result.failed,
+        ).length;
+        const hasWorktrees = allReports.some(
+          (report) => report.worktree !== undefined,
+        );
+
+        const stageDigest = renderStageDigest(
+          stageReports,
+          taskOutputBudget(total),
+        );
+        const worktreeNote = hasWorktrees
+          ? "\n\nWorktrees are left in place for review; never merged automatically. Removal requires the user-approved worktree_remove tool."
+          : "";
+        const summary = `Workflow completed: ${succeeded}/${total} tasks succeeded across ${stageReports.length} stage(s).`;
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: capText(`${summary}\n\n${stageDigest}${worktreeNote}`),
+            },
+          ],
+          details: {
+            stages: stageReports,
+            succeeded,
+            total,
+          } satisfies WorkflowDetails,
+        };
+      } finally {
+        if (invocationId !== undefined && childRuns !== undefined) {
+          const aborted = isAborted(signal);
+          childRuns.registry.terminalizeInvocation(
+            invocationId,
+            {
+              status: aborted ? "aborted" : "skipped",
+              reason: aborted ? "parent-abort" : "dependency-failed",
+            },
+            {
+              status: aborted ? "aborted" : "failed",
+              reason: aborted ? "parent-abort" : "setup-error",
+            },
+          );
+          emitUpdate?.(lastUpdateText);
+        }
       }
-
-      if (isAborted(signal)) throw new Error("Workflow was aborted");
-
-      const allReports = stageReports.flatMap((stage) => stage.tasks);
-      const total = allReports.length;
-      const succeeded = allReports.filter(
-        (report) => !isSpawnFailure(report.result) && !report.result.failed,
-      ).length;
-      const hasWorktrees = allReports.some(
-        (report) => report.worktree !== undefined,
-      );
-
-      const stageDigest = renderStageDigest(
-        stageReports,
-        taskOutputBudget(total),
-      );
-      const worktreeNote = hasWorktrees
-        ? "\n\nWorktrees are left in place for review; never merged automatically. Removal requires the user-approved worktree_remove tool."
-        : "";
-      const summary = `Workflow completed: ${succeeded}/${total} tasks succeeded across ${stageReports.length} stage(s).`;
-
-      return {
-        content: [
-          {
-            type: "text",
-            text: capText(`${summary}\n\n${stageDigest}${worktreeNote}`),
-          },
-        ],
-        details: {
-          stages: stageReports,
-          succeeded,
-          total,
-        } satisfies WorkflowDetails,
-      };
     },
-  });
+    renderResult: renderChildRunsResult,
+  };
+  pi.registerTool(tool);
 };
 
 export default setupWorkflow;

--- a/pi/extensions/pi-harness/index.ts
+++ b/pi/extensions/pi-harness/index.ts
@@ -20,6 +20,7 @@ import setupStatusline from "./features/statusline/index";
 import setupProviderLog from "./features/provider-log/index";
 import setupAsukuNotify from "./features/asuku-notify/index";
 import setupAskUserQuestion from "./features/ask-user-question/index";
+import setupChildRuns from "./features/child-runs/index";
 
 // The parameter is typed against the narrowed PiLike seam instead of pi's
 // ExtensionAPI: pi invokes this default export at runtime (jiti, no type
@@ -30,8 +31,12 @@ const setupHarness = (pi: PiLike, config: HarnessConfig): void => {
   setupPermissionPolicy(pi, config);
 
   if (config.features["hook-bridge"]) setupHookBridge(pi, config);
-  if (config.features.subagent) setupSubagent(pi, config);
-  if (config.features.workflow) setupWorkflow(pi, config);
+  const childRuns =
+    config.features.subagent || config.features.workflow
+      ? setupChildRuns(pi)
+      : undefined;
+  if (config.features.subagent) setupSubagent(pi, config, { childRuns });
+  if (config.features.workflow) setupWorkflow(pi, config, { childRuns });
   if (config.features["bit-task"]) setupBitTask(pi, config);
   if (config.features.statusline) setupStatusline(pi, config);
   if (config.features["provider-log"]) setupProviderLog(pi, config);

--- a/pi/extensions/pi-harness/lib/terminal-text.ts
+++ b/pi/extensions/pi-harness/lib/terminal-text.ts
@@ -1,0 +1,181 @@
+const consumeCsi = (value: string, start: number): number => {
+  for (let index = start; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 64 && code <= 126) return index + 1;
+  }
+  return value.length;
+};
+
+const consumeControlString = (value: string, start: number): number => {
+  for (let index = start; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code === 7 || code === 156) return index + 1;
+    if (
+      value[index] === "\u001b" &&
+      index + 1 < value.length &&
+      value[index + 1] === "\\"
+    ) {
+      return index + 2;
+    }
+  }
+  return value.length;
+};
+
+/** Remove terminal control sequences before model-produced text reaches TUI. */
+export const stripTerminalControls = (
+  value: string,
+  lineFeedReplacement: string = "\n",
+): string => {
+  let output = "";
+  let index = 0;
+  while (index < value.length) {
+    const code = value.charCodeAt(index);
+    if (value[index] === "\u001b") {
+      const next = value[index + 1];
+      if (next === "[") index = consumeCsi(value, index + 2);
+      else if (
+        next === "]" ||
+        next === "P" ||
+        next === "X" ||
+        next === "^" ||
+        next === "_"
+      ) {
+        index = consumeControlString(value, index + 2);
+      } else index += index + 1 < value.length ? 2 : 1;
+      continue;
+    }
+    if (code === 155) {
+      index = consumeCsi(value, index + 1);
+      continue;
+    }
+    if (
+      code === 157 ||
+      code === 144 ||
+      code === 152 ||
+      code === 158 ||
+      code === 159
+    ) {
+      index = consumeControlString(value, index + 1);
+      continue;
+    }
+    if (value[index] === "\n") {
+      output += lineFeedReplacement;
+      index += 1;
+      continue;
+    }
+    if (value[index] === "\t") {
+      output += "  ";
+      index += 1;
+      continue;
+    }
+    if (code <= 31 || (code >= 127 && code <= 159)) {
+      index += 1;
+      continue;
+    }
+    output += value[index];
+    index += 1;
+  }
+  return output;
+};
+
+const TRUNCATION_SUFFIX = "…";
+
+/** Prefix-cap a string by UTF-8 bytes without splitting a surrogate pair. */
+export const capUtf8 = (value: string, maxBytes: number): string => {
+  if (maxBytes <= 0) return "";
+  if (Buffer.byteLength(value, "utf8") <= maxBytes) return value;
+  const suffixBytes = Buffer.byteLength(TRUNCATION_SUFFIX, "utf8");
+  const contentBytes = Math.max(0, maxBytes - suffixBytes);
+  let low = 0;
+  let high = value.length;
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    if (Buffer.byteLength(value.slice(0, middle), "utf8") <= contentBytes) {
+      low = middle;
+    } else high = middle - 1;
+  }
+  let end = low;
+  const last = value.charCodeAt(end - 1);
+  if (last >= 0xd800 && last <= 0xdbff) end -= 1;
+  return `${value.slice(0, end)}${TRUNCATION_SUFFIX}`;
+};
+
+const isZeroWidth = (code: number): boolean =>
+  (code >= 0x300 && code <= 0x36f) ||
+  (code >= 0x1ab0 && code <= 0x1aff) ||
+  (code >= 0x1dc0 && code <= 0x1dff) ||
+  (code >= 0x20d0 && code <= 0x20ff) ||
+  (code >= 0xfe00 && code <= 0xfe0f) ||
+  (code >= 0xfe20 && code <= 0xfe2f) ||
+  code === 0x200d;
+
+const isWide = (code: number): boolean =>
+  code >= 0x1100 &&
+  (code <= 0x115f ||
+    code === 0x2329 ||
+    code === 0x232a ||
+    (code >= 0x2e80 && code <= 0xa4cf && code !== 0x303f) ||
+    (code >= 0xac00 && code <= 0xd7a3) ||
+    (code >= 0xf900 && code <= 0xfaff) ||
+    (code >= 0xfe10 && code <= 0xfe19) ||
+    (code >= 0xfe30 && code <= 0xfe6f) ||
+    (code >= 0xff00 && code <= 0xff60) ||
+    (code >= 0xffe0 && code <= 0xffe6) ||
+    (code >= 0x1f000 && code <= 0x1faff) ||
+    (code >= 0x20000 && code <= 0x3fffd));
+
+const runeWidth = (rune: string): number => {
+  const code = rune.codePointAt(0) ?? 0;
+  if (isZeroWidth(code)) return 0;
+  return isWide(code) ? 2 : 1;
+};
+
+export const visibleWidth = (value: string): number =>
+  Array.from(value).reduce((width, rune) => width + runeWidth(rune), 0);
+
+export const truncateToWidth = (
+  value: string,
+  width: number,
+  suffix: string = "…",
+): string => {
+  if (width <= 0) return "";
+  if (visibleWidth(value) <= width) return value;
+  const suffixWidth = visibleWidth(suffix);
+  const available = Math.max(0, width - suffixWidth);
+  let output = "";
+  let used = 0;
+  for (const rune of value) {
+    const next = runeWidth(rune);
+    if (used + next > available) break;
+    output += rune;
+    used += next;
+  }
+  return `${output}${suffixWidth <= width ? suffix : ""}`;
+};
+
+/** Wrap already-sanitized plain text. Every returned line fits width. */
+export const wrapPlainText = (value: string, width: number): string[] => {
+  if (width <= 0) return [""];
+  const lines: string[] = [];
+  for (const sourceLine of value.split("\n")) {
+    if (sourceLine === "") {
+      lines.push("");
+      continue;
+    }
+    let current = "";
+    let used = 0;
+    for (const rune of sourceLine) {
+      const next = runeWidth(rune);
+      if (used > 0 && used + next > width) {
+        lines.push(current);
+        current = "";
+        used = 0;
+      }
+      if (next > width) continue;
+      current += rune;
+      used += next;
+    }
+    lines.push(current);
+  }
+  return lines.length === 0 ? [""] : lines;
+};

--- a/pi/extensions/pi-harness/lib/terminal-text.ts
+++ b/pi/extensions/pi-harness/lib/terminal-text.ts
@@ -85,7 +85,8 @@ export const capUtf8 = (value: string, maxBytes: number): string => {
   if (maxBytes <= 0) return "";
   if (Buffer.byteLength(value, "utf8") <= maxBytes) return value;
   const suffixBytes = Buffer.byteLength(TRUNCATION_SUFFIX, "utf8");
-  const contentBytes = Math.max(0, maxBytes - suffixBytes);
+  const includeSuffix = suffixBytes <= maxBytes;
+  const contentBytes = maxBytes - (includeSuffix ? suffixBytes : 0);
   let low = 0;
   let high = value.length;
   while (low < high) {
@@ -97,7 +98,7 @@ export const capUtf8 = (value: string, maxBytes: number): string => {
   let end = low;
   const last = value.charCodeAt(end - 1);
   if (last >= 0xd800 && last <= 0xdbff) end -= 1;
-  return `${value.slice(0, end)}${TRUNCATION_SUFFIX}`;
+  return `${value.slice(0, end)}${includeSuffix ? TRUNCATION_SUFFIX : ""}`;
 };
 
 const isZeroWidth = (code: number): boolean =>

--- a/tests/pi-harness/child-run-integration.test.ts
+++ b/tests/pi-harness/child-run-integration.test.ts
@@ -1,0 +1,504 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import type { HarnessConfig } from "../../pi/extensions/pi-harness/config";
+import setupChildRuns from "../../pi/extensions/pi-harness/features/child-runs/index";
+import setupSubagent from "../../pi/extensions/pi-harness/features/subagent/index";
+import type {
+  SpawnFunction,
+  SpawnedProcess,
+} from "../../pi/extensions/pi-harness/features/subagent/spawn";
+import type {
+  CtxLike,
+  PiLike,
+  ToolDefLike,
+} from "../../pi/extensions/pi-harness/lib/pi-like";
+import { resolvePaths } from "../../pi/extensions/pi-harness/lib/paths";
+import { cleanupTestDirectory, setupTestDirectory } from "../test-helpers";
+
+const tempDirectories: string[] = [];
+afterEach(async () => {
+  await Promise.all(tempDirectories.splice(0).map(cleanupTestDirectory));
+});
+
+const makeConfig = (home: string): HarnessConfig => ({
+  isChild: false,
+  features: {
+    "hook-bridge": false,
+    subagent: true,
+    workflow: false,
+    "bit-task": false,
+    statusline: false,
+    "provider-log": false,
+    "asuku-notify": false,
+    "ask-user-question": false,
+  },
+  trust: { trustedRoots: [] },
+  paths: resolvePaths(home),
+});
+
+interface OverlayHandleFake {
+  hidden: boolean;
+  focused: boolean;
+  hide(): void;
+  setHidden(value: boolean): void;
+  isHidden(): boolean;
+  focus(): void;
+  unfocus(): void;
+  isFocused(): boolean;
+}
+
+const createOverlayHandle = (): OverlayHandleFake => ({
+  hidden: false,
+  focused: false,
+  hide() {
+    this.hidden = true;
+  },
+  setHidden(value) {
+    this.hidden = value;
+  },
+  isHidden() {
+    return this.hidden;
+  },
+  focus() {
+    this.focused = true;
+  },
+  unfocus() {
+    this.focused = false;
+  },
+  isFocused() {
+    return this.focused;
+  },
+});
+
+const createRuntime = (cwd: string) => {
+  const tools: ToolDefLike[] = [];
+  const handlers = new Map<
+    string,
+    ((event: unknown, ctx: RuntimeContext) => unknown)[]
+  >();
+  const commands = new Map<
+    string,
+    { handler: (args: string, ctx: RuntimeContext) => Promise<void> }
+  >();
+  const shortcuts = new Map<
+    string,
+    { handler: (ctx: RuntimeContext) => Promise<void> | void }
+  >();
+  const overlayHandle = createOverlayHandle();
+  let customCalls = 0;
+  let component:
+    | { render(width: number): string[]; handleInput?(data: string): void }
+    | undefined;
+  let overlayOptions: Record<string, unknown> | undefined;
+  let branch: unknown[] = [];
+
+  const ctx = {
+    cwd,
+    mode: "tui",
+    hasUI: true,
+    sessionManager: { getBranch: () => branch },
+    ui: {
+      select: async () => undefined,
+      confirm: async () => false,
+      input: async () => undefined,
+      notify: () => {},
+      custom(factory: Function, options: Record<string, unknown>) {
+        customCalls += 1;
+        component = Reflect.apply(factory, undefined, [
+          { terminal: { rows: 40 }, requestRender: () => {} },
+          {},
+          {
+            matches: (data: string, key: string) =>
+              (key === "tui.select.confirm" && data === "\r") ||
+              (key === "tui.select.cancel" && data === "\u001b") ||
+              (key === "tui.select.up" && data === "up") ||
+              (key === "tui.select.down" && data === "down"),
+          },
+          () => {},
+        ]);
+        const rawOverlayOptions = options.overlayOptions;
+        overlayOptions =
+          typeof rawOverlayOptions === "function"
+            ? Reflect.apply(rawOverlayOptions, undefined, [])
+            : (rawOverlayOptions as Record<string, unknown>);
+        Reflect.apply(options.onHandle as Function, undefined, [overlayHandle]);
+        return new Promise<void>(() => {});
+      },
+    },
+  } as unknown as RuntimeContext;
+
+  const pi = {
+    on(
+      event: string,
+      handler: (event: unknown, eventCtx: RuntimeContext) => unknown,
+    ) {
+      const list = handlers.get(event) ?? [];
+      list.push(handler);
+      handlers.set(event, list);
+    },
+    registerTool(tool: ToolDefLike) {
+      tools.push(tool);
+    },
+    registerCommand(
+      name: string,
+      options: typeof commands extends Map<string, infer V> ? V : never,
+    ) {
+      commands.set(name, options);
+    },
+    registerShortcut(
+      key: string,
+      options: typeof shortcuts extends Map<string, infer V> ? V : never,
+    ) {
+      shortcuts.set(key, options);
+    },
+  } as unknown as PiLike;
+
+  return {
+    pi,
+    ctx,
+    tools,
+    commands,
+    shortcuts,
+    overlayHandle,
+    getCustomCalls: () => customCalls,
+    getComponent: () => component,
+    getOverlayOptions: () => overlayOptions,
+    setBranch(entries: unknown[]) {
+      branch = entries;
+    },
+    async emit(event: string, payload: unknown) {
+      let patch: unknown;
+      for (const handler of handlers.get(event) ?? []) {
+        const next = await handler(payload, ctx);
+        if (next !== undefined) patch = next;
+      }
+      return patch;
+    },
+  };
+};
+
+type RuntimeContext = CtxLike & {
+  mode: string;
+  sessionManager: { getBranch(): unknown[] };
+};
+
+const scriptedSpawn =
+  (text: string, stopReason: string = "stop"): SpawnFunction =>
+  (_command, _args, _options) => {
+    const stdout: ((chunk: string | Uint8Array) => void)[] = [];
+    const stderr: ((chunk: string | Uint8Array) => void)[] = [];
+    const close: ((
+      code: number | null,
+      signal: NodeJS.Signals | null,
+    ) => void)[] = [];
+    const error: ((error: Error) => void)[] = [];
+    const proc: SpawnedProcess = {
+      stdout: {
+        on(_event, listener) {
+          stdout.push(listener);
+          return this;
+        },
+      },
+      stderr: {
+        on(_event, listener) {
+          stderr.push(listener);
+          return this;
+        },
+      },
+      on(event, listener) {
+        if (event === "close") close.push(listener as never);
+        else error.push(listener as never);
+        return this;
+      },
+      kill: () => true,
+      killed: false,
+    };
+    queueMicrotask(() => {
+      const privateEvents = [
+        {
+          type: "tool_execution_start",
+          toolCallId: "SECRET_RAW_TOOL_ID",
+          toolName: "read",
+          args: { path: "SECRET_ARGUMENT" },
+        },
+        {
+          type: "tool_execution_end",
+          toolCallId: "SECRET_RAW_TOOL_ID",
+          toolName: "read",
+          result: { content: [{ type: "text", text: "SECRET_RESULT" }] },
+          isError: false,
+        },
+        {
+          type: "message_end",
+          message: {
+            role: "assistant",
+            model: "test-model",
+            stopReason,
+            content: [
+              { type: "thinking", thinking: "SECRET_THINKING" },
+              { type: "text", text },
+            ],
+          },
+        },
+      ];
+      const bytes = Buffer.from(
+        `${privateEvents.map((event) => JSON.stringify(event)).join("\n")}\n`,
+        "utf8",
+      );
+      // Deliberately split in the middle of a multibyte rune.
+      const split = Math.max(1, bytes.indexOf(Buffer.from("界")) + 1);
+      for (const listener of stdout) {
+        listener(bytes.subarray(0, split));
+        listener(bytes.subarray(split));
+      }
+      for (const listener of close) listener(0, null);
+    });
+    return proc;
+  };
+
+const writeAgent = async (home: string): Promise<void> => {
+  const dir = resolvePaths(home).claudeAgentsDir;
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(
+    join(dir, "worker.md"),
+    ["---", "name: worker", "description: worker", "---", "Work safely."].join(
+      "\n",
+    ),
+  );
+};
+
+describe("child-run subagent integration", () => {
+  test("mounts one non-capturing overlay, streams summaries, and persists a safe transcript", async () => {
+    const home = await setupTestDirectory("pi-child-integration");
+    tempDirectories.push(home);
+    await writeAgent(home);
+    const runtime = createRuntime(home);
+    const childRuns = setupChildRuns(runtime.pi);
+    setupSubagent(runtime.pi, makeConfig(home), {
+      childRuns,
+      spawnFn: scriptedSpawn("hello 界"),
+    });
+    const tool = runtime.tools.find((item) => item.name === "subagent")!;
+    const updates: unknown[] = [];
+    const result = await Reflect.apply(tool.execute, undefined, [
+      "parent-call",
+      { agent: "worker", task: "inspect" },
+      undefined,
+      (update: unknown) => updates.push(update),
+      runtime.ctx,
+    ]);
+
+    expect(runtime.getCustomCalls()).toBe(1);
+    expect(runtime.getOverlayOptions()?.nonCapturing).toBe(true);
+    expect(runtime.overlayHandle.focused).toBe(false);
+    expect(JSON.stringify(updates)).toContain('"kind":"summary"');
+    expect(
+      JSON.stringify(
+        updates.map((update) => (update as { details?: unknown }).details),
+      ),
+    ).not.toContain("hello 界");
+
+    const patch = (await runtime.emit("tool_result", {
+      type: "tool_result",
+      toolName: "subagent",
+      toolCallId: "parent-call",
+      details: (result as { details: unknown }).details,
+      isError: false,
+    })) as { details: Record<string, unknown> };
+    const serialized = JSON.stringify(patch.details.childRuns);
+    expect(serialized).toContain("hello 界");
+    expect(serialized).toContain('"name":"read"');
+    for (const secret of [
+      "SECRET_RAW_TOOL_ID",
+      "SECRET_ARGUMENT",
+      "SECRET_RESULT",
+      "SECRET_THINKING",
+    ]) {
+      expect(serialized).not.toContain(secret);
+    }
+    expect(patch.details.mode).toBe("single");
+    const renderer = (
+      tool as ToolDefLike & {
+        renderResult: (
+          result: unknown,
+          options: { expanded: boolean },
+        ) => { render(width: number): string[] };
+      }
+    ).renderResult;
+    const rendered = renderer(
+      {
+        content: [
+          { type: "text", text: "worktree: /tmp/review-tree — left in place" },
+        ],
+        details: patch.details,
+      },
+      { expanded: true },
+    ).render(36);
+    expect(rendered.join("\n")).toContain("/subagents");
+    expect(rendered.join("\n")).toContain("/tmp/review-tree");
+    expect(rendered.every((line) => line.length <= 36)).toBe(true);
+  });
+
+  test("attaches failed child details without changing thrown semantics", async () => {
+    const home = await setupTestDirectory("pi-child-failure");
+    tempDirectories.push(home);
+    await writeAgent(home);
+    const runtime = createRuntime(home);
+    const childRuns = setupChildRuns(runtime.pi);
+    setupSubagent(runtime.pi, makeConfig(home), {
+      childRuns,
+      spawnFn: scriptedSpawn("provider failed", "error"),
+    });
+    const tool = runtime.tools.find((item) => item.name === "subagent")!;
+
+    await expect(
+      Reflect.apply(tool.execute, undefined, [
+        "parent-call",
+        { agent: "worker", task: "inspect" },
+        undefined,
+        undefined,
+        runtime.ctx,
+      ]),
+    ).rejects.toThrow("stopReason error");
+
+    const patch = (await runtime.emit("tool_result", {
+      type: "tool_result",
+      toolName: "subagent",
+      toolCallId: "parent-call",
+      details: {},
+      isError: true,
+    })) as { details: { childRuns: { runs: { status: string }[] } } };
+    expect(patch.details.childRuns.runs[0]?.status).toBe("failed");
+  });
+
+  test("distinguishes a child-reported aborted stop from a generic failure", async () => {
+    const home = await setupTestDirectory("pi-child-model-aborted");
+    tempDirectories.push(home);
+    await writeAgent(home);
+    const runtime = createRuntime(home);
+    const childRuns = setupChildRuns(runtime.pi);
+    setupSubagent(runtime.pi, makeConfig(home), {
+      childRuns,
+      spawnFn: scriptedSpawn("child aborted", "aborted"),
+    });
+    const tool = runtime.tools.find((item) => item.name === "subagent")!;
+    await expect(
+      Reflect.apply(tool.execute, undefined, [
+        "parent-call",
+        { agent: "worker", task: "inspect" },
+        undefined,
+        undefined,
+        runtime.ctx,
+      ]),
+    ).rejects.toThrow("stopReason aborted");
+    expect(
+      childRuns.registry
+        .getSnapshots()[0]
+        ?.runs.map((run) => [run.status, run.terminalReason]),
+    ).toEqual([["aborted", "model-aborted"]]);
+  });
+
+  test("marks the unlaunched remainder of a failed chain as skipped", async () => {
+    const home = await setupTestDirectory("pi-child-chain-failure");
+    tempDirectories.push(home);
+    await writeAgent(home);
+    const runtime = createRuntime(home);
+    const childRuns = setupChildRuns(runtime.pi);
+    setupSubagent(runtime.pi, makeConfig(home), {
+      childRuns,
+      spawnFn: scriptedSpawn("first failed", "error"),
+    });
+    const tool = runtime.tools.find((item) => item.name === "subagent")!;
+
+    await expect(
+      Reflect.apply(tool.execute, undefined, [
+        "parent-call",
+        {
+          chain: [
+            { agent: "worker", task: "first" },
+            { agent: "worker", task: "second {previous}" },
+          ],
+        },
+        undefined,
+        undefined,
+        runtime.ctx,
+      ]),
+    ).rejects.toThrow("stopReason error");
+
+    expect(
+      childRuns.registry
+        .getSnapshots()[0]
+        ?.runs.map((run) => [run.status, run.terminalReason]),
+    ).toEqual([
+      ["failed", "model-error"],
+      ["skipped", "dependency-failed"],
+    ]);
+  });
+
+  test("replaces browser history from the active session branch", async () => {
+    const home = await setupTestDirectory("pi-child-replay");
+    tempDirectories.push(home);
+    const runtime = createRuntime(home);
+    const childRuns = setupChildRuns(runtime.pi);
+    runtime.setBranch([
+      {
+        type: "message",
+        message: {
+          role: "toolResult",
+          details: {
+            childRuns: {
+              schema: "pi-harness/child-runs",
+              version: 1,
+              kind: "transcript",
+              invocationId: "persisted-invocation",
+              source: "subagent",
+              mode: "single",
+              label: "persisted",
+              createdAt: 1,
+              runs: [
+                {
+                  runId: "persisted-run",
+                  agent: "worker",
+                  task: "old task",
+                  taskIndex: 0,
+                  status: "succeeded",
+                  terminalReason: "completed",
+                  transcript: [{ type: "assistant", text: "old answer" }],
+                },
+              ],
+            },
+          },
+        },
+      },
+    ]);
+    await runtime.emit("session_start", { type: "session_start" });
+    expect(childRuns.registry.getSnapshots()[0]?.invocationId).toBe(
+      "persisted-invocation",
+    );
+
+    runtime.setBranch([]);
+    await runtime.emit("session_tree", { type: "session_tree" });
+    expect(childRuns.registry.getSnapshots()).toEqual([]);
+  });
+
+  test("/subagents focuses the resident overlay and Escape only unfocuses", async () => {
+    const home = await setupTestDirectory("pi-child-command");
+    tempDirectories.push(home);
+    const runtime = createRuntime(home);
+    setupChildRuns(runtime.pi);
+
+    await runtime.commands.get("subagents")!.handler("", runtime.ctx);
+    const visible = runtime.getOverlayOptions()?.visible as
+      | ((width: number, height: number) => boolean)
+      | undefined;
+    expect(visible?.(80, 30)).toBe(true);
+    expect(runtime.overlayHandle.focused).toBe(true);
+    runtime.getComponent()?.handleInput?.("\u001b");
+    expect(runtime.overlayHandle.focused).toBe(false);
+    expect(runtime.overlayHandle.hidden).toBe(false);
+    runtime.getComponent()?.handleInput?.("q");
+    expect(runtime.overlayHandle.hidden).toBe(true);
+    expect(visible?.(80, 30)).toBe(false);
+  });
+});

--- a/tests/pi-harness/child-run-persistence.test.ts
+++ b/tests/pi-harness/child-run-persistence.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CHILD_RUNS_SCHEMA,
+  CHILD_RUNS_VERSION,
+  MAX_RUN_TRANSCRIPT_BYTES,
+  type PersistedChildRunsV1,
+} from "../../pi/extensions/pi-harness/features/child-runs/model";
+import {
+  attachChildRunsDetails,
+  decodePersistedChildRuns,
+  extractPersistedChildRuns,
+} from "../../pi/extensions/pi-harness/features/child-runs/persistence";
+
+const payload = (
+  overrides: Partial<PersistedChildRunsV1> = {},
+): PersistedChildRunsV1 => ({
+  schema: CHILD_RUNS_SCHEMA,
+  version: CHILD_RUNS_VERSION,
+  kind: "transcript",
+  invocationId: "invocation-1",
+  source: "workflow",
+  label: "workflow",
+  createdAt: 100,
+  runs: [
+    {
+      runId: "run-1",
+      agent: "reviewer",
+      task: "review task",
+      taskIndex: 0,
+      stageIndex: 0,
+      stageName: "review",
+      status: "succeeded",
+      terminalReason: "completed",
+      startedAt: 101,
+      endedAt: 102,
+      transcript: [
+        { type: "assistant", text: "safe answer" },
+        { type: "tool", localId: 1, name: "read", status: "succeeded" },
+      ],
+    },
+  ],
+  ...overrides,
+});
+
+describe("child-run persisted details", () => {
+  test("preserves existing tool details under a namespaced childRuns key", () => {
+    const childRuns = payload();
+    expect(attachChildRunsDetails({ stages: ["legacy"] }, childRuns)).toEqual({
+      stages: ["legacy"],
+      childRuns,
+    });
+  });
+
+  test("decodes an allowlisted payload and strips terminal controls", () => {
+    const hostile = payload();
+    hostile.label = "work\u001b]2;spoof\u0007flow";
+    hostile.runs[0]!.transcript[0] = {
+      type: "assistant",
+      text: "safe\u001b[31m answer\u001b[0m",
+    };
+    const decoded = decodePersistedChildRuns(hostile)!;
+    expect(decoded.label).toBe("workflow");
+    expect(decoded.runs[0]?.transcript[0]).toEqual({
+      type: "assistant",
+      text: "safe answer",
+    });
+  });
+
+  test("rejects future, malformed, nonterminal, and oversized data", () => {
+    expect(
+      decodePersistedChildRuns({ ...payload(), version: 999 }),
+    ).toBeUndefined();
+    expect(
+      decodePersistedChildRuns({ ...payload(), source: "unknown" }),
+    ).toBeUndefined();
+    const running = payload();
+    (running.runs[0] as unknown as { status: string }).status = "running";
+    expect(decodePersistedChildRuns(running)).toBeUndefined();
+    const oversized = payload({ label: "x".repeat(600 * 1024) });
+    // Label is safely capped, so the decoded form remains bounded.
+    expect(
+      Buffer.byteLength(
+        JSON.stringify(decodePersistedChildRuns(oversized)),
+        "utf8",
+      ),
+    ).toBeLessThan(600 * 1024);
+  });
+
+  test("re-caps a hostile replay payload to the per-run byte limit", () => {
+    const hostile = payload();
+    hostile.runs[0]!.transcript = Array.from({ length: 20 }, (_, index) => ({
+      type: "assistant" as const,
+      text: `${index}:${"x".repeat(10_000)}`,
+    }));
+    const decoded = decodePersistedChildRuns(hostile)!;
+    expect(
+      Buffer.byteLength(JSON.stringify(decoded.runs[0]), "utf8"),
+    ).toBeLessThanOrEqual(MAX_RUN_TRANSCRIPT_BYTES);
+    expect(
+      decoded.runs[0]?.transcript.some((item) => item.type === "truncated"),
+    ).toBe(true);
+  });
+
+  test("extracts only active-branch tool-result payloads and deduplicates ids", () => {
+    const older = payload();
+    const newer = payload({ label: "newer" });
+    const branch = [
+      {
+        type: "message",
+        message: { role: "assistant", details: { childRuns: payload() } },
+      },
+      {
+        type: "message",
+        message: { role: "toolResult", details: { childRuns: older } },
+      },
+      { type: "custom", data: { childRuns: payload() } },
+      {
+        type: "message",
+        message: { role: "toolResult", details: { childRuns: newer } },
+      },
+    ];
+    expect(extractPersistedChildRuns(branch)).toEqual([newer]);
+  });
+
+  test("never admits unallowlisted privacy sentinels", () => {
+    const raw = payload() as unknown as Record<string, unknown>;
+    raw.stderr = "SECRET_STDERR";
+    raw.cwd = "/SECRET_CWD";
+    raw.provider = "SECRET_PROVIDER";
+    const run = (raw.runs as Record<string, unknown>[])[0]!;
+    run.liveDraft = "SECRET_DRAFT";
+    run.arguments = { command: "SECRET_ARGUMENT" };
+    run.result = "SECRET_RESULT";
+    run.thinking = "SECRET_THINKING";
+    run.rawToolCallId = "SECRET_TOOL_ID";
+    const decoded = decodePersistedChildRuns(raw)!;
+    const serialized = JSON.stringify(decoded);
+    for (const secret of [
+      "SECRET_STDERR",
+      "SECRET_CWD",
+      "SECRET_PROVIDER",
+      "SECRET_DRAFT",
+      "SECRET_ARGUMENT",
+      "SECRET_RESULT",
+      "SECRET_THINKING",
+      "SECRET_TOOL_ID",
+    ]) {
+      expect(serialized).not.toContain(secret);
+    }
+  });
+});

--- a/tests/pi-harness/child-run-persistence.test.ts
+++ b/tests/pi-harness/child-run-persistence.test.ts
@@ -3,6 +3,7 @@ import {
   CHILD_RUNS_SCHEMA,
   CHILD_RUNS_VERSION,
   MAX_RUN_TRANSCRIPT_BYTES,
+  MAX_RUN_TRANSCRIPT_ITEMS,
   type PersistedChildRunsV1,
 } from "../../pi/extensions/pi-harness/features/child-runs/model";
 import {
@@ -99,6 +100,24 @@ describe("child-run persisted details", () => {
     expect(
       decoded.runs[0]?.transcript.some((item) => item.type === "truncated"),
     ).toBe(true);
+  });
+
+  test("keeps replay transcripts within the item cap including truncation", () => {
+    const hostile = payload();
+    hostile.runs[0]!.transcript = Array.from(
+      { length: MAX_RUN_TRANSCRIPT_ITEMS + 1 },
+      (_, index) => ({
+        type: "assistant" as const,
+        text: `answer-${index}`,
+      }),
+    );
+
+    const transcript = decodePersistedChildRuns(hostile)!.runs[0]!.transcript;
+    expect(transcript).toHaveLength(MAX_RUN_TRANSCRIPT_ITEMS);
+    expect(transcript.at(-1)).toMatchObject({
+      type: "truncated",
+      omittedItems: 2,
+    });
   });
 
   test("extracts only active-branch tool-result payloads and deduplicates ids", () => {

--- a/tests/pi-harness/child-run-persistence.test.ts
+++ b/tests/pi-harness/child-run-persistence.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 import {
   CHILD_RUNS_SCHEMA,
   CHILD_RUNS_VERSION,
+  MAX_REPLAY_BYTES,
+  MAX_REPLAY_INVOCATIONS,
   MAX_RUN_TRANSCRIPT_BYTES,
   MAX_RUN_TRANSCRIPT_ITEMS,
   type PersistedChildRunsV1,
@@ -11,6 +13,14 @@ import {
   decodePersistedChildRuns,
   extractPersistedChildRuns,
 } from "../../pi/extensions/pi-harness/features/child-runs/persistence";
+
+const serializedBytes = (value: unknown): number =>
+  Buffer.byteLength(JSON.stringify(value), "utf8");
+
+const toolResult = (childRuns: PersistedChildRunsV1) => ({
+  type: "message",
+  message: { role: "toolResult", details: { childRuns } },
+});
 
 const payload = (
   overrides: Partial<PersistedChildRunsV1> = {},
@@ -42,6 +52,20 @@ const payload = (
   ],
   ...overrides,
 });
+
+const largePayload = (invocationId: string): PersistedChildRunsV1 =>
+  payload({
+    invocationId,
+    runs: Array.from({ length: 32 }, (_, index) => ({
+      runId: `${invocationId}-run-${index}`,
+      agent: "reviewer",
+      task: "review task",
+      taskIndex: index,
+      status: "succeeded" as const,
+      terminalReason: "completed" as const,
+      transcript: [{ type: "assistant" as const, text: "x".repeat(14_000) }],
+    })),
+  });
 
 describe("child-run persisted details", () => {
   test("preserves existing tool details under a namespaced childRuns key", () => {
@@ -139,6 +163,31 @@ describe("child-run persisted details", () => {
       },
     ];
     expect(extractPersistedChildRuns(branch)).toEqual([newer]);
+  });
+
+  test("retains a contiguous newest suffix at the replay byte boundary", () => {
+    const newest = Array.from({ length: 4 }, (_, index) =>
+      largePayload(`newest-${index}`),
+    );
+    const largeBytes = newest.map((item) =>
+      serializedBytes(decodePersistedChildRuns(item)),
+    );
+    expect(
+      largeBytes.reduce((total, bytes) => total + bytes, 0),
+    ).toBeLessThanOrEqual(MAX_REPLAY_BYTES);
+    expect(
+      largeBytes.reduce((total, bytes) => total + bytes, 0) + largeBytes[0]!,
+    ).toBeGreaterThan(MAX_REPLAY_BYTES);
+    expect(newest.length + 2).toBeLessThan(MAX_REPLAY_INVOCATIONS);
+
+    const oldestSmall = payload({ invocationId: "oldest-small" });
+    const blocker = largePayload("blocker");
+    const selected = extractPersistedChildRuns(
+      [oldestSmall, blocker, ...newest].map(toolResult),
+    );
+    expect(selected.map(({ invocationId }) => invocationId)).toEqual(
+      newest.map(({ invocationId }) => invocationId),
+    );
   });
 
   test("never admits unallowlisted privacy sentinels", () => {

--- a/tests/pi-harness/child-run-protocol.test.ts
+++ b/tests/pi-harness/child-run-protocol.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, test } from "bun:test";
+import {
+  MAX_ASSISTANT_ITEM_BYTES,
+  type ChildObservation,
+} from "../../pi/extensions/pi-harness/features/child-runs/model";
+import { createChildProtocolParser } from "../../pi/extensions/pi-harness/features/child-runs/protocol";
+import {
+  capUtf8,
+  stripTerminalControls,
+  truncateToWidth,
+  visibleWidth,
+  wrapPlainText,
+} from "../../pi/extensions/pi-harness/lib/terminal-text";
+
+describe("child JSON protocol normalization", () => {
+  test("keeps legacy first-block output while emitting sanitized full assistant text", () => {
+    const observations: ChildObservation[] = [];
+    const parser = createChildProtocolParser({
+      observe: (item) => observations.push(item),
+      now: () => 123,
+    });
+    const line = JSON.stringify({
+      type: "message_end",
+      responseId: "SECRET_RESPONSE",
+      message: {
+        role: "assistant",
+        model: "model\u001b]2;title\u0007-safe",
+        stopReason: "stop",
+        content: [
+          {
+            type: "thinking",
+            thinking: "SECRET_THINKING",
+            signature: "SECRET_SIGNATURE",
+          },
+          { type: "text", text: "first\u001b[31m red\u001b[0m" },
+          {
+            type: "toolCall",
+            id: "SECRET_TOOL_ID",
+            name: "bash",
+            arguments: { command: "SECRET_ARGUMENT" },
+          },
+          { type: "text", text: "second" },
+        ],
+      },
+    });
+
+    expect(parser.processLine(line)).toEqual({
+      text: "first\u001b[31m red\u001b[0m",
+      stopReason: "stop",
+      errorMessage: undefined,
+    });
+    expect(observations).toEqual([
+      {
+        type: "assistant_final",
+        text: "first red\nsecond",
+        at: 123,
+        model: "model-safe",
+        stopReason: "stop",
+      },
+    ]);
+    const serialized = JSON.stringify(observations);
+    for (const secret of [
+      "SECRET_RESPONSE",
+      "SECRET_THINKING",
+      "SECRET_SIGNATURE",
+      "SECRET_TOOL_ID",
+      "SECRET_ARGUMENT",
+    ]) {
+      expect(serialized).not.toContain(secret);
+    }
+  });
+
+  test("emits only text as a live draft", () => {
+    const observations: ChildObservation[] = [];
+    const parser = createChildProtocolParser({
+      observe: (item) => observations.push(item),
+    });
+
+    parser.processLine(
+      JSON.stringify({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "thinking_delta",
+          delta: "SECRET_DELTA",
+        },
+        message: {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "SECRET_THINKING" },
+            { type: "text", text: "safe draft" },
+            {
+              type: "toolCall",
+              id: "SECRET_ID",
+              arguments: { value: "SECRET_ARGS" },
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(observations).toEqual([
+      { type: "assistant_draft", text: "safe draft" },
+    ]);
+    expect(JSON.stringify(observations)).not.toContain("SECRET");
+  });
+
+  test("maps raw tool ids to stable local ordinals and drops payloads", () => {
+    const observations: ChildObservation[] = [];
+    const parser = createChildProtocolParser({
+      observe: (item) => observations.push(item),
+      now: () => 9,
+    });
+
+    parser.processLine(
+      JSON.stringify({
+        type: "tool_execution_start",
+        toolCallId: "provider-secret-id",
+        toolName: "bash\u001b[31m",
+        args: { command: "rm SECRET" },
+      }),
+    );
+    parser.processLine(
+      JSON.stringify({
+        type: "tool_execution_end",
+        toolCallId: "provider-secret-id",
+        toolName: "bash",
+        result: { content: [{ type: "text", text: "SECRET_RESULT" }] },
+        isError: true,
+      }),
+    );
+
+    expect(observations).toEqual([
+      { type: "tool_started", localId: 1, name: "bash", at: 9 },
+      {
+        type: "tool_finished",
+        localId: 1,
+        name: "bash",
+        failed: true,
+        at: 9,
+      },
+    ]);
+    expect(JSON.stringify(observations)).not.toContain("SECRET");
+    expect(JSON.stringify(observations)).not.toContain("provider-secret-id");
+  });
+
+  test("reports malformed and oversized input without echoing it", () => {
+    const observations: ChildObservation[] = [];
+    const parser = createChildProtocolParser({
+      observe: (item) => observations.push(item),
+    });
+
+    parser.processLine("SECRET malformed {");
+    parser.oversizedLine();
+
+    expect(observations).toEqual([
+      { type: "protocol_warning", code: "malformed" },
+      { type: "protocol_warning", code: "oversized" },
+    ]);
+    expect(JSON.stringify(observations)).not.toContain("SECRET");
+  });
+
+  test("contains observer failures", () => {
+    const parser = createChildProtocolParser({
+      observe: () => {
+        throw new Error("observer failed");
+      },
+    });
+    expect(() =>
+      parser.processLine(
+        JSON.stringify({
+          type: "message_end",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "ok" }],
+          },
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  test("caps finalized text by UTF-8 bytes", () => {
+    const observations: ChildObservation[] = [];
+    const parser = createChildProtocolParser({
+      observe: (item) => observations.push(item),
+    });
+    parser.processLine(
+      JSON.stringify({
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "界".repeat(10_000) }],
+        },
+      }),
+    );
+    const final = observations[0];
+    expect(final?.type).toBe("assistant_final");
+    if (final?.type === "assistant_final") {
+      expect(Buffer.byteLength(final.text, "utf8")).toBeLessThanOrEqual(
+        MAX_ASSISTANT_ITEM_BYTES,
+      );
+      expect(final.text).not.toContain("�");
+    }
+  });
+});
+
+describe("terminal-safe text helpers", () => {
+  test("strips ANSI, OSC, C0, C1 and DEL", () => {
+    expect(
+      stripTerminalControls(
+        "\u001b]2;title\u0007a\u001b[31mb\u001b[0m\u0000\u007f\u009b32mc\u009b0m",
+      ),
+    ).toBe("abc");
+  });
+
+  test("caps and wraps CJK and emoji without exceeding width", () => {
+    expect(capUtf8("😀😀😀", 8)).toBe("😀…");
+    expect(visibleWidth("a界😀")).toBe(5);
+    expect(truncateToWidth("a界😀z", 5)).toBe("a界…");
+    const wrapped = wrapPlainText("a界😀z", 3);
+    expect(wrapped).toEqual(["a界", "😀z"]);
+    expect(wrapped.every((line) => visibleWidth(line) <= 3)).toBe(true);
+  });
+});

--- a/tests/pi-harness/child-run-protocol.test.ts
+++ b/tests/pi-harness/child-run-protocol.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import {
   MAX_ASSISTANT_ITEM_BYTES,
+  MAX_RUN_TRANSCRIPT_BYTES,
+  MAX_RUN_TRANSCRIPT_ITEMS,
   type ChildObservation,
 } from "../../pi/extensions/pi-harness/features/child-runs/model";
 import { createChildProtocolParser } from "../../pi/extensions/pi-harness/features/child-runs/protocol";
@@ -143,6 +145,81 @@ describe("child JSON protocol normalization", () => {
     expect(JSON.stringify(observations)).not.toContain("provider-secret-id");
   });
 
+  test("bounds retained raw tool-id correlations by item count", () => {
+    const observations: ChildObservation[] = [];
+    const parser = createChildProtocolParser({
+      observe: (item) => observations.push(item),
+      now: () => 9,
+    });
+
+    for (let index = 0; index < MAX_RUN_TRANSCRIPT_ITEMS; index++) {
+      parser.processLine(
+        JSON.stringify({
+          type: "tool_execution_start",
+          toolCallId: `tool-${index}`,
+          toolName: "bash",
+        }),
+      );
+    }
+    parser.processLine(
+      JSON.stringify({
+        type: "tool_execution_start",
+        toolCallId: "overflow-tool",
+        toolName: "read",
+      }),
+    );
+    parser.processLine(
+      JSON.stringify({
+        type: "tool_execution_end",
+        toolCallId: "overflow-tool",
+        toolName: "read",
+      }),
+    );
+    parser.processLine(
+      JSON.stringify({
+        type: "tool_execution_end",
+        toolCallId: "tool-0",
+        toolName: "bash",
+      }),
+    );
+
+    expect(observations.at(MAX_RUN_TRANSCRIPT_ITEMS)).toMatchObject({
+      type: "tool_started",
+      localId: MAX_RUN_TRANSCRIPT_ITEMS + 1,
+    });
+    expect(observations.at(MAX_RUN_TRANSCRIPT_ITEMS + 1)).toMatchObject({
+      type: "tool_finished",
+      localId: MAX_RUN_TRANSCRIPT_ITEMS + 2,
+    });
+    expect(observations.at(MAX_RUN_TRANSCRIPT_ITEMS + 2)).toMatchObject({
+      type: "tool_finished",
+      localId: 1,
+    });
+  });
+
+  test("does not retain a raw tool id beyond the byte budget", () => {
+    const observations: ChildObservation[] = [];
+    const parser = createChildProtocolParser({
+      observe: (item) => observations.push(item),
+    });
+    const oversizedId = `shared-prefix-${"x".repeat(MAX_RUN_TRANSCRIPT_BYTES)}`;
+
+    for (const type of ["tool_execution_start", "tool_execution_end"]) {
+      parser.processLine(
+        JSON.stringify({
+          type,
+          toolCallId: oversizedId,
+          toolName: "bash",
+        }),
+      );
+    }
+
+    expect(observations).toMatchObject([
+      { type: "tool_started", localId: 1 },
+      { type: "tool_finished", localId: 2 },
+    ]);
+  });
+
   test("reports malformed and oversized input without echoing it", () => {
     const observations: ChildObservation[] = [];
     const parser = createChildProtocolParser({
@@ -210,6 +287,16 @@ describe("terminal-safe text helpers", () => {
         "\u001b]2;title\u0007a\u001b[31mb\u001b[0m\u0000\u007f\u009b32mc\u009b0m",
       ),
     ).toBe("abc");
+  });
+
+  test("keeps byte caps smaller than the truncation suffix", () => {
+    expect(capUtf8("abcdef", 1)).toBe("a");
+    expect(capUtf8("界", 2)).toBe("");
+    for (const maxBytes of [0, 1, 2]) {
+      expect(
+        Buffer.byteLength(capUtf8("abcdef", maxBytes), "utf8"),
+      ).toBeLessThanOrEqual(maxBytes);
+    }
   });
 
   test("caps and wraps CJK and emoji without exceeding width", () => {

--- a/tests/pi-harness/child-run-registry.test.ts
+++ b/tests/pi-harness/child-run-registry.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import {
+  CHILD_RUNS_SCHEMA,
+  CHILD_RUNS_VERSION,
   MAX_PERSISTED_INVOCATION_BYTES,
+  MAX_REPLAY_BYTES,
+  MAX_REPLAY_INVOCATIONS,
   MAX_RUN_TRANSCRIPT_BYTES,
   MAX_RUN_TRANSCRIPT_ITEMS,
+  type PersistedChildRunsV1,
 } from "../../pi/extensions/pi-harness/features/child-runs/model";
 import { ChildRunRegistry } from "../../pi/extensions/pi-harness/features/child-runs/registry";
 
@@ -15,18 +20,50 @@ const registry = () => {
   });
 };
 
-const begin = (store: ChildRunRegistry, count = 2) =>
+const begin = (
+  store: ChildRunRegistry,
+  count = 2,
+  toolCallId = "parent-tool-call",
+) =>
   store.beginInvocation({
-    toolCallId: "parent-tool-call",
+    toolCallId,
     source: "subagent",
     mode: "parallel",
-    label: "parallel",
+    label: toolCallId,
     runs: Array.from({ length: count }, (_, index) => ({
       agent: `agent-${index + 1}`,
       task: `task-${index + 1}`,
       taskIndex: index,
     })),
   });
+
+const persistedHistory = (
+  invocationId: string,
+  runId: string,
+): PersistedChildRunsV1 => ({
+  schema: CHILD_RUNS_SCHEMA,
+  version: CHILD_RUNS_VERSION,
+  kind: "transcript",
+  invocationId,
+  source: "subagent",
+  mode: "single",
+  label: invocationId,
+  createdAt: 1,
+  runs: [
+    {
+      runId,
+      agent: "reviewer",
+      task: "review",
+      taskIndex: 0,
+      status: "succeeded",
+      terminalReason: "completed",
+      transcript: [{ type: "assistant", text: "done" }],
+    },
+  ],
+});
+
+const serializedBytes = (value: unknown): number =>
+  Buffer.byteLength(JSON.stringify(value), "utf8");
 
 describe("child-run registry", () => {
   test("tracks stable declaration order and monotonic terminal states", () => {
@@ -215,6 +252,173 @@ describe("child-run registry", () => {
     expect(
       persistedRun.transcript.some((item) => item.type === "truncated"),
     ).toBe(true);
+  });
+
+  test("retains the newest completed histories and never prunes active work", () => {
+    const store = registry();
+    const active = begin(store, 1, "active");
+    const completed: Array<{
+      invocationId: string;
+      payload: PersistedChildRunsV1;
+    }> = [];
+
+    for (let index = 0; index < MAX_REPLAY_INVOCATIONS; index++) {
+      const toolCallId = `completed-${index}`;
+      const invocation = begin(store, 1, toolCallId);
+      store.finishRun(invocation.runIds[0]!, {
+        status: "succeeded",
+        reason: "completed",
+      });
+      completed.push({
+        invocationId: invocation.invocationId,
+        payload: store.completeToolCall(toolCallId)!,
+      });
+    }
+
+    expect(
+      store.getSnapshots().map(({ invocationId }) => invocationId),
+    ).toEqual([
+      active.invocationId,
+      ...completed.map(({ invocationId }) => invocationId),
+    ]);
+
+    store.finishRun(active.runIds[0]!, {
+      status: "succeeded",
+      reason: "completed",
+    });
+    let notifications = 0;
+    let publishedIds: string[] = [];
+    store.subscribe(() => {
+      notifications += 1;
+      publishedIds = store
+        .getSnapshots()
+        .map(({ invocationId }) => invocationId);
+    });
+    const activePayload = store.completeToolCall("active")!;
+    const expectedIds = [
+      ...completed.slice(1).map(({ invocationId }) => invocationId),
+      active.invocationId,
+    ];
+
+    expect(notifications).toBe(1);
+    expect(publishedIds).toEqual(expectedIds);
+    expect(
+      store.getSnapshots().map(({ invocationId }) => invocationId),
+    ).toEqual(expectedIds);
+
+    const replay = registry();
+    replay.replacePersistedHistory([
+      ...completed.slice(1).map(({ payload }) => payload),
+      activePayload,
+    ]);
+    expect(
+      replay.getSnapshots().map(({ invocationId }) => invocationId),
+    ).toEqual(expectedIds);
+  });
+
+  test("compacts oversized live data and enforces the completed byte cap", () => {
+    const store = registry();
+    const completed: Array<{
+      invocationId: string;
+      payload: PersistedChildRunsV1;
+      bytes: number;
+    }> = [];
+
+    for (let invocationIndex = 0; invocationIndex < 6; invocationIndex++) {
+      const toolCallId = `large-${invocationIndex}`;
+      const invocation = begin(store, 64, toolCallId);
+      for (const runId of invocation.runIds) {
+        store.observe(runId, { type: "process_started", at: 1 });
+        store.observe(runId, {
+          type: "assistant_final",
+          text: "x".repeat(6_000),
+          at: 2,
+        });
+        store.finishRun(runId, {
+          status: "succeeded",
+          reason: "completed",
+        });
+      }
+      const payload = store.completeToolCall(toolCallId)!;
+      expect(
+        payload.runs.every((run) =>
+          run.transcript.some((item) => item.type === "assistant"),
+        ),
+      ).toBe(true);
+      completed.push({
+        invocationId: invocation.invocationId,
+        payload,
+        bytes: serializedBytes(payload),
+      });
+    }
+
+    expect(completed).toHaveLength(6);
+    expect(
+      completed.reduce((total, item) => total + item.bytes, 0),
+    ).toBeGreaterThan(MAX_REPLAY_BYTES);
+    expect(completed.length).toBeLessThan(MAX_REPLAY_INVOCATIONS);
+    let retainedBytes = 0;
+    const expected: string[] = [];
+    for (const item of [...completed].reverse()) {
+      if (retainedBytes + item.bytes > MAX_REPLAY_BYTES) break;
+      expected.unshift(item.invocationId);
+      retainedBytes += item.bytes;
+    }
+    expect(
+      store.getSnapshots().map(({ invocationId }) => invocationId),
+    ).toEqual(expected);
+
+    const oversized = registry();
+    const invocation = begin(oversized, 64, "single-oversized");
+    for (const runId of invocation.runIds) {
+      oversized.observe(runId, { type: "process_started", at: 1 });
+      for (let item = 0; item < 5; item++) {
+        oversized.observe(runId, {
+          type: "assistant_final",
+          text: "界".repeat(6_000),
+          at: 2,
+        });
+      }
+      oversized.finishRun(runId, {
+        status: "succeeded",
+        reason: "completed",
+      });
+    }
+    const beforeBytes = serializedBytes(
+      oversized.getInvocation(invocation.invocationId),
+    );
+    expect(beforeBytes).toBeGreaterThan(MAX_REPLAY_BYTES);
+    const compacted = oversized.completeToolCall("single-oversized")!;
+    expect(serializedBytes(compacted)).toBeLessThanOrEqual(
+      MAX_PERSISTED_INVOCATION_BYTES,
+    );
+    expect(
+      oversized.getSnapshots().map(({ invocationId }) => invocationId),
+    ).toEqual([invocation.invocationId]);
+    expect(
+      serializedBytes(oversized.getInvocation(invocation.invocationId)),
+    ).toBeLessThan(beforeBytes);
+  });
+
+  test("rejects replay identities that collide with active or accepted history", () => {
+    const store = registry();
+    const active = begin(store, 1, "active");
+    const accepted = persistedHistory("history-1", "history-run-1");
+
+    store.replacePersistedHistory([
+      persistedHistory(active.invocationId, "other-run"),
+      persistedHistory("active-run-collision", active.runIds[0]!),
+      accepted,
+      persistedHistory("history-1", "history-run-2"),
+      persistedHistory("history-2", "history-run-1"),
+    ]);
+
+    expect(
+      store.getSnapshots().map(({ invocationId }) => invocationId),
+    ).toEqual([active.invocationId, accepted.invocationId]);
+    expect(store.getRunStatus(active.runIds[0]!)).toBe("queued");
+    expect(store.getRunStatus("history-run-1")).toBe("succeeded");
+    expect(store.getRunStatus("history-run-2")).toBeUndefined();
   });
 
   test("exposes compact summaries without transcript text", () => {

--- a/tests/pi-harness/child-run-registry.test.ts
+++ b/tests/pi-harness/child-run-registry.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, test } from "bun:test";
+import {
+  MAX_PERSISTED_INVOCATION_BYTES,
+  MAX_RUN_TRANSCRIPT_BYTES,
+  MAX_RUN_TRANSCRIPT_ITEMS,
+} from "../../pi/extensions/pi-harness/features/child-runs/model";
+import { ChildRunRegistry } from "../../pi/extensions/pi-harness/features/child-runs/registry";
+
+const registry = () => {
+  let id = 0;
+  let now = 100;
+  return new ChildRunRegistry({
+    idFactory: () => `id-${++id}`,
+    now: () => ++now,
+  });
+};
+
+const begin = (store: ChildRunRegistry, count = 2) =>
+  store.beginInvocation({
+    toolCallId: "parent-tool-call",
+    source: "subagent",
+    mode: "parallel",
+    label: "parallel",
+    runs: Array.from({ length: count }, (_, index) => ({
+      agent: `agent-${index + 1}`,
+      task: `task-${index + 1}`,
+      taskIndex: index,
+    })),
+  });
+
+describe("child-run registry", () => {
+  test("tracks stable declaration order and monotonic terminal states", () => {
+    const store = registry();
+    const { invocationId, runIds } = begin(store);
+    store.observe(runIds[0]!, { type: "process_started", at: 10 });
+    store.observe(runIds[0]!, {
+      type: "assistant_final",
+      text: "done",
+      at: 11,
+      model: "model",
+      stopReason: "stop",
+    });
+    store.finishRun(runIds[0]!, {
+      status: "succeeded",
+      reason: "completed",
+      endedAt: 12,
+    });
+    store.finishRun(runIds[0]!, {
+      status: "failed",
+      reason: "model-error",
+    });
+    store.finishRun(runIds[1]!, {
+      status: "skipped",
+      reason: "fail-fast",
+    });
+
+    const snapshot = store.getInvocation(invocationId)!;
+    expect(snapshot.runs.map((run) => run.runId)).toEqual(runIds);
+    expect(snapshot.runs.map((run) => run.status)).toEqual([
+      "succeeded",
+      "skipped",
+    ]);
+    expect(snapshot.runs[0]?.transcript).toEqual([
+      { type: "assistant", text: "done" },
+    ]);
+    expect(snapshot.runs[0]?.liveDraft).toBeUndefined();
+  });
+
+  test("updates tool markers without retaining payloads or raw ids", () => {
+    const store = registry();
+    const { invocationId, runIds } = begin(store, 1);
+    const runId = runIds[0]!;
+    store.observe(runId, { type: "process_started", at: 1 });
+    store.observe(runId, {
+      type: "tool_started",
+      localId: 1,
+      name: "bash",
+      at: 2,
+    });
+    store.observe(runId, {
+      type: "tool_finished",
+      localId: 1,
+      name: "bash",
+      failed: false,
+      at: 3,
+    });
+    store.finishRun(runId, {
+      status: "succeeded",
+      reason: "completed",
+    });
+
+    expect(store.getInvocation(invocationId)?.runs[0]?.transcript).toEqual([
+      { type: "tool", localId: 1, name: "bash", status: "succeeded" },
+    ]);
+  });
+
+  test("marks a tool without an end event interrupted when its run terminates", () => {
+    const store = registry();
+    const { invocationId, runIds } = begin(store, 1);
+    const runId = runIds[0]!;
+    store.observe(runId, { type: "process_started", at: 1 });
+    store.observe(runId, {
+      type: "tool_started",
+      localId: 1,
+      name: "bash",
+      at: 2,
+    });
+    store.finishRun(runId, { status: "failed", reason: "spawn-error" });
+
+    expect(store.getInvocation(invocationId)?.runs[0]?.transcript).toEqual([
+      { type: "tool", localId: 1, name: "bash", status: "interrupted" },
+    ]);
+    expect(store.toPersisted(invocationId)?.runs[0]?.transcript).toEqual([
+      { type: "tool", localId: 1, name: "bash", status: "interrupted" },
+    ]);
+  });
+
+  test("terminalizes every queued and running child with distinct reasons", () => {
+    const store = registry();
+    const { invocationId, runIds } = begin(store, 3);
+    store.observe(runIds[0]!, { type: "process_started", at: 1 });
+    store.terminalizeInvocation(
+      invocationId,
+      { status: "skipped", reason: "dependency-failed" },
+      { status: "aborted", reason: "parent-abort" },
+    );
+
+    expect(
+      store
+        .getInvocation(invocationId)
+        ?.runs.map((run) => [run.status, run.terminalReason]),
+    ).toEqual([
+      ["aborted", "parent-abort"],
+      ["skipped", "dependency-failed"],
+      ["skipped", "dependency-failed"],
+    ]);
+  });
+
+  test("isolates subscriber errors", () => {
+    const store = registry();
+    let calls = 0;
+    store.subscribe(() => {
+      throw new Error("bad subscriber");
+    });
+    store.subscribe(() => calls++);
+    expect(() => begin(store, 1)).not.toThrow();
+    expect(calls).toBe(1);
+  });
+
+  test("enforces run and invocation transcript caps fairly", () => {
+    const store = registry();
+    const { invocationId, runIds } = begin(store, 64);
+    for (const runId of runIds) {
+      store.observe(runId, { type: "process_started", at: 1 });
+      for (let index = 0; index < MAX_RUN_TRANSCRIPT_ITEMS + 20; index++) {
+        store.observe(runId, {
+          type: "assistant_final",
+          text: `${index}:${"界".repeat(2_000)}`,
+          at: 2,
+        });
+      }
+      store.finishRun(runId, {
+        status: "succeeded",
+        reason: "completed",
+      });
+    }
+
+    const live = store.getInvocation(invocationId)!;
+    expect(
+      live.runs.every(
+        (run) =>
+          run.transcript.length <= MAX_RUN_TRANSCRIPT_ITEMS &&
+          run.transcriptBytes <= MAX_RUN_TRANSCRIPT_BYTES,
+      ),
+    ).toBe(true);
+    const persisted = store.toPersisted(invocationId)!;
+    expect(
+      Buffer.byteLength(JSON.stringify(persisted), "utf8"),
+    ).toBeLessThanOrEqual(MAX_PERSISTED_INVOCATION_BYTES);
+    expect(persisted.runs).toHaveLength(64);
+    expect(
+      persisted.runs.every((run) =>
+        run.transcript.some((item) => item.type === "truncated"),
+      ),
+    ).toBe(true);
+  });
+
+  test("exposes compact summaries without transcript text", () => {
+    const store = registry();
+    const { invocationId, runIds } = begin(store, 1);
+    store.observe(runIds[0]!, { type: "process_started", at: 1 });
+    store.observe(runIds[0]!, {
+      type: "assistant_draft",
+      text: "SECRET_DRAFT",
+    });
+    const details = store.getUpdateDetails(invocationId)!;
+    expect(details.childRuns.runs[0]?.status).toBe("running");
+    expect(JSON.stringify(details)).not.toContain("SECRET_DRAFT");
+  });
+});

--- a/tests/pi-harness/child-run-registry.test.ts
+++ b/tests/pi-harness/child-run-registry.test.ts
@@ -185,6 +185,38 @@ describe("child-run registry", () => {
     ).toBe(true);
   });
 
+  test("enforces the serialized per-run byte cap during persistence", () => {
+    const store = registry();
+    const { invocationId, runIds } = begin(store, 1);
+    const runId = runIds[0]!;
+    store.observe(runId, { type: "process_started", at: 1 });
+    for (let index = 0; index < 400; index++) {
+      store.observe(runId, {
+        type: "assistant_final",
+        text: `${index}:${"x".repeat(234)}`,
+        at: 2,
+      });
+    }
+    store.finishRun(runId, {
+      status: "succeeded",
+      reason: "completed",
+    });
+
+    const liveTranscript =
+      store.getInvocation(invocationId)!.runs[0]!.transcript;
+    expect(
+      Buffer.byteLength(JSON.stringify(liveTranscript), "utf8"),
+    ).toBeGreaterThan(MAX_RUN_TRANSCRIPT_BYTES);
+
+    const persistedRun = store.toPersisted(invocationId)!.runs[0]!;
+    expect(
+      Buffer.byteLength(JSON.stringify(persistedRun), "utf8"),
+    ).toBeLessThanOrEqual(MAX_RUN_TRANSCRIPT_BYTES);
+    expect(
+      persistedRun.transcript.some((item) => item.type === "truncated"),
+    ).toBe(true);
+  });
+
   test("exposes compact summaries without transcript text", () => {
     const store = registry();
     const { invocationId, runIds } = begin(store, 1);

--- a/tests/pi-harness/child-run-ui.test.ts
+++ b/tests/pi-harness/child-run-ui.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, test } from "bun:test";
+import { TUI, type Component, type Terminal } from "@earendil-works/pi-tui";
+import { ChildRunRegistry } from "../../pi/extensions/pi-harness/features/child-runs/registry";
+import { ChildRunsBrowserComponent } from "../../pi/extensions/pi-harness/features/child-runs/ui";
+import { visibleWidth } from "../../pi/extensions/pi-harness/lib/terminal-text";
+
+const setup = () => {
+  let id = 0;
+  const registry = new ChildRunRegistry({
+    idFactory: () => `id-${++id}`,
+    now: () => 100,
+  });
+  const renders: number[] = [];
+  const tui = {
+    terminal: { rows: 20 },
+    requestRender: () => renders.push(1),
+  };
+  const keybindings = {
+    matches(data: string, key: string) {
+      const values: Record<string, string> = {
+        "tui.select.up": "up",
+        "tui.select.down": "down",
+        "tui.select.pageUp": "pageup",
+        "tui.select.pageDown": "pagedown",
+        "tui.select.confirm": "enter",
+        "tui.select.cancel": "escape",
+        "tui.editor.cursorLeft": "left",
+        "tui.editor.cursorRight": "right",
+        "tui.editor.cursorLineEnd": "end",
+      };
+      return values[key] === data;
+    },
+  };
+  let unfocused = 0;
+  let hidden = 0;
+  const component = new ChildRunsBrowserComponent(
+    registry,
+    tui,
+    keybindings,
+    () => unfocused++,
+    () => hidden++,
+  );
+  return {
+    registry,
+    component,
+    renders,
+    getUnfocused: () => unfocused,
+    getHidden: () => hidden,
+  };
+};
+
+describe("pi-tui overlay focus contract", () => {
+  test("non-capturing mount keeps editor input and explicit focus survives a temporary modal", () => {
+    let onInput: ((data: string) => void) | undefined;
+    const terminal: Terminal = {
+      start(input) {
+        onInput = input;
+      },
+      stop() {},
+      drainInput: async () => {},
+      write() {},
+      columns: 120,
+      rows: 30,
+      kittyProtocolActive: false,
+      moveBy() {},
+      hideCursor() {},
+      showCursor() {},
+      clearLine() {},
+      clearFromCursor() {},
+      clearScreen() {},
+      setTitle() {},
+      setProgress() {},
+    };
+    const counts = { editor: 0, browser: 0, modal: 0 };
+    const component = (name: keyof typeof counts): Component => ({
+      render: () => [name],
+      invalidate() {},
+      handleInput() {
+        counts[name] += 1;
+      },
+    });
+    const editor = component("editor");
+    const browser = component("browser");
+    const modal = component("modal");
+    const tui = new TUI(terminal);
+    tui.addChild(editor);
+    tui.start();
+    tui.setFocus(editor);
+
+    const browserHandle = tui.showOverlay(browser, {
+      nonCapturing: true,
+      width: 40,
+      visible: () => true,
+    });
+    onInput?.("a");
+    expect(counts).toEqual({ editor: 1, browser: 0, modal: 0 });
+
+    browserHandle.focus();
+    onInput?.("b");
+    expect(counts.browser).toBe(1);
+    tui.showOverlay(modal, { width: 20 });
+    onInput?.("c");
+    expect(counts.modal).toBe(1);
+    tui.hideOverlay();
+    onInput?.("d");
+    expect(counts.browser).toBe(2);
+
+    browserHandle.unfocus();
+    onInput?.("e");
+    expect(counts.editor).toBe(2);
+    tui.stop();
+  });
+});
+
+describe("child-session browser component", () => {
+  test("renders an explanatory empty state within width", () => {
+    const { component } = setup();
+    const lines = component.render(24);
+    expect(lines.join("\n")).toContain("No child runs");
+    expect(lines.every((item) => visibleWidth(item) <= 24)).toBe(true);
+  });
+
+  test("keeps selection stable by run id and opens the selected detail", () => {
+    const { registry, component } = setup();
+    const started = registry.beginInvocation({
+      toolCallId: "parent",
+      source: "workflow",
+      label: "workflow",
+      runs: [
+        { agent: "one", task: "first", taskIndex: 0, stageIndex: 0 },
+        { agent: "two", task: "second", taskIndex: 1, stageIndex: 0 },
+      ],
+    });
+    component.render(40);
+    component.handleInput("down");
+    expect(component.getSelectedRunId()).toBe(started.runIds[1]);
+    registry.observe(started.runIds[0]!, { type: "process_started", at: 1 });
+    expect(component.getSelectedRunId()).toBe(started.runIds[1]);
+    component.handleInput("enter");
+    expect(component.getMode()).toBe("detail");
+    expect(component.render(40).join("\n")).toContain("second");
+  });
+
+  test("sanitizes and width-bounds assistant transcript rendering", () => {
+    const { registry, component } = setup();
+    const { runIds } = registry.beginInvocation({
+      toolCallId: "parent",
+      source: "subagent",
+      mode: "single",
+      label: "subagent",
+      runs: [
+        {
+          agent: "worker\u001b]2;spoof\u0007",
+          task: "inspect 界😀",
+          taskIndex: 0,
+        },
+      ],
+    });
+    registry.observe(runIds[0]!, { type: "process_started", at: 1 });
+    registry.observe(runIds[0]!, {
+      type: "assistant_final",
+      text: "answer\u001b[31m red\u001b[0m 界😀".repeat(10),
+      at: 2,
+    });
+    component.render(28);
+    component.handleInput("enter");
+    const lines = component.render(28);
+    expect(lines.join("\n")).toContain("answer red");
+    expect(lines.join("\n")).not.toContain("\u001b");
+    expect(lines.every((item) => visibleWidth(item) <= 28)).toBe(true);
+  });
+
+  test("pauses live follow on upward scroll and resumes with End", () => {
+    const { registry, component } = setup();
+    const { runIds } = registry.beginInvocation({
+      toolCallId: "parent",
+      source: "subagent",
+      mode: "single",
+      label: "subagent",
+      runs: [{ agent: "worker", task: "inspect", taskIndex: 0 }],
+    });
+    const runId = runIds[0]!;
+    registry.observe(runId, { type: "process_started", at: 1 });
+    for (let index = 0; index < 30; index++) {
+      registry.observe(runId, {
+        type: "assistant_final",
+        text: `line ${index}`,
+        at: index + 2,
+      });
+    }
+    component.render(40);
+    component.handleInput("enter");
+    component.render(40);
+    component.handleInput("up");
+    expect(component.render(40)[1]).toContain("[PAUSED]");
+    component.handleInput("end");
+    expect(component.render(40)[1]).toContain("[LIVE]");
+  });
+
+  test("Escape unfocuses and q hides without changing run state", () => {
+    const { registry, component, getUnfocused, getHidden } = setup();
+    const { runIds } = registry.beginInvocation({
+      toolCallId: "parent",
+      source: "subagent",
+      mode: "single",
+      label: "subagent",
+      runs: [{ agent: "worker", task: "inspect", taskIndex: 0 }],
+    });
+    component.handleInput("escape");
+    component.handleInput("q");
+    expect(getUnfocused()).toBe(1);
+    expect(getHidden()).toBe(1);
+    expect(registry.getRunStatus(runIds[0]!)).toBe("queued");
+  });
+});

--- a/tests/pi-harness/workflow.test.ts
+++ b/tests/pi-harness/workflow.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
 import type { HarnessConfig } from "../../pi/extensions/pi-harness/config";
+import { ChildRunRegistry } from "../../pi/extensions/pi-harness/features/child-runs/registry";
 import setupWorkflow from "../../pi/extensions/pi-harness/features/workflow/index";
 import type {
   SpawnFunction,
@@ -269,6 +270,83 @@ describe("pi-harness workflow", () => {
     expect(text).toContain("finding-two");
     expect(details.succeeded).toBe(2);
     expect(details.total).toBe(2);
+  });
+
+  test("publishes one live child run per stage task while preserving degradation", async () => {
+    const home = await makeTempDirectory("pi-workflow-child-runs");
+    await writeAgents(home, ["codex-reviewer"]);
+    const { records, spawnFn } = makeSpawnFn((taskArg) =>
+      taskArg.includes("fails")
+        ? { stderr: "rate limited", code: 15 }
+        : { text: `done: ${taskArg}` },
+    );
+    let nextId = 0;
+    const registry = new ChildRunRegistry({
+      idFactory: () => `workflow-id-${++nextId}`,
+      now: () => 100,
+    });
+    let visibleCalls = 0;
+    const pi = createFakePi({ cwd: home });
+    setupWorkflow(pi, makeConfig(home), {
+      spawnFn,
+      childRuns: {
+        registry,
+        ensureVisible: () => visibleCalls++,
+      },
+    });
+    const updates: unknown[] = [];
+    const result = await Reflect.apply(
+      findWorkflowTool(pi.tools).execute,
+      undefined,
+      [
+        "workflow-live",
+        {
+          stages: [
+            {
+              name: "review",
+              mode: "fanout",
+              tasks: [
+                { agentType: "codex-reviewer", task: "succeeds" },
+                { agentType: "codex-reviewer", task: "fails" },
+              ],
+            },
+            {
+              name: "judge",
+              mode: "single",
+              tasks: [
+                { agentType: "codex-reviewer", task: "judge {previous}" },
+              ],
+            },
+          ],
+        },
+        undefined,
+        (update: unknown) => updates.push(update),
+        pi.ctx,
+      ],
+    );
+
+    expect(getResult(result).details.succeeded).toBe(2);
+    expect(records).toHaveLength(3);
+    expect(visibleCalls).toBe(1);
+    const snapshots = registry.getSnapshots();
+    expect(snapshots).toHaveLength(1);
+    expect(
+      snapshots[0]?.runs.map((run) => [
+        run.stageIndex,
+        run.taskIndex,
+        run.status,
+      ]),
+    ).toEqual([
+      [0, 0, "succeeded"],
+      [0, 1, "failed"],
+      [1, 0, "succeeded"],
+    ]);
+    expect(JSON.stringify(updates)).toContain('"kind":"summary"');
+    expect(
+      JSON.stringify(
+        updates.map((update) => (update as { details?: unknown }).details),
+      ),
+    ).not.toContain("done: succeeds");
   });
 
   test("oversized outputs share the report budget so every task stays represented", async () => {


### PR DESCRIPTION
## Summary

- capture privacy-safe, bounded child-run transcripts for subagent and workflow executions
- show live child status in tool rows and a resident `/subagents` browser with focus, hide, and replay support
- persist strict transcript projections while omitting sensitive protocol data
- add protocol, registry, persistence, orchestration, rendering, overlay, and documentation coverage

## Testing

- `bun run run-all` (840 passed, 2 skipped)
- pi extension load smoke test
