### PR TITLE
feat(pi): move child-run browser below editor

### DIFF
--- a/pi/extensions/pi-harness/features/child-runs/README.md
+++ b/pi/extensions/pi-harness/features/child-runs/README.md
@@ -9,10 +9,17 @@ resident full-width TUI browser between the chat editor and statusline.
   slot without stealing focus from the main editor.
 - The browser receives the full terminal content width and remains in normal
   layout flow, so it does not cover chat or editor content.
+- Its height is approximately one quarter of the terminal, clamped to 4–10
+  lines. The cap preserves useful editor and conversation space on common
+  24-row and 40-row terminals; extremely short terminals may still be tight.
 - `/subagents` or `Ctrl+Alt+S` shows and focuses the browser.
-- When the editor has focus, Down keeps its native cursor/history behavior.
-  If native Down changes neither editor text nor cursor at the bottom boundary,
-  focus moves to the browser with its current run selected.
+- When a cursor-aware editor has focus, Down keeps its native cursor/history
+  behavior. If native Down changes neither editor text nor cursor at the bottom
+  boundary, focus moves to the browser with its current run selected.
+- Down transfer is best-effort: editors without `getText()` and `getCursor()`
+  retain native Down handling and use `/subagents` or `Ctrl+Alt+S` for explicit
+  focus. Remapped Down is honored when the editor's runtime keybindings manager
+  is detectable; otherwise default terminal sequences are used.
 - `Esc` returns focus to the main editor while leaving the browser visible.
 - `q` hides the browser. A new child run, `/subagents`, or the shortcut shows
   it again.

--- a/pi/extensions/pi-harness/features/child-runs/README.md
+++ b/pi/extensions/pi-harness/features/child-runs/README.md
@@ -1,21 +1,24 @@
 # Child-session browser
 
 The pi-harness `subagent` and `workflow` tools expose their child runs in a
-resident TUI browser.
+resident full-width TUI browser between the chat editor and statusline.
 
 ## Behavior
 
-- The first child invocation mounts a non-capturing overlay on the right.
-- The overlay is visible at terminal widths of 120 columns or more and never
-  steals focus from the main editor.
+- The first child invocation mounts the browser in pi's `belowEditor` widget
+  slot without stealing focus from the main editor.
+- The browser receives the full terminal content width and remains in normal
+  layout flow, so it does not cover chat or editor content.
 - `/subagents` or `Ctrl+Alt+S` shows and focuses the browser.
-- `Esc` returns focus to the main session while leaving the overlay visible.
-- `q` hides the overlay. A new child run, `/subagents`, or the shortcut shows
+- When the editor has focus, Down keeps its native cursor/history behavior.
+  If native Down changes neither editor text nor cursor at the bottom boundary,
+  focus moves to the browser with its current run selected.
+- `Esc` returns focus to the main editor while leaving the browser visible.
+- `q` hides the browser. A new child run, `/subagents`, or the shortcut shows
   it again.
 - Arrow keys select runs and scroll transcripts. Enter opens a run, Left or
   `b` returns to the list, and End resumes live-follow mode.
-- On narrow terminals the normal subagent/workflow tool row remains the live
-  status fallback.
+- The normal subagent/workflow tool row remains a compact status summary.
 
 Closing, hiding, or unfocusing the browser never cancels child execution.
 
@@ -50,10 +53,12 @@ raw source data.
 
 ## Interactive smoke check
 
-1. Start pi in a terminal at least 120 columns wide.
-2. Launch a parallel `subagent` call or a multi-task `workflow`.
-3. Confirm the right overlay appears without taking editor focus.
-4. Press `Ctrl+Alt+S`, select a running child, and verify live updates.
+1. Start pi and launch a parallel `subagent` call or a multi-task `workflow`.
+2. Confirm the full-width browser appears below the editor and above the
+   statusline without taking editor focus.
+3. In a multi-line draft, press Down and confirm native cursor movement still
+   works; at the bottom boundary, press Down again and confirm browser focus.
+4. Select a running child and verify live updates.
 5. Press `Esc` and confirm normal editor input continues.
 6. Press `q`, then run `/subagents` and confirm the same browser reappears.
 7. Resume the parent session and confirm completed transcripts are restored.

--- a/pi/extensions/pi-harness/features/child-runs/index.ts
+++ b/pi/extensions/pi-harness/features/child-runs/index.ts
@@ -4,7 +4,7 @@ import {
   extractPersistedChildRuns,
 } from "./persistence";
 import { ChildRunRegistry } from "./registry";
-import { ChildRunsOverlayController, type BrowserContextLike } from "./ui";
+import { ChildRunsPanelController, type BrowserContextLike } from "./ui";
 
 interface RuntimeContextLike extends BrowserContextLike {
   sessionManager?: {
@@ -58,7 +58,7 @@ const replayBranch = (
 const setupChildRuns = (pi: PiLike): ChildRunsIntegration => {
   const runtime = pi as unknown as RuntimePiLike;
   const registry = new ChildRunRegistry();
-  const overlay = new ChildRunsOverlayController(registry);
+  const panel = new ChildRunsPanelController(registry);
 
   runtime.registerCommand("subagents", {
     description: "Show and focus the live child-session browser",
@@ -72,14 +72,14 @@ const setupChildRuns = (pi: PiLike): ChildRunsIntegration => {
         }
         return;
       }
-      await overlay.showAndFocus(ctx);
+      await panel.showAndFocus(ctx);
     },
   });
 
   runtime.registerShortcut("ctrl+alt+s", {
     description: "Show and focus child sessions",
     handler: async (ctx) => {
-      await overlay.showAndFocus(ctx);
+      await panel.showAndFocus(ctx);
     },
   });
 
@@ -108,14 +108,14 @@ const setupChildRuns = (pi: PiLike): ChildRunsIntegration => {
   runtime.on("session_start", (_event, ctx) => replayBranch(registry, ctx));
   runtime.on("session_tree", (_event, ctx) => replayBranch(registry, ctx));
   runtime.on("session_shutdown", () => {
-    overlay.dispose();
+    panel.dispose();
     registry.dispose();
   });
 
   return {
     registry,
     ensureVisible(ctx) {
-      overlay.ensureVisible(ctx as RuntimeContextLike);
+      panel.ensureVisible(ctx as RuntimeContextLike);
     },
   };
 };

--- a/pi/extensions/pi-harness/features/child-runs/ui.ts
+++ b/pi/extensions/pi-harness/features/child-runs/ui.ts
@@ -14,47 +14,37 @@ import type {
 import { statusIcon, type ComponentLike } from "./presentation";
 import { ChildRunRegistry } from "./registry";
 
-interface TuiLike {
-  terminal: { rows: number };
-  requestRender(force?: boolean): void;
-}
-
 interface KeybindingsLike {
   matches(data: string, keybinding: string): boolean;
 }
 
-interface OverlayHandleLike {
-  hide(): void;
-  setHidden(hidden: boolean): void;
-  isHidden(): boolean;
-  focus(): void;
-  unfocus(options?: { target: ComponentLike | null }): void;
-  isFocused(): boolean;
+interface EditorLike extends ComponentLike {
+  handleInput(data: string): void;
+  getText(): string;
+  getCursor(): { line: number; col: number };
+  isShowingAutocomplete?(): boolean;
+  keybindings?: KeybindingsLike;
 }
 
-interface OverlayOptionsLike {
-  width?: number | `${number}%`;
-  maxHeight?: number | `${number}%`;
-  anchor?: string;
-  margin?: number;
-  nonCapturing?: boolean;
-  visible?: (termWidth: number, termHeight: number) => boolean;
+interface TuiLike {
+  terminal: { rows: number };
+  requestRender(force?: boolean): void;
+  setFocus?(component: ComponentLike | null): void;
+  // pi-tui has no public focus getter. The widget needs the currently focused
+  // editor so it can preserve native Down handling and restore focus after
+  // browsing. Keep this private runtime seam isolated to this adapter.
+  focusedComponent?: ComponentLike | null;
 }
 
-interface CustomUiLike {
-  custom<T>(
-    factory: (
-      tui: TuiLike,
-      theme: unknown,
-      keybindings: KeybindingsLike,
-      done: (result: T) => void,
-    ) => ComponentLike,
-    options: {
-      overlay: true;
-      overlayOptions: OverlayOptionsLike | (() => OverlayOptionsLike);
-      onHandle: (handle: OverlayHandleLike) => void;
-    },
-  ): Promise<T>;
+interface WidgetUiLike {
+  setWidget(
+    key: string,
+    content: ((tui: TuiLike, theme: unknown) => ComponentLike) | undefined,
+    options?: { placement: "belowEditor" },
+  ): void;
+  onTerminalInput?(
+    handler: (data: string) => { consume?: boolean; data?: string } | undefined,
+  ): () => void;
   notify(message: string, level?: "info" | "warning" | "error"): void;
 }
 
@@ -344,137 +334,236 @@ export class ChildRunsBrowserComponent implements ComponentLike {
   }
 }
 
-type MountState = "unmounted" | "mounting" | "mounted" | "disposed";
+type MountState = "unmounted" | "mounted" | "disposed";
 
-export class ChildRunsOverlayController {
+export const CHILD_RUNS_WIDGET_KEY = "pi-harness-child-runs";
+
+const isKeyRelease = (data: string): boolean =>
+  !data.includes("\u001b[200~") &&
+  [":3u", ":3~", ":3A", ":3B", ":3C", ":3D", ":3H", ":3F"].some((marker) =>
+    data.includes(marker),
+  );
+
+const defaultKeyMatches = (data: string, keybinding: string): boolean => {
+  const legacyKeys: Record<string, string[]> = {
+    "tui.editor.cursorDown": ["down", "\u001b[B"],
+    "tui.editor.cursorLeft": ["left", "\u001b[D"],
+    "tui.editor.cursorRight": ["right", "\u001b[C"],
+    "tui.editor.cursorLineEnd": ["end", "\u001b[F", "\u001b[4~"],
+    "tui.select.up": ["up", "\u001b[A"],
+    "tui.select.down": ["down", "\u001b[B"],
+    "tui.select.pageUp": ["pageup", "\u001b[5~"],
+    "tui.select.pageDown": ["pagedown", "\u001b[6~"],
+    "tui.select.confirm": ["enter", "\r", "\n"],
+    "tui.select.cancel": ["escape", "\u001b"],
+  };
+  if (legacyKeys[keybinding]?.includes(data)) return true;
+
+  if (!data.startsWith("\u001b[")) return false;
+  const kittySequence = data.slice(2);
+  const kittyPatterns: Partial<Record<string, RegExp>> = {
+    "tui.editor.cursorDown": /^1;1(?::[12])?B$/,
+    "tui.editor.cursorLeft": /^1;1(?::[12])?D$/,
+    "tui.editor.cursorRight": /^1;1(?::[12])?C$/,
+    "tui.editor.cursorLineEnd": /^(?:1;1(?::[12])?F|8;1(?::[12])?~)$/,
+    "tui.select.up": /^1;1(?::[12])?A$/,
+    "tui.select.down": /^1;1(?::[12])?B$/,
+    "tui.select.pageUp": /^5;1(?::[12])?~$/,
+    "tui.select.pageDown": /^6;1(?::[12])?~$/,
+    "tui.select.confirm": /^13(?:;1)?(?::[12])?u$/,
+    "tui.select.cancel": /^27(?:;1)?(?::[12])?u$/,
+  };
+  return kittyPatterns[keybinding]?.test(kittySequence) ?? false;
+};
+
+const isEditorLike = (value: unknown): value is EditorLike =>
+  typeof value === "object" &&
+  value !== null &&
+  "handleInput" in value &&
+  typeof value.handleInput === "function" &&
+  "getText" in value &&
+  typeof value.getText === "function" &&
+  "getCursor" in value &&
+  typeof value.getCursor === "function";
+
+const sameCursor = (
+  left: { line: number; col: number },
+  right: { line: number; col: number },
+): boolean => left.line === right.line && left.col === right.col;
+
+/**
+ * Resident full-width child browser mounted in pi's below-editor widget slot.
+ *
+ * pi-tui currently exposes setFocus() but no public focus getter. To preserve
+ * normal editor navigation, the controller reads the focused editor through a
+ * single structural seam, forwards Down to it first, and only transfers focus
+ * when text and cursor are unchanged (the editor's bottom boundary).
+ */
+export class ChildRunsPanelController {
   private state: MountState = "unmounted";
-  private handle: OverlayHandleLike | undefined;
   private component: ChildRunsBrowserComponent | undefined;
-  private pendingFocus = false;
-  private explicitlyVisible = false;
-  private ready: Promise<boolean> | undefined;
+  private editor: EditorLike | undefined;
+  private returnFocus: ComponentLike | undefined;
+  private tui: TuiLike | undefined;
+  private ui: WidgetUiLike | undefined;
+  private unsubscribeInput: (() => void) | undefined;
+  private readonly keybindings: KeybindingsLike = {
+    matches: (data, keybinding) =>
+      this.editor?.keybindings?.matches(data, keybinding) ??
+      defaultKeyMatches(data, keybinding),
+  };
 
   constructor(private readonly registry: ChildRunRegistry) {}
 
   ensureVisible(ctx: BrowserContextLike): void {
-    void this.show(ctx, false);
+    this.show(ctx, false);
   }
 
   async showAndFocus(ctx: BrowserContextLike): Promise<void> {
-    await this.show(ctx, true);
+    this.show(ctx, true);
   }
 
   dispose(): void {
     if (this.state === "disposed") return;
-    this.state = "disposed";
-    this.component?.dispose();
+    if (this.tui?.focusedComponent === this.component) this.restoreFocus();
+    if (this.state === "mounted") {
+      this.ui?.setWidget(CHILD_RUNS_WIDGET_KEY, undefined);
+    }
+    this.unsubscribeInput?.();
+    this.unsubscribeInput = undefined;
     this.component = undefined;
-    this.explicitlyVisible = false;
-    this.handle?.hide();
-    this.handle = undefined;
+    this.editor = undefined;
+    this.returnFocus = undefined;
+    this.tui = undefined;
+    this.ui = undefined;
+    this.state = "disposed";
   }
 
   getMountState(): MountState {
     return this.state;
   }
 
-  getHandle(): OverlayHandleLike | undefined {
-    return this.handle;
-  }
-
-  private async show(
-    ctx: BrowserContextLike,
-    focus: boolean,
-  ): Promise<boolean> {
+  private show(ctx: BrowserContextLike, focus: boolean): boolean {
     if (ctx.mode !== "tui" || this.state === "disposed") return false;
-    if (focus) this.explicitlyVisible = true;
-    if (this.state === "mounted" && this.handle !== undefined) {
-      this.handle.setHidden(false);
-      if (focus) this.handle.focus();
+    if (this.state === "mounted") {
+      if (focus) this.focusBrowser();
       return true;
     }
-    if (this.state === "mounting") {
-      this.pendingFocus ||= focus;
-      return (await this.ready) ?? false;
+
+    const ui = ctx.ui as unknown as WidgetUiLike;
+    this.ui = ui;
+    this.installInputListener(ui);
+    try {
+      ui.setWidget(
+        CHILD_RUNS_WIDGET_KEY,
+        (tui) => {
+          this.tui = tui;
+          this.captureFocusTarget(tui.focusedComponent);
+          const component = new ChildRunsBrowserComponent(
+            this.registry,
+            tui,
+            this.keybindings,
+            () => this.restoreFocus(),
+            () => this.hide(),
+          );
+          this.component = component;
+          return component;
+        },
+        { placement: "belowEditor" },
+      );
+      if (this.component === undefined || this.tui === undefined) {
+        throw new Error("widget factory did not mount a component");
+      }
+      this.state = "mounted";
+      if (focus) this.focusBrowser();
+      return true;
+    } catch (error) {
+      this.state = "unmounted";
+      this.component?.dispose();
+      this.component = undefined;
+      ui.notify(
+        `Child-session browser could not open: ${String(error)}`,
+        "warning",
+      );
+      return false;
+    }
+  }
+
+  private installInputListener(ui: WidgetUiLike): void {
+    if (this.unsubscribeInput !== undefined || ui.onTerminalInput === undefined)
+      return;
+    this.unsubscribeInput = ui.onTerminalInput((data) =>
+      this.handleTerminalInput(data),
+    );
+  }
+
+  private handleTerminalInput(data: string): { consume: true } | undefined {
+    if (
+      this.state !== "mounted" ||
+      this.component === undefined ||
+      this.tui === undefined ||
+      isKeyRelease(data) ||
+      !this.keybindings.matches(data, "tui.editor.cursorDown")
+    ) {
+      return undefined;
     }
 
-    this.state = "mounting";
-    this.pendingFocus = focus;
-    let settleReady: (mounted: boolean) => void = () => {};
-    this.ready = new Promise<boolean>((resolve) => {
-      settleReady = resolve;
-    });
-    const ui = ctx.ui as unknown as CustomUiLike;
-    let localComponent: ChildRunsBrowserComponent | undefined;
-    const customPromise = ui.custom<void>(
-      (tui, _theme, keybindings) => {
-        localComponent = new ChildRunsBrowserComponent(
-          this.registry,
-          tui,
-          keybindings,
-          () => this.handle?.unfocus(),
-          () => this.hide(),
-        );
-        this.component = localComponent;
-        return localComponent;
-      },
-      {
-        overlay: true,
-        overlayOptions: () => ({
-          nonCapturing: true,
-          anchor: "right-center",
-          width: 48,
-          maxHeight: "80%",
-          margin: 1,
-          visible: (termWidth) =>
-            termWidth >= 120 ||
-            this.explicitlyVisible ||
-            this.handle?.isFocused() === true,
-        }),
-        onHandle: (handle) => {
-          if (this.state === "disposed") {
-            handle.hide();
-            settleReady(false);
-            return;
-          }
-          this.handle = handle;
-          this.state = "mounted";
-          handle.setHidden(false);
-          if (this.pendingFocus) handle.focus();
-          this.pendingFocus = false;
-          settleReady(true);
-        },
-      },
-    );
-    void customPromise
-      .then(() => {
-        if (this.state === "disposed") return;
-        localComponent?.dispose();
-        if (this.component === localComponent) this.component = undefined;
-        this.handle = undefined;
-        this.explicitlyVisible = false;
-        this.state = "unmounted";
-      })
-      .catch((error) => {
-        if (this.state !== "disposed") {
-          this.state = "unmounted";
-          this.handle = undefined;
-          this.explicitlyVisible = false;
-          this.component?.dispose();
-          this.component = undefined;
-          ui.notify(
-            `Child-session browser could not open: ${String(error)}`,
-            "warning",
-          );
-        }
-        settleReady(false);
-      });
-    return (await this.ready) ?? false;
+    const focused = this.tui.focusedComponent;
+    if (focused === this.component) return undefined;
+    this.captureFocusTarget(focused);
+    const editor = this.editor;
+    if (
+      editor === undefined ||
+      focused !== editor ||
+      editor.isShowingAutocomplete?.() === true
+    ) {
+      return undefined;
+    }
+
+    const beforeText = editor.getText();
+    const beforeCursor = editor.getCursor();
+    editor.handleInput(data);
+    const afterText = editor.getText();
+    const afterCursor = editor.getCursor();
+    if (beforeText === afterText && sameCursor(beforeCursor, afterCursor)) {
+      this.focusBrowser();
+    } else {
+      this.tui.requestRender();
+    }
+    return { consume: true };
+  }
+
+  private captureFocusTarget(
+    candidate: ComponentLike | null | undefined,
+  ): void {
+    if (
+      candidate === undefined ||
+      candidate === null ||
+      candidate === this.component
+    )
+      return;
+    this.returnFocus = candidate;
+    if (isEditorLike(candidate)) this.editor = candidate;
+  }
+
+  private focusBrowser(): void {
+    if (this.state !== "mounted" || this.component === undefined) return;
+    this.captureFocusTarget(this.tui?.focusedComponent);
+    this.tui?.setFocus?.(this.component);
+    this.tui?.requestRender();
+  }
+
+  private restoreFocus(): void {
+    if (this.returnFocus === undefined) return;
+    this.tui?.setFocus?.(this.returnFocus);
+    this.tui?.requestRender();
   }
 
   private hide(): void {
-    this.explicitlyVisible = false;
-    this.handle?.unfocus();
-    this.handle?.setHidden(true);
+    if (this.state !== "mounted") return;
+    this.restoreFocus();
+    this.state = "unmounted";
+    this.component = undefined;
+    this.ui?.setWidget(CHILD_RUNS_WIDGET_KEY, undefined);
   }
 }

--- a/pi/extensions/pi-harness/features/child-runs/ui.ts
+++ b/pi/extensions/pi-harness/features/child-runs/ui.ts
@@ -114,9 +114,13 @@ export class ChildRunsBrowserComponent implements ComponentLike {
 
   render(width: number): string[] {
     const safeWidth = Math.max(1, width);
+    // The browser now participates in normal layout flow with chat, editor,
+    // status rows, and footer. Keep its budget conservative rather than using
+    // the former overlay-sized 80%/30-row cap. Common 24/40-row terminals get
+    // at most 6/10 browser rows; very small terminals retain minimal controls.
     const height = Math.max(
-      6,
-      Math.min(Math.floor(this.tui.terminal.rows * 0.8), 30),
+      4,
+      Math.min(Math.floor(this.tui.terminal.rows / 4), 10),
     );
     const snapshots = this.registry.getSnapshots();
     const runs = flattenRuns(snapshots);
@@ -129,8 +133,8 @@ export class ChildRunsBrowserComponent implements ComponentLike {
 
     const body =
       this.mode === "detail"
-        ? this.renderDetail(runs, safeWidth, height - 3)
-        : this.renderList(snapshots, runs, safeWidth, height - 3);
+        ? this.renderDetail(runs, safeWidth, height - 2)
+        : this.renderList(snapshots, runs, safeWidth, height - 2);
     const title =
       this.mode === "detail" ? " Child session " : " Child sessions ";
     const borderWidth = Math.max(1, safeWidth - visibleWidth(title));
@@ -398,6 +402,12 @@ const sameCursor = (
  * normal editor navigation, the controller reads the focused editor through a
  * single structural seam, forwards Down to it first, and only transfers focus
  * when text and cursor are unchanged (the editor's bottom boundary).
+ *
+ * Boundary transfer is best-effort for cursor-aware editors that expose
+ * getText() and getCursor(). Editors without those optional capabilities keep
+ * native Down handling and can focus the browser via /subagents or Ctrl+Alt+S.
+ * Remapped Down is honored when the editor exposes its runtime keybindings
+ * manager; otherwise only the fallback default terminal sequences are known.
  */
 export class ChildRunsPanelController {
   private state: MountState = "unmounted";

--- a/tests/pi-harness/child-run-integration.test.ts
+++ b/tests/pi-harness/child-run-integration.test.ts
@@ -37,39 +37,12 @@ const makeConfig = (home: string): HarnessConfig => ({
   paths: resolvePaths(home),
 });
 
-interface OverlayHandleFake {
-  hidden: boolean;
-  focused: boolean;
-  hide(): void;
-  setHidden(value: boolean): void;
-  isHidden(): boolean;
-  focus(): void;
-  unfocus(): void;
-  isFocused(): boolean;
+interface RuntimeComponent {
+  render(width: number): string[];
+  invalidate(): void;
+  handleInput?(data: string): void;
+  dispose?(): void;
 }
-
-const createOverlayHandle = (): OverlayHandleFake => ({
-  hidden: false,
-  focused: false,
-  hide() {
-    this.hidden = true;
-  },
-  setHidden(value) {
-    this.hidden = value;
-  },
-  isHidden() {
-    return this.hidden;
-  },
-  focus() {
-    this.focused = true;
-  },
-  unfocus() {
-    this.focused = false;
-  },
-  isFocused() {
-    return this.focused;
-  },
-});
 
 const createRuntime = (cwd: string) => {
   const tools: ToolDefLike[] = [];
@@ -85,12 +58,56 @@ const createRuntime = (cwd: string) => {
     string,
     { handler: (ctx: RuntimeContext) => Promise<void> | void }
   >();
-  const overlayHandle = createOverlayHandle();
-  let customCalls = 0;
-  let component:
-    | { render(width: number): string[]; handleInput?(data: string): void }
+  const keybindings = {
+    matches: (data: string, key: string) =>
+      (key === "tui.editor.cursorDown" &&
+        (data === "down" || data === "\u001b[1;1:3B")) ||
+      (key === "tui.select.confirm" && data === "\r") ||
+      (key === "tui.select.cancel" && data === "\u001b") ||
+      (key === "tui.select.up" && data === "up") ||
+      (key === "tui.select.down" && data === "down"),
+  };
+  let editorLines = [""];
+  let editorCursor = { line: 0, col: 0 };
+  const editor: RuntimeComponent & {
+    keybindings: typeof keybindings;
+    getText(): string;
+    getCursor(): { line: number; col: number };
+    isShowingAutocomplete(): boolean;
+  } = {
+    keybindings,
+    render: () => ["editor"],
+    invalidate() {},
+    getText: () => editorLines.join("\n"),
+    getCursor: () => ({ ...editorCursor }),
+    isShowingAutocomplete: () => false,
+    handleInput(data) {
+      if (!keybindings.matches(data, "tui.editor.cursorDown")) return;
+      if (editorCursor.line < editorLines.length - 1) {
+        editorCursor.line += 1;
+        editorCursor.col = Math.min(
+          editorCursor.col,
+          editorLines[editorCursor.line]?.length ?? 0,
+        );
+        return;
+      }
+      editorCursor.col = editorLines[editorCursor.line]?.length ?? 0;
+    },
+  };
+  const tui = {
+    terminal: { rows: 40 },
+    requestRender: () => {},
+    focusedComponent: editor as RuntimeComponent | null,
+    setFocus(next: RuntimeComponent | null) {
+      this.focusedComponent = next;
+    },
+  };
+  let widgetCalls = 0;
+  let component: RuntimeComponent | undefined;
+  let widgetPlacement: string | undefined;
+  let terminalInputHandler:
+    | ((data: string) => { consume?: boolean; data?: string } | undefined)
     | undefined;
-  let overlayOptions: Record<string, unknown> | undefined;
   let branch: unknown[] = [];
 
   const ctx = {
@@ -103,27 +120,32 @@ const createRuntime = (cwd: string) => {
       confirm: async () => false,
       input: async () => undefined,
       notify: () => {},
-      custom(factory: Function, options: Record<string, unknown>) {
-        customCalls += 1;
-        component = Reflect.apply(factory, undefined, [
-          { terminal: { rows: 40 }, requestRender: () => {} },
-          {},
-          {
-            matches: (data: string, key: string) =>
-              (key === "tui.select.confirm" && data === "\r") ||
-              (key === "tui.select.cancel" && data === "\u001b") ||
-              (key === "tui.select.up" && data === "up") ||
-              (key === "tui.select.down" && data === "down"),
-          },
-          () => {},
-        ]);
-        const rawOverlayOptions = options.overlayOptions;
-        overlayOptions =
-          typeof rawOverlayOptions === "function"
-            ? Reflect.apply(rawOverlayOptions, undefined, [])
-            : (rawOverlayOptions as Record<string, unknown>);
-        Reflect.apply(options.onHandle as Function, undefined, [overlayHandle]);
-        return new Promise<void>(() => {});
+      setWidget(
+        _key: string,
+        content:
+          | ((widgetTui: typeof tui, theme: unknown) => RuntimeComponent)
+          | undefined,
+        options?: { placement?: string },
+      ) {
+        widgetCalls += 1;
+        if (content === undefined) {
+          component?.dispose?.();
+          component = undefined;
+          return;
+        }
+        widgetPlacement = options?.placement;
+        component = content(tui, {});
+      },
+      onTerminalInput(
+        handler: (
+          data: string,
+        ) => { consume?: boolean; data?: string } | undefined,
+      ) {
+        terminalInputHandler = handler;
+        return () => {
+          if (terminalInputHandler === handler)
+            terminalInputHandler = undefined;
+        };
       },
     },
   } as unknown as RuntimeContext;
@@ -160,10 +182,20 @@ const createRuntime = (cwd: string) => {
     tools,
     commands,
     shortcuts,
-    overlayHandle,
-    getCustomCalls: () => customCalls,
+    editor,
+    tui,
+    getWidgetCalls: () => widgetCalls,
     getComponent: () => component,
-    getOverlayOptions: () => overlayOptions,
+    getWidgetPlacement: () => widgetPlacement,
+    setEditorState(lines: string[], line: number, col: number) {
+      editorLines = [...lines];
+      editorCursor = { line, col };
+    },
+    dispatchInput(data: string) {
+      const result = terminalInputHandler?.(data);
+      if (result?.consume) return;
+      tui.focusedComponent?.handleInput?.(result?.data ?? data);
+    },
     setBranch(entries: unknown[]) {
       branch = entries;
     },
@@ -269,7 +301,7 @@ const writeAgent = async (home: string): Promise<void> => {
 };
 
 describe("child-run subagent integration", () => {
-  test("mounts one non-capturing overlay, streams summaries, and persists a safe transcript", async () => {
+  test("mounts one full-width below-editor panel, streams summaries, and persists a safe transcript", async () => {
     const home = await setupTestDirectory("pi-child-integration");
     tempDirectories.push(home);
     await writeAgent(home);
@@ -289,9 +321,10 @@ describe("child-run subagent integration", () => {
       runtime.ctx,
     ]);
 
-    expect(runtime.getCustomCalls()).toBe(1);
-    expect(runtime.getOverlayOptions()?.nonCapturing).toBe(true);
-    expect(runtime.overlayHandle.focused).toBe(false);
+    expect(runtime.getWidgetCalls()).toBe(1);
+    expect(runtime.getWidgetPlacement()).toBe("belowEditor");
+    expect(runtime.getComponent()).toBeDefined();
+    expect(runtime.tui.focusedComponent).toBe(runtime.editor);
     expect(JSON.stringify(updates)).toContain('"kind":"summary"');
     expect(
       JSON.stringify(
@@ -482,23 +515,73 @@ describe("child-run subagent integration", () => {
     expect(childRuns.registry.getSnapshots()).toEqual([]);
   });
 
-  test("/subagents focuses the resident overlay and Escape only unfocuses", async () => {
+  test("Down transfers focus only after native editor navigation reaches its bottom boundary", () => {
+    const home = "/tmp/pi-child-down-focus";
+    const runtime = createRuntime(home);
+    const childRuns = setupChildRuns(runtime.pi);
+    childRuns.ensureVisible(runtime.ctx);
+    const panel = runtime.getComponent();
+    if (panel === undefined) throw new Error("child-run panel did not mount");
+
+    runtime.setEditorState(["first", "second"], 0, 0);
+    runtime.dispatchInput("down");
+    expect(runtime.editor.getCursor()).toEqual({ line: 1, col: 0 });
+    expect(runtime.tui.focusedComponent).toBe(runtime.editor);
+
+    runtime.setEditorState(["first", "second"], 1, 6);
+    runtime.dispatchInput("\u001b[1;1:3B");
+    expect(runtime.tui.focusedComponent).toBe(runtime.editor);
+
+    runtime.dispatchInput("down");
+    expect(runtime.tui.focusedComponent).toBe(panel);
+
+    panel.handleInput?.("\u001b");
+    expect(runtime.tui.focusedComponent).toBe(runtime.editor);
+  });
+
+  test("/subagents restores generic custom-editor focus on Escape and q", async () => {
     const home = await setupTestDirectory("pi-child-command");
     tempDirectories.push(home);
     const runtime = createRuntime(home);
     setupChildRuns(runtime.pi);
+    const customEditor: RuntimeComponent = {
+      render: () => ["custom editor"],
+      invalidate() {},
+      handleInput() {},
+    };
+    runtime.tui.setFocus(customEditor);
 
     await runtime.commands.get("subagents")!.handler("", runtime.ctx);
-    const visible = runtime.getOverlayOptions()?.visible as
-      | ((width: number, height: number) => boolean)
-      | undefined;
-    expect(visible?.(80, 30)).toBe(true);
-    expect(runtime.overlayHandle.focused).toBe(true);
-    runtime.getComponent()?.handleInput?.("\u001b");
-    expect(runtime.overlayHandle.focused).toBe(false);
-    expect(runtime.overlayHandle.hidden).toBe(false);
+    const panel = runtime.getComponent();
+    if (panel === undefined) throw new Error("child-run panel did not mount");
+    expect(runtime.getWidgetPlacement()).toBe("belowEditor");
+    expect(runtime.tui.focusedComponent).toBe(panel);
+    panel.handleInput?.("\u001b");
+    expect(runtime.tui.focusedComponent).toBe(customEditor);
+    expect(runtime.getComponent()).toBeDefined();
+
+    await runtime.commands.get("subagents")!.handler("", runtime.ctx);
     runtime.getComponent()?.handleInput?.("q");
-    expect(runtime.overlayHandle.hidden).toBe(true);
-    expect(visible?.(80, 30)).toBe(false);
+    expect(runtime.tui.focusedComponent).toBe(customEditor);
+    expect(runtime.getComponent()).toBeUndefined();
+  });
+
+  test("explicit focus refresh replaces a stale pre-mount focus target", async () => {
+    const runtime = createRuntime("/tmp/pi-child-stale-focus");
+    const childRuns = setupChildRuns(runtime.pi);
+    const temporarySelector: RuntimeComponent = {
+      render: () => ["selector"],
+      invalidate() {},
+      handleInput() {},
+    };
+    runtime.tui.setFocus(temporarySelector);
+    childRuns.ensureVisible(runtime.ctx);
+
+    runtime.tui.setFocus(runtime.editor);
+    await runtime.commands.get("subagents")!.handler("", runtime.ctx);
+    const panel = runtime.getComponent();
+    if (panel === undefined) throw new Error("child-run panel did not mount");
+    panel.handleInput?.("\u001b");
+    expect(runtime.tui.focusedComponent).toBe(runtime.editor);
   });
 });

--- a/tests/pi-harness/child-run-integration.test.ts
+++ b/tests/pi-harness/child-run-integration.test.ts
@@ -539,6 +539,63 @@ describe("child-run subagent integration", () => {
     expect(runtime.tui.focusedComponent).toBe(runtime.editor);
   });
 
+  test("custom editors without cursor capability retain native Down handling", () => {
+    const runtime = createRuntime("/tmp/pi-child-custom-down");
+    const childRuns = setupChildRuns(runtime.pi);
+    const received: string[] = [];
+    const customEditor: RuntimeComponent = {
+      render: () => ["custom editor"],
+      invalidate() {},
+      handleInput(data) {
+        received.push(data);
+      },
+    };
+    runtime.tui.setFocus(customEditor);
+    childRuns.ensureVisible(runtime.ctx);
+
+    runtime.dispatchInput("down");
+    expect(received).toEqual(["down"]);
+    expect(runtime.tui.focusedComponent).toBe(customEditor);
+  });
+
+  test("cursor-aware editors honor a remapped Down binding", () => {
+    const runtime = createRuntime("/tmp/pi-child-remapped-down");
+    const childRuns = setupChildRuns(runtime.pi);
+    const received: string[] = [];
+    const remappedEditor: RuntimeComponent & {
+      keybindings: { matches(data: string, key: string): boolean };
+      getText(): string;
+      getCursor(): { line: number; col: number };
+    } = {
+      keybindings: {
+        matches: (data, key) =>
+          (key === "tui.editor.cursorDown" && data === "\u000e") ||
+          (key === "tui.select.cancel" && data === "\u001b"),
+      },
+      render: () => ["remapped editor"],
+      invalidate() {},
+      getText: () => "draft",
+      getCursor: () => ({ line: 0, col: 5 }),
+      handleInput(data) {
+        received.push(data);
+      },
+    };
+    runtime.tui.setFocus(remappedEditor);
+    childRuns.ensureVisible(runtime.ctx);
+    const panel = runtime.getComponent();
+    if (panel === undefined) throw new Error("child-run panel did not mount");
+
+    runtime.dispatchInput("\u001b[B");
+    expect(received).toEqual(["\u001b[B"]);
+    expect(runtime.tui.focusedComponent).toBe(remappedEditor);
+
+    runtime.dispatchInput("\u000e");
+    expect(received).toEqual(["\u001b[B", "\u000e"]);
+    expect(runtime.tui.focusedComponent).toBe(panel);
+    panel.handleInput?.("\u001b");
+    expect(runtime.tui.focusedComponent).toBe(remappedEditor);
+  });
+
   test("/subagents restores generic custom-editor focus on Escape and q", async () => {
     const home = await setupTestDirectory("pi-child-command");
     tempDirectories.push(home);

--- a/tests/pi-harness/child-run-layout.test.ts
+++ b/tests/pi-harness/child-run-layout.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+import {
+  Editor,
+  Spacer,
+  Text,
+  TUI,
+  type EditorTheme,
+  type Terminal,
+} from "@earendil-works/pi-tui";
+import { ChildRunRegistry } from "../../pi/extensions/pi-harness/features/child-runs/registry";
+import { ChildRunsBrowserComponent } from "../../pi/extensions/pi-harness/features/child-runs/ui";
+
+type BrowserTui = ConstructorParameters<typeof ChildRunsBrowserComponent>[1];
+
+const identity = (text: string): string => text;
+
+const editorTheme: EditorTheme = {
+  borderColor: identity,
+  selectList: {
+    selectedPrefix: identity,
+    selectedText: identity,
+    description: identity,
+    scrollInfo: identity,
+    noMatch: identity,
+  },
+};
+
+const createTerminal = (columns: number, rows: number): Terminal => ({
+  start() {},
+  stop() {},
+  drainInput: async () => {},
+  write() {},
+  columns,
+  rows,
+  kittyProtocolActive: false,
+  moveBy() {},
+  hideCursor() {},
+  showCursor() {},
+  clearLine() {},
+  clearFromCursor() {},
+  clearScreen() {},
+  setTitle() {},
+  setProgress() {},
+});
+
+const createLayout = (rows: number, columns: number) => {
+  let id = 0;
+  const registry = new ChildRunRegistry({
+    idFactory: () => `layout-${++id}`,
+    now: () => 100,
+  });
+  registry.beginInvocation({
+    toolCallId: "layout-parent",
+    source: "workflow",
+    label: "workflow",
+    runs: Array.from({ length: 30 }, (_, taskIndex) => ({
+      agent: `agent-${taskIndex}`,
+      task: `inspect task ${taskIndex}`,
+      taskIndex,
+      stageIndex: 0,
+    })),
+  });
+
+  const terminal = createTerminal(columns, rows);
+  const tui = new TUI(terminal);
+  const chat = new Text(
+    Array.from(
+      { length: 30 },
+      (_, index) => `chat-${String(index).padStart(2, "0")}`,
+    ).join("\n"),
+    0,
+    0,
+  );
+  const status = new Text("working status", 0, 0);
+  const editor = new Editor(tui, editorTheme, { paddingX: 0 });
+  editor.setText("draft-1\ndraft-2\ndraft-3\ndraft-4\ndraft-5");
+  const browser = new ChildRunsBrowserComponent(
+    registry,
+    tui as unknown as BrowserTui,
+    { matches: () => false },
+    () => {},
+    () => {},
+  );
+  const footer = new Text("footer-main\nfooter-detail", 0, 0);
+
+  // Match interactive-mode's vertical order around the editor: status,
+  // empty aboveEditor spacer, editor, belowEditor widget, then footer.
+  tui.addChild(chat);
+  tui.addChild(status);
+  tui.addChild(new Spacer(1));
+  tui.addChild(editor);
+  tui.addChild(browser);
+  tui.addChild(footer);
+
+  const editorLines = editor.render(columns);
+  const browserLines = browser.render(columns);
+  const allLines = tui.render(columns);
+  const viewport = allLines.slice(-rows);
+  return { editorLines, browserLines, viewport };
+};
+
+const countLine = (lines: string[], target: string): number =>
+  lines.filter((line) => line === target).length;
+
+describe("child-session browser normal-flow layout", () => {
+  for (const [rows, columns, expectedPanelHeight] of [
+    [24, 80, 6],
+    [40, 120, 10],
+  ] as const) {
+    test(`keeps the editor visible in a ${rows}-row terminal`, () => {
+      const { editorLines, browserLines, viewport } = createLayout(
+        rows,
+        columns,
+      );
+
+      expect(browserLines).toHaveLength(expectedPanelHeight);
+      for (const editorLine of new Set(editorLines)) {
+        expect(countLine(viewport, editorLine)).toBeGreaterThanOrEqual(
+          countLine(editorLines, editorLine),
+        );
+      }
+      expect(viewport.filter((line) => line.startsWith("chat-"))).toHaveLength(
+        rows === 24 ? 7 : 19,
+      );
+      expect(viewport.at(-2)?.trimEnd()).toBe("footer-main");
+      expect(viewport.at(-1)?.trimEnd()).toBe("footer-detail");
+    });
+  }
+});

--- a/tests/pi-harness/child-run-ui.test.ts
+++ b/tests/pi-harness/child-run-ui.test.ts
@@ -4,7 +4,7 @@ import { ChildRunRegistry } from "../../pi/extensions/pi-harness/features/child-
 import { ChildRunsBrowserComponent } from "../../pi/extensions/pi-harness/features/child-runs/ui";
 import { visibleWidth } from "../../pi/extensions/pi-harness/lib/terminal-text";
 
-const setup = () => {
+const setup = (rows = 20) => {
   let id = 0;
   const registry = new ChildRunRegistry({
     idFactory: () => `id-${++id}`,
@@ -12,7 +12,7 @@ const setup = () => {
   });
   const renders: number[] = [];
   const tui = {
-    terminal: { rows: 20 },
+    terminal: { rows },
     requestRender: () => renders.push(1),
   };
   const keybindings = {
@@ -49,12 +49,58 @@ const setup = () => {
   };
 };
 
+const addRuns = (registry: ChildRunRegistry, count: number): string[] =>
+  registry.beginInvocation({
+    toolCallId: `parent-${count}`,
+    source: "workflow",
+    label: "workflow",
+    runs: Array.from({ length: count }, (_, taskIndex) => ({
+      agent: `agent-${taskIndex}`,
+      task: `inspect task ${taskIndex}`,
+      taskIndex,
+      stageIndex: 0,
+    })),
+  }).runIds;
+
 describe("child-session browser component", () => {
   test("renders an explanatory empty state within width", () => {
     const { component } = setup();
     const lines = component.render(24);
     expect(lines.join("\n")).toContain("No child runs");
     expect(lines.every((item) => visibleWidth(item) <= 24)).toBe(true);
+  });
+
+  test("caps populated list height for common and small terminals", () => {
+    for (const [rows, expectedHeight] of [
+      [24, 6],
+      [40, 10],
+      [12, 4],
+    ] as const) {
+      const { registry, component } = setup(rows);
+      addRuns(registry, 30);
+      const lines = component.render(80);
+      expect(lines).toHaveLength(expectedHeight);
+      expect(lines.at(-1)).toContain("↑↓ select");
+    }
+  });
+
+  test("caps populated detail height and preserves its hint row", () => {
+    const { registry, component } = setup(24);
+    const [runId] = addRuns(registry, 1);
+    if (runId === undefined) throw new Error("run did not initialize");
+    registry.observe(runId, { type: "process_started", at: 1 });
+    for (let index = 0; index < 30; index++) {
+      registry.observe(runId, {
+        type: "assistant_final",
+        text: `line ${index}`,
+        at: index + 2,
+      });
+    }
+    component.render(80);
+    component.handleInput("enter");
+    const lines = component.render(80);
+    expect(lines).toHaveLength(6);
+    expect(lines.at(-1)).toContain("End live");
   });
 
   test("keeps selection stable by run id and opens the selected detail", () => {

--- a/tests/pi-harness/child-run-ui.test.ts
+++ b/tests/pi-harness/child-run-ui.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { TUI, type Component, type Terminal } from "@earendil-works/pi-tui";
+
 import { ChildRunRegistry } from "../../pi/extensions/pi-harness/features/child-runs/registry";
 import { ChildRunsBrowserComponent } from "../../pi/extensions/pi-harness/features/child-runs/ui";
 import { visibleWidth } from "../../pi/extensions/pi-harness/lib/terminal-text";
@@ -48,69 +48,6 @@ const setup = () => {
     getHidden: () => hidden,
   };
 };
-
-describe("pi-tui overlay focus contract", () => {
-  test("non-capturing mount keeps editor input and explicit focus survives a temporary modal", () => {
-    let onInput: ((data: string) => void) | undefined;
-    const terminal: Terminal = {
-      start(input) {
-        onInput = input;
-      },
-      stop() {},
-      drainInput: async () => {},
-      write() {},
-      columns: 120,
-      rows: 30,
-      kittyProtocolActive: false,
-      moveBy() {},
-      hideCursor() {},
-      showCursor() {},
-      clearLine() {},
-      clearFromCursor() {},
-      clearScreen() {},
-      setTitle() {},
-      setProgress() {},
-    };
-    const counts = { editor: 0, browser: 0, modal: 0 };
-    const component = (name: keyof typeof counts): Component => ({
-      render: () => [name],
-      invalidate() {},
-      handleInput() {
-        counts[name] += 1;
-      },
-    });
-    const editor = component("editor");
-    const browser = component("browser");
-    const modal = component("modal");
-    const tui = new TUI(terminal);
-    tui.addChild(editor);
-    tui.start();
-    tui.setFocus(editor);
-
-    const browserHandle = tui.showOverlay(browser, {
-      nonCapturing: true,
-      width: 40,
-      visible: () => true,
-    });
-    onInput?.("a");
-    expect(counts).toEqual({ editor: 1, browser: 0, modal: 0 });
-
-    browserHandle.focus();
-    onInput?.("b");
-    expect(counts.browser).toBe(1);
-    tui.showOverlay(modal, { width: 20 });
-    onInput?.("c");
-    expect(counts.modal).toBe(1);
-    tui.hideOverlay();
-    onInput?.("d");
-    expect(counts.browser).toBe(2);
-
-    browserHandle.unfocus();
-    onInput?.("e");
-    expect(counts.editor).toBe(2);
-    tui.stop();
-  });
-});
 
 describe("child-session browser component", () => {
   test("renders an explanatory empty state within width", () => {


### PR DESCRIPTION
## Summary

- render the child-run browser at full width below the chat editor so it no longer covers conversation content
- preserve native editor Down navigation and transfer focus only after the cursor reaches the bottom boundary
- keep Escape/q focus restoration reliable across Kitty key events and custom editors

## Testing

- `bun run run-all` (867 passed, 2 skipped)