### PR TITLE
fix(pi): make child transcript navigation reliable

### DIFF
--- a/pi/extensions/pi-harness/features/child-runs/README.md
+++ b/pi/extensions/pi-harness/features/child-runs/README.md
@@ -23,8 +23,14 @@ resident full-width TUI browser between the chat editor and statusline.
 - `Esc` returns focus to the main editor while leaving the browser visible.
 - `q` hides the browser. A new child run, `/subagents`, or the shortcut shows
   it again.
-- Arrow keys select runs and scroll transcripts. Enter opens a run, Left or
-  `b` returns to the list, and End resumes live-follow mode.
+- In the resident list, arrow keys only select runs. Enter opens the selected
+  run in a focused, near-full-screen overlay; raw Enter sequences are accepted
+  even when the editor keybinding adapter cannot classify them.
+- In the detail overlay, arrow keys only scroll that fixed transcript.
+  PageUp/PageDown move by a viewport, Home/End jump to the beginning/live end,
+  and Escape, Left, `b`, or `q` closes the overlay and returns to the list.
+- Completed transcripts open at the beginning. Running transcripts open in
+  live-follow mode; scrolling upward pauses follow until End is pressed.
 - The normal subagent/workflow tool row remains a compact status summary.
 
 Closing, hiding, or unfocusing the browser never cancels child execution.
@@ -61,11 +67,16 @@ raw source data.
 ## Interactive smoke check
 
 1. Start pi and launch a parallel `subagent` call or a multi-task `workflow`.
-2. Confirm the full-width browser appears below the editor and above the
+2. Confirm the full-width list appears below the editor and above the
    statusline without taking editor focus.
 3. In a multi-line draft, press Down and confirm native cursor movement still
-   works; at the bottom boundary, press Down again and confirm browser focus.
-4. Select a running child and verify live updates.
-5. Press `Esc` and confirm normal editor input continues.
-6. Press `q`, then run `/subagents` and confirm the same browser reappears.
-7. Resume the parent session and confirm completed transcripts are restored.
+   works; at the bottom boundary, press Down again and confirm list focus.
+4. Select a running child, press Enter, and confirm its near-full-screen detail
+   overlay opens with live updates.
+5. Press Up/PageUp and confirm the transcript scrolls while the selected run
+   remains fixed; press End and confirm live-follow resumes.
+6. Press Escape and confirm focus returns to the resident list, then Escape
+   again and confirm normal editor input continues.
+7. Press `q` in the list, then run `/subagents` and confirm it reappears.
+8. Resume the parent session and confirm completed transcripts open from the
+   beginning and remain scrollable within the documented retention bounds.

--- a/pi/extensions/pi-harness/features/child-runs/ui.ts
+++ b/pi/extensions/pi-harness/features/child-runs/ui.ts
@@ -42,6 +42,23 @@ interface WidgetUiLike {
     content: ((tui: TuiLike, theme: unknown) => ComponentLike) | undefined,
     options?: { placement: "belowEditor" },
   ): void;
+  custom?<T>(
+    factory: (
+      tui: TuiLike,
+      theme: unknown,
+      keybindings: KeybindingsLike,
+      done: (result: T) => void,
+    ) => ComponentLike,
+    options?: {
+      overlay?: boolean;
+      overlayOptions?: {
+        width?: number | `${number}%`;
+        maxHeight?: number | `${number}%`;
+        anchor?: string;
+        margin?: number;
+      };
+    },
+  ): Promise<T>;
   onTerminalInput?(
     handler: (data: string) => { consume?: boolean; data?: string } | undefined,
   ): () => void;
@@ -49,8 +66,6 @@ interface WidgetUiLike {
 }
 
 export type BrowserContextLike = CtxLike;
-
-type BrowserMode = "list" | "detail";
 
 type FlatRun = {
   invocation: ChildInvocationSnapshot;
@@ -65,6 +80,12 @@ const flattenRuns = (snapshots: ChildInvocationSnapshot[]): FlatRun[] =>
     invocation.runs.map((run) => ({ invocation, run })),
   );
 
+const findRun = (
+  snapshots: ChildInvocationSnapshot[],
+  runId: string | undefined,
+): FlatRun | undefined =>
+  flattenRuns(snapshots).find(({ run }) => run.runId === runId);
+
 const line = (value: string, width: number): string =>
   truncateToWidth(stripTerminalControls(value), Math.max(0, width), "");
 
@@ -73,11 +94,12 @@ const taskOneLine = (task: string): string =>
 
 const transcriptLines = (item: TranscriptItem, width: number): string[] => {
   if (item.type === "assistant") {
-    return ["assistant:"].concat(
-      wrapPlainText(item.text, Math.max(1, width - 2)).map(
+    return [
+      "assistant:",
+      ...wrapPlainText(item.text, Math.max(1, width - 2)).map(
         (part) => `  ${part}`,
       ),
-    );
+    ];
   }
   if (item.type === "tool") {
     let runStatus: ChildRunStatus = "succeeded";
@@ -94,18 +116,15 @@ const transcriptLines = (item: TranscriptItem, width: number): string[] => {
 };
 
 export class ChildRunsBrowserComponent implements ComponentLike {
-  private mode: BrowserMode = "list";
   private selectedRunId: string | undefined;
   private listOffset = 0;
-  private detailOffset = 0;
-  private follow = true;
-  private lastDetailMaxOffset = 0;
   private readonly unsubscribe: () => void;
 
   constructor(
     private readonly registry: ChildRunRegistry,
     private readonly tui: TuiLike,
     private readonly keybindings: KeybindingsLike,
+    private readonly onInspect: (runId: string) => void,
     private readonly onUnfocus: () => void,
     private readonly onHide: () => void,
   ) {
@@ -131,22 +150,13 @@ export class ChildRunsBrowserComponent implements ComponentLike {
       this.selectedRunId = runs[0]?.run.runId;
     }
 
-    const body =
-      this.mode === "detail"
-        ? this.renderDetail(runs, safeWidth, height - 2)
-        : this.renderList(snapshots, runs, safeWidth, height - 2);
-    const title =
-      this.mode === "detail" ? " Child session " : " Child sessions ";
+    const body = this.renderList(snapshots, runs, safeWidth, height - 2);
+    const title = " Child sessions ";
     const borderWidth = Math.max(1, safeWidth - visibleWidth(title));
     return [
       line(`${title}${"─".repeat(borderWidth)}`, safeWidth),
       ...body,
-      line(
-        this.mode === "detail"
-          ? "←/b list  ↑↓ scroll  End live  Esc unfocus  q hide"
-          : "↑↓ select  Enter inspect  Esc unfocus  q hide",
-        safeWidth,
-      ),
+      line("↑↓ select  Enter inspect  Esc unfocus  q hide", safeWidth),
     ].slice(0, height);
   }
 
@@ -161,57 +171,29 @@ export class ChildRunsBrowserComponent implements ComponentLike {
       return;
     }
 
-    if (this.mode === "list") {
-      const current = Math.max(
-        0,
-        runs.findIndex(({ run }) => run.runId === this.selectedRunId),
-      );
-      if (this.matches(data, "tui.select.up") || data === "k") {
-        this.selectedRunId = runs[Math.max(0, current - 1)]?.run.runId;
-      } else if (this.matches(data, "tui.select.down") || data === "j") {
-        this.selectedRunId =
-          runs[Math.min(runs.length - 1, current + 1)]?.run.runId;
-      } else if (this.matches(data, "tui.select.pageUp")) {
-        this.selectedRunId = runs[Math.max(0, current - 8)]?.run.runId;
-      } else if (this.matches(data, "tui.select.pageDown")) {
-        this.selectedRunId =
-          runs[Math.min(runs.length - 1, current + 8)]?.run.runId;
-      } else if (
-        this.matches(data, "tui.select.confirm") ||
-        this.matches(data, "tui.editor.cursorRight")
-      ) {
-        if (this.selectedRunId !== undefined) {
-          this.mode = "detail";
-          this.follow = true;
-          this.detailOffset = 0;
-        }
-      } else return;
-    } else {
-      if (data === "b" || this.matches(data, "tui.editor.cursorLeft")) {
-        this.mode = "list";
-      } else if (this.matches(data, "tui.select.up") || data === "k") {
-        this.follow = false;
-        this.detailOffset = Math.max(0, this.detailOffset - 1);
-      } else if (this.matches(data, "tui.select.pageUp")) {
-        this.follow = false;
-        this.detailOffset = Math.max(0, this.detailOffset - 8);
-      } else if (this.matches(data, "tui.select.down") || data === "j") {
-        this.detailOffset = Math.min(
-          this.lastDetailMaxOffset,
-          this.detailOffset + 1,
-        );
-        this.follow = this.detailOffset >= this.lastDetailMaxOffset;
-      } else if (this.matches(data, "tui.select.pageDown")) {
-        this.detailOffset = Math.min(
-          this.lastDetailMaxOffset,
-          this.detailOffset + 8,
-        );
-        this.follow = this.detailOffset >= this.lastDetailMaxOffset;
-      } else if (this.matches(data, "tui.editor.cursorLineEnd")) {
-        this.follow = true;
-        this.detailOffset = this.lastDetailMaxOffset;
-      } else return;
-    }
+    const current = Math.max(
+      0,
+      runs.findIndex(({ run }) => run.runId === this.selectedRunId),
+    );
+    if (this.matches(data, "tui.select.up") || data === "k") {
+      this.selectedRunId = runs[Math.max(0, current - 1)]?.run.runId;
+    } else if (this.matches(data, "tui.select.down") || data === "j") {
+      this.selectedRunId =
+        runs[Math.min(runs.length - 1, current + 1)]?.run.runId;
+    } else if (this.matches(data, "tui.select.pageUp")) {
+      this.selectedRunId = runs[Math.max(0, current - 8)]?.run.runId;
+    } else if (this.matches(data, "tui.select.pageDown")) {
+      this.selectedRunId =
+        runs[Math.min(runs.length - 1, current + 8)]?.run.runId;
+    } else if (
+      this.matches(data, "tui.select.confirm") ||
+      defaultKeyMatches(data, "tui.select.confirm") ||
+      this.matches(data, "tui.editor.cursorRight")
+    ) {
+      if (this.selectedRunId !== undefined) {
+        this.onInspect(this.selectedRunId);
+      }
+    } else return;
     this.tui.requestRender();
   }
 
@@ -223,10 +205,6 @@ export class ChildRunsBrowserComponent implements ComponentLike {
 
   getSelectedRunId(): string | undefined {
     return this.selectedRunId;
-  }
-
-  getMode(): BrowserMode {
-    return this.mode;
   }
 
   private renderList(
@@ -277,56 +255,184 @@ export class ChildRunsBrowserComponent implements ComponentLike {
       .map((item) => line(item.text, width));
   }
 
-  private renderDetail(
-    runs: FlatRun[],
-    width: number,
-    viewport: number,
-  ): string[] {
-    const selected = runs.find(({ run }) => run.runId === this.selectedRunId);
-    if (selected === undefined) {
-      this.mode = "list";
-      return [line("Selected child run is no longer available.", width)];
+  private matches(data: string, keybinding: string): boolean {
+    try {
+      return this.keybindings.matches(data, keybinding);
+    } catch {
+      return false;
     }
-    const { invocation, run } = selected;
-    const allLines: string[] = [
-      `${run.agent} · ${statusLabel(run.status)}`,
-      `${invocation.label}${run.stageName ? ` · ${run.stageName}` : ""}`,
-      `task: ${taskOneLine(run.task)}`,
-      "",
-    ];
-    for (const item of run.transcript) {
-      allLines.push(...transcriptLines(item, width));
+  }
+}
+
+const detailContentLines = (selected: FlatRun, width: number): string[] => {
+  const { invocation, run } = selected;
+  const lines: string[] = [
+    `${run.agent} · ${statusLabel(run.status)}`,
+    `${invocation.label}${run.stageName ? ` · ${run.stageName}` : ""}`,
+    `task: ${taskOneLine(run.task)}`,
+    "",
+  ];
+  for (const item of run.transcript) {
+    lines.push(...transcriptLines(item, width));
+  }
+  if (run.liveDraft) {
+    lines.push("assistant [live]:");
+    lines.push(
+      ...wrapPlainText(run.liveDraft, Math.max(1, width - 2)).map(
+        (part) => `  ${part}`,
+      ),
+    );
+  }
+  if (run.transcript.length === 0 && !run.liveDraft) {
+    lines.push(
+      run.status === "queued" ? "(not launched)" : "(no assistant text yet)",
+    );
+  }
+  if (run.protocolWarnings > 0) {
+    lines.push(`(${run.protocolWarnings} child stream warning(s))`);
+  }
+  return lines;
+};
+
+/** Focused, near-full-screen transcript viewer for one fixed child run. */
+export class ChildRunDetailComponent implements ComponentLike {
+  private offset = 0;
+  private follow: boolean;
+  private lastMaxOffset = 0;
+  private lastViewport = 1;
+  private readonly unsubscribe: () => void;
+
+  constructor(
+    private readonly registry: ChildRunRegistry,
+    private readonly runId: string,
+    private readonly tui: TuiLike,
+    private readonly keybindings: KeybindingsLike,
+    private readonly onClose: () => void,
+  ) {
+    const initialStatus = findRun(this.registry.getSnapshots(), this.runId)?.run
+      .status;
+    this.follow = initialStatus === "queued" || initialStatus === "running";
+    this.unsubscribe = registry.subscribe(() => this.tui.requestRender());
+  }
+
+  render(width: number): string[] {
+    const safeWidth = Math.max(1, width);
+    // The overlay uses a one-cell margin on each side, so rows - 2 fills the
+    // available height without competing with the resident editor-flow panel.
+    // On tiny terminals, drop the hint and then the title before reducing the
+    // transcript to zero visible rows.
+    const height = Math.max(1, this.tui.terminal.rows - 2);
+    const showTitle = height >= 2;
+    const showHint = height >= 3;
+    const chrome = Number(showTitle) + Number(showHint);
+    const viewport = Math.max(1, height - chrome);
+    this.lastViewport = viewport;
+    const selected = findRun(this.registry.getSnapshots(), this.runId);
+    const allLines =
+      selected === undefined
+        ? ["Selected child run is no longer available."]
+        : detailContentLines(selected, safeWidth);
+
+    this.lastMaxOffset = Math.max(0, allLines.length - viewport);
+    if (this.follow) this.offset = this.lastMaxOffset;
+    else this.offset = Math.min(this.offset, this.lastMaxOffset);
+
+    const visible = allLines.slice(this.offset, this.offset + viewport);
+    while (visible.length < viewport) visible.push("");
+
+    const running = selected?.run.status === "running";
+    let state = "";
+    if (running && this.follow) state = " · LIVE";
+    else if (!this.follow) state = " · PAUSED";
+    const title = ` Child session${state} `;
+    const borderWidth = Math.max(1, safeWidth - visibleWidth(title));
+    const first = allLines.length === 0 ? 0 : this.offset + 1;
+    const last = Math.min(allLines.length, this.offset + viewport);
+    const position = `${first}-${last}/${allLines.length}`;
+    const output: string[] = [];
+    if (showTitle) {
+      output.push(line(`${title}${"─".repeat(borderWidth)}`, safeWidth));
     }
-    if (run.liveDraft) {
-      allLines.push("assistant [live]:");
-      allLines.push(
-        ...wrapPlainText(run.liveDraft, Math.max(1, width - 2)).map(
-          (part) => `  ${part}`,
+    output.push(...visible.map((item) => line(item, safeWidth)));
+    if (showHint) {
+      output.push(
+        line(
+          `↑↓ scroll  PgUp/PgDn page  Home/End  Esc/←/b close  ${position}`,
+          safeWidth,
         ),
       );
     }
-    if (run.transcript.length === 0 && !run.liveDraft) {
-      allLines.push(
-        run.status === "queued" ? "(not launched)" : "(no assistant text yet)",
-      );
+    return output.slice(0, height);
+  }
+
+  handleInput(data: string): void {
+    if (
+      data === "q" ||
+      data === "b" ||
+      this.matches(data, "tui.select.cancel") ||
+      this.matches(data, "tui.editor.cursorLeft") ||
+      defaultKeyMatches(data, "tui.select.cancel") ||
+      defaultKeyMatches(data, "tui.editor.cursorLeft")
+    ) {
+      this.onClose();
+      return;
     }
-    if (run.protocolWarnings > 0) {
-      allLines.push(`(${run.protocolWarnings} child stream warning(s))`);
-    }
-    this.lastDetailMaxOffset = Math.max(0, allLines.length - viewport);
-    if (this.follow) this.detailOffset = this.lastDetailMaxOffset;
-    else
-      this.detailOffset = Math.min(this.detailOffset, this.lastDetailMaxOffset);
-    const visible = allLines.slice(
-      this.detailOffset,
-      this.detailOffset + Math.max(1, viewport),
-    );
-    if (this.follow && run.status === "running") {
-      visible[0] = `[LIVE] ${visible[0] ?? ""}`;
-    } else if (!this.follow) {
-      visible[0] = `[PAUSED] ${visible[0] ?? ""}`;
-    }
-    return visible.map((item) => line(item, width));
+
+    const page = Math.max(1, this.lastViewport - 1);
+    if (
+      data === "k" ||
+      this.matches(data, "tui.select.up") ||
+      defaultKeyMatches(data, "tui.select.up")
+    ) {
+      this.follow = false;
+      this.offset = Math.max(0, this.offset - 1);
+    } else if (
+      this.matches(data, "tui.select.pageUp") ||
+      defaultKeyMatches(data, "tui.select.pageUp")
+    ) {
+      this.follow = false;
+      this.offset = Math.max(0, this.offset - page);
+    } else if (
+      data === "j" ||
+      this.matches(data, "tui.select.down") ||
+      defaultKeyMatches(data, "tui.select.down")
+    ) {
+      this.offset = Math.min(this.lastMaxOffset, this.offset + 1);
+      this.follow = this.offset >= this.lastMaxOffset;
+    } else if (
+      this.matches(data, "tui.select.pageDown") ||
+      defaultKeyMatches(data, "tui.select.pageDown")
+    ) {
+      this.offset = Math.min(this.lastMaxOffset, this.offset + page);
+      this.follow = this.offset >= this.lastMaxOffset;
+    } else if (
+      this.matches(data, "tui.editor.cursorLineStart") ||
+      defaultKeyMatches(data, "tui.editor.cursorLineStart")
+    ) {
+      this.follow = false;
+      this.offset = 0;
+    } else if (
+      this.matches(data, "tui.editor.cursorLineEnd") ||
+      defaultKeyMatches(data, "tui.editor.cursorLineEnd")
+    ) {
+      this.follow = true;
+      this.offset = this.lastMaxOffset;
+    } else return;
+    this.tui.requestRender();
+  }
+
+  invalidate(): void {}
+
+  dispose(): void {
+    this.unsubscribe();
+  }
+
+  getOffset(): number {
+    return this.offset;
+  }
+
+  isFollowing(): boolean {
+    return this.follow;
   }
 
   private matches(data: string, keybinding: string): boolean {
@@ -353,6 +459,7 @@ const defaultKeyMatches = (data: string, keybinding: string): boolean => {
     "tui.editor.cursorDown": ["down", "\u001b[B"],
     "tui.editor.cursorLeft": ["left", "\u001b[D"],
     "tui.editor.cursorRight": ["right", "\u001b[C"],
+    "tui.editor.cursorLineStart": ["home", "\u001b[H", "\u001b[1~"],
     "tui.editor.cursorLineEnd": ["end", "\u001b[F", "\u001b[4~"],
     "tui.select.up": ["up", "\u001b[A"],
     "tui.select.down": ["down", "\u001b[B"],
@@ -369,6 +476,7 @@ const defaultKeyMatches = (data: string, keybinding: string): boolean => {
     "tui.editor.cursorDown": /^1;1(?::[12])?B$/,
     "tui.editor.cursorLeft": /^1;1(?::[12])?D$/,
     "tui.editor.cursorRight": /^1;1(?::[12])?C$/,
+    "tui.editor.cursorLineStart": /^(?:1;1(?::[12])?H|7;1(?::[12])?~)$/,
     "tui.editor.cursorLineEnd": /^(?:1;1(?::[12])?F|8;1(?::[12])?~)$/,
     "tui.select.up": /^1;1(?::[12])?A$/,
     "tui.select.down": /^1;1(?::[12])?B$/,
@@ -417,6 +525,8 @@ export class ChildRunsPanelController {
   private tui: TuiLike | undefined;
   private ui: WidgetUiLike | undefined;
   private unsubscribeInput: (() => void) | undefined;
+  private detailClose: (() => void) | undefined;
+  private detailPromise: Promise<void> | undefined;
   private readonly keybindings: KeybindingsLike = {
     matches: (data, keybinding) =>
       this.editor?.keybindings?.matches(data, keybinding) ??
@@ -435,6 +545,8 @@ export class ChildRunsPanelController {
 
   dispose(): void {
     if (this.state === "disposed") return;
+    this.detailClose?.();
+    this.detailClose = undefined;
     if (this.tui?.focusedComponent === this.component) this.restoreFocus();
     if (this.state === "mounted") {
       this.ui?.setWidget(CHILD_RUNS_WIDGET_KEY, undefined);
@@ -473,6 +585,7 @@ export class ChildRunsPanelController {
             this.registry,
             tui,
             this.keybindings,
+            (runId) => this.openDetail(runId),
             () => this.restoreFocus(),
             () => this.hide(),
           );
@@ -499,6 +612,69 @@ export class ChildRunsPanelController {
     }
   }
 
+  private openDetail(runId: string): void {
+    const { ui } = this;
+    if (ui?.custom === undefined) {
+      ui?.notify(
+        "Child-session detail view requires custom TUI support.",
+        "warning",
+      );
+      return;
+    }
+    if (this.detailPromise !== undefined) return;
+
+    let detailPromise: Promise<void>;
+    try {
+      detailPromise = ui.custom<void>(
+        (tui, _theme, keybindings, done) => {
+          let closed = false;
+          const close = () => {
+            if (closed) return;
+            closed = true;
+            done(undefined);
+          };
+          this.detailClose = close;
+          return new ChildRunDetailComponent(
+            this.registry,
+            runId,
+            tui,
+            keybindings,
+            close,
+          );
+        },
+        {
+          overlay: true,
+          overlayOptions: {
+            width: "100%",
+            maxHeight: "100%",
+            anchor: "center",
+            margin: 1,
+          },
+        },
+      );
+    } catch (error) {
+      ui.notify(
+        `Child-session detail view could not open: ${String(error)}`,
+        "warning",
+      );
+      return;
+    }
+
+    this.detailPromise = detailPromise;
+    void detailPromise
+      .catch((error) => {
+        ui.notify(
+          `Child-session detail view could not open: ${String(error)}`,
+          "warning",
+        );
+      })
+      .finally(() => {
+        if (this.detailPromise !== detailPromise) return;
+        this.detailPromise = undefined;
+        this.detailClose = undefined;
+      });
+  }
+
   private installInputListener(ui: WidgetUiLike): void {
     if (this.unsubscribeInput !== undefined || ui.onTerminalInput === undefined)
       return;
@@ -519,16 +695,10 @@ export class ChildRunsPanelController {
     }
 
     const focused = this.tui.focusedComponent;
-    if (focused === this.component) return undefined;
+    if (focused === this.component || !isEditorLike(focused)) return undefined;
     this.captureFocusTarget(focused);
-    const editor = this.editor;
-    if (
-      editor === undefined ||
-      focused !== editor ||
-      editor.isShowingAutocomplete?.() === true
-    ) {
-      return undefined;
-    }
+    const editor = focused;
+    if (editor.isShowingAutocomplete?.() === true) return undefined;
 
     const beforeText = editor.getText();
     const beforeCursor = editor.getCursor();

--- a/tests/pi-harness/child-run-integration.test.ts
+++ b/tests/pi-harness/child-run-integration.test.ts
@@ -105,6 +105,14 @@ const createRuntime = (cwd: string) => {
   let widgetCalls = 0;
   let component: RuntimeComponent | undefined;
   let widgetPlacement: string | undefined;
+  let customCalls = 0;
+  let customComponent: RuntimeComponent | undefined;
+  let customOptions:
+    | {
+        overlay?: boolean;
+        overlayOptions?: Record<string, unknown>;
+      }
+    | undefined;
   let terminalInputHandler:
     | ((data: string) => { consume?: boolean; data?: string } | undefined)
     | undefined;
@@ -135,6 +143,35 @@ const createRuntime = (cwd: string) => {
         }
         widgetPlacement = options?.placement;
         component = content(tui, {});
+      },
+      custom(
+        factory: (
+          customTui: typeof tui,
+          theme: unknown,
+          customKeybindings: typeof keybindings,
+          done: (value: unknown) => void,
+        ) => RuntimeComponent,
+        options?: {
+          overlay?: boolean;
+          overlayOptions?: Record<string, unknown>;
+        },
+      ) {
+        customCalls += 1;
+        customOptions = options;
+        const previousFocus = tui.focusedComponent;
+        return new Promise<unknown>((resolve) => {
+          let closed = false;
+          const done = (value: unknown) => {
+            if (closed) return;
+            closed = true;
+            customComponent?.dispose?.();
+            customComponent = undefined;
+            tui.setFocus(previousFocus);
+            resolve(value);
+          };
+          customComponent = factory(tui, {}, keybindings, done);
+          tui.setFocus(customComponent);
+        });
       },
       onTerminalInput(
         handler: (
@@ -187,6 +224,9 @@ const createRuntime = (cwd: string) => {
     getWidgetCalls: () => widgetCalls,
     getComponent: () => component,
     getWidgetPlacement: () => widgetPlacement,
+    getCustomCalls: () => customCalls,
+    getCustomComponent: () => customComponent,
+    getCustomOptions: () => customOptions,
     setEditorState(lines: string[], line: number, col: number) {
       editorLines = [...lines];
       editorCursor = { line, col };
@@ -513,6 +553,74 @@ describe("child-run subagent integration", () => {
     runtime.setBranch([]);
     await runtime.emit("session_tree", { type: "session_tree" });
     expect(childRuns.registry.getSnapshots()).toEqual([]);
+  });
+
+  test("Enter opens a focused transcript overlay whose arrows do not move the run list", () => {
+    const runtime = createRuntime("/tmp/pi-child-detail-overlay");
+    const childRuns = setupChildRuns(runtime.pi);
+    const started = childRuns.registry.beginInvocation({
+      toolCallId: "overlay-parent",
+      source: "workflow",
+      label: "workflow",
+      runs: [
+        { agent: "one", task: "first", taskIndex: 0, stageIndex: 0 },
+        { agent: "two", task: "second", taskIndex: 1, stageIndex: 0 },
+      ],
+    });
+    const [, selectedRunId] = started.runIds;
+    if (selectedRunId === undefined)
+      throw new Error("second child run did not initialize");
+    childRuns.registry.observe(selectedRunId, {
+      type: "process_started",
+      at: 1,
+    });
+    for (let index = 0; index < 30; index++) {
+      childRuns.registry.observe(selectedRunId, {
+        type: "assistant_final",
+        text: `detail line ${index}`,
+        at: index + 2,
+      });
+    }
+    childRuns.ensureVisible(runtime.ctx);
+    const panel = runtime.getComponent() as
+      | (RuntimeComponent & { getSelectedRunId(): string | undefined })
+      | undefined;
+    if (panel === undefined) throw new Error("child-run panel did not mount");
+    panel.render(80);
+    runtime.tui.setFocus(panel);
+
+    runtime.dispatchInput("down");
+    expect(panel.getSelectedRunId()).toBe(selectedRunId);
+    runtime.dispatchInput("\r");
+
+    const detail = runtime.getCustomComponent();
+    if (detail === undefined) throw new Error("detail overlay did not mount");
+    expect(runtime.getCustomCalls()).toBe(1);
+    expect(runtime.getCustomOptions()).toMatchObject({
+      overlay: true,
+      overlayOptions: { width: "100%", maxHeight: "100%", margin: 1 },
+    });
+    expect(runtime.tui.focusedComponent).toBe(detail);
+    expect(detail.render(80)[0]).toContain("LIVE");
+
+    runtime.dispatchInput("up");
+    expect(detail.render(80)[0]).toContain("PAUSED");
+    expect(panel.getSelectedRunId()).toBe(selectedRunId);
+
+    runtime.dispatchInput("down");
+    expect(detail.render(80)[0]).toContain("LIVE");
+    expect(panel.getSelectedRunId()).toBe(selectedRunId);
+    for (const kittyDown of ["\u001b[1;1:1B", "\u001b[1;1:2B"]) {
+      runtime.dispatchInput("up");
+      runtime.dispatchInput(kittyDown);
+      expect(detail.render(80)[0]).toContain("LIVE");
+      expect(panel.getSelectedRunId()).toBe(selectedRunId);
+    }
+
+    runtime.dispatchInput("escape");
+    expect(runtime.getCustomComponent()).toBeUndefined();
+    expect(runtime.tui.focusedComponent).toBe(panel);
+    expect(panel.getSelectedRunId()).toBe(selectedRunId);
   });
 
   test("Down transfers focus only after native editor navigation reaches its bottom boundary", () => {

--- a/tests/pi-harness/child-run-layout.test.ts
+++ b/tests/pi-harness/child-run-layout.test.ts
@@ -80,6 +80,7 @@ const createLayout = (rows: number, columns: number) => {
     { matches: () => false },
     () => {},
     () => {},
+    () => {},
   );
   const footer = new Text("footer-main\nfooter-detail", 0, 0);
 

--- a/tests/pi-harness/child-run-ui.test.ts
+++ b/tests/pi-harness/child-run-ui.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import { ChildRunRegistry } from "../../pi/extensions/pi-harness/features/child-runs/registry";
-import { ChildRunsBrowserComponent } from "../../pi/extensions/pi-harness/features/child-runs/ui";
+import {
+  ChildRunDetailComponent,
+  ChildRunsBrowserComponent,
+} from "../../pi/extensions/pi-harness/features/child-runs/ui";
 import { visibleWidth } from "../../pi/extensions/pi-harness/lib/terminal-text";
 
 const setup = (rows = 20) => {
@@ -26,24 +29,30 @@ const setup = (rows = 20) => {
         "tui.select.cancel": "escape",
         "tui.editor.cursorLeft": "left",
         "tui.editor.cursorRight": "right",
+        "tui.editor.cursorLineStart": "home",
         "tui.editor.cursorLineEnd": "end",
       };
       return values[key] === data;
     },
   };
+  const inspected: string[] = [];
   let unfocused = 0;
   let hidden = 0;
   const component = new ChildRunsBrowserComponent(
     registry,
     tui,
     keybindings,
+    (runId) => inspected.push(runId),
     () => unfocused++,
     () => hidden++,
   );
   return {
     registry,
     component,
+    tui,
+    keybindings,
     renders,
+    inspected,
     getUnfocused: () => unfocused,
     getHidden: () => hidden,
   };
@@ -61,6 +70,27 @@ const addRuns = (registry: ChildRunRegistry, count: number): string[] =>
       stageIndex: 0,
     })),
   }).runIds;
+
+const runAt = (runIds: string[], index: number): string => {
+  const runId = runIds[index];
+  if (runId === undefined) throw new Error(`run ${index} did not initialize`);
+  return runId;
+};
+
+const addTranscript = (
+  registry: ChildRunRegistry,
+  runId: string,
+  count: number,
+): void => {
+  registry.observe(runId, { type: "process_started", at: 1 });
+  for (let index = 0; index < count; index++) {
+    registry.observe(runId, {
+      type: "assistant_final",
+      text: `line ${index}`,
+      at: index + 2,
+    });
+  }
+};
 
 describe("child-session browser component", () => {
   test("renders an explanatory empty state within width", () => {
@@ -84,27 +114,18 @@ describe("child-session browser component", () => {
     }
   });
 
-  test("caps populated detail height and preserves its hint row", () => {
-    const { registry, component } = setup(24);
-    const [runId] = addRuns(registry, 1);
-    if (runId === undefined) throw new Error("run did not initialize");
-    registry.observe(runId, { type: "process_started", at: 1 });
-    for (let index = 0; index < 30; index++) {
-      registry.observe(runId, {
-        type: "assistant_final",
-        text: `line ${index}`,
-        at: index + 2,
-      });
-    }
+  test("routes raw Enter to the selected run", () => {
+    const { registry, component, inspected } = setup();
+    const runIds = addRuns(registry, 2);
     component.render(80);
-    component.handleInput("enter");
-    const lines = component.render(80);
-    expect(lines).toHaveLength(6);
-    expect(lines.at(-1)).toContain("End live");
+    component.handleInput("down");
+    component.handleInput("\r");
+    expect(inspected).toEqual([runIds[1]]);
+    expect(component.getSelectedRunId()).toBe(runIds[1]);
   });
 
-  test("keeps selection stable by run id and opens the selected detail", () => {
-    const { registry, component } = setup();
+  test("keeps selection stable by run id while opening its detail viewer", () => {
+    const { registry, component, inspected } = setup();
     const started = registry.beginInvocation({
       toolCallId: "parent",
       source: "workflow",
@@ -117,67 +138,14 @@ describe("child-session browser component", () => {
     component.render(40);
     component.handleInput("down");
     expect(component.getSelectedRunId()).toBe(started.runIds[1]);
-    registry.observe(started.runIds[0]!, { type: "process_started", at: 1 });
+    registry.observe(runAt(started.runIds, 0), {
+      type: "process_started",
+      at: 1,
+    });
     expect(component.getSelectedRunId()).toBe(started.runIds[1]);
     component.handleInput("enter");
-    expect(component.getMode()).toBe("detail");
-    expect(component.render(40).join("\n")).toContain("second");
-  });
-
-  test("sanitizes and width-bounds assistant transcript rendering", () => {
-    const { registry, component } = setup();
-    const { runIds } = registry.beginInvocation({
-      toolCallId: "parent",
-      source: "subagent",
-      mode: "single",
-      label: "subagent",
-      runs: [
-        {
-          agent: "worker\u001b]2;spoof\u0007",
-          task: "inspect 界😀",
-          taskIndex: 0,
-        },
-      ],
-    });
-    registry.observe(runIds[0]!, { type: "process_started", at: 1 });
-    registry.observe(runIds[0]!, {
-      type: "assistant_final",
-      text: "answer\u001b[31m red\u001b[0m 界😀".repeat(10),
-      at: 2,
-    });
-    component.render(28);
-    component.handleInput("enter");
-    const lines = component.render(28);
-    expect(lines.join("\n")).toContain("answer red");
-    expect(lines.join("\n")).not.toContain("\u001b");
-    expect(lines.every((item) => visibleWidth(item) <= 28)).toBe(true);
-  });
-
-  test("pauses live follow on upward scroll and resumes with End", () => {
-    const { registry, component } = setup();
-    const { runIds } = registry.beginInvocation({
-      toolCallId: "parent",
-      source: "subagent",
-      mode: "single",
-      label: "subagent",
-      runs: [{ agent: "worker", task: "inspect", taskIndex: 0 }],
-    });
-    const runId = runIds[0]!;
-    registry.observe(runId, { type: "process_started", at: 1 });
-    for (let index = 0; index < 30; index++) {
-      registry.observe(runId, {
-        type: "assistant_final",
-        text: `line ${index}`,
-        at: index + 2,
-      });
-    }
-    component.render(40);
-    component.handleInput("enter");
-    component.render(40);
-    component.handleInput("up");
-    expect(component.render(40)[1]).toContain("[PAUSED]");
-    component.handleInput("end");
-    expect(component.render(40)[1]).toContain("[LIVE]");
+    expect(inspected).toEqual([started.runIds[1]]);
+    expect(component.getSelectedRunId()).toBe(started.runIds[1]);
   });
 
   test("Escape unfocuses and q hides without changing run state", () => {
@@ -193,6 +161,203 @@ describe("child-session browser component", () => {
     component.handleInput("q");
     expect(getUnfocused()).toBe(1);
     expect(getHidden()).toBe(1);
-    expect(registry.getRunStatus(runIds[0]!)).toBe("queued");
+    expect(registry.getRunStatus(runAt(runIds, 0))).toBe("queued");
+  });
+});
+
+describe("child-session detail component", () => {
+  test("uses the near-full terminal height and starts completed output at the top", () => {
+    const { registry, tui, keybindings } = setup(24);
+    const [runId] = addRuns(registry, 1);
+    if (runId === undefined) throw new Error("run did not initialize");
+    addTranscript(registry, runId, 30);
+    registry.finishRun(runId, {
+      status: "succeeded",
+      reason: "completed",
+      endedAt: 100,
+    });
+    const detail = new ChildRunDetailComponent(
+      registry,
+      runId,
+      tui,
+      keybindings,
+      () => {},
+    );
+
+    const lines = detail.render(80);
+    expect(lines).toHaveLength(22);
+    expect(lines[0]).toContain("Child session");
+    expect(lines[1]).toContain("agent-0");
+    expect(lines.at(-1)).toContain("Home/End");
+  });
+
+  test("keeps automatic follow when a queued run starts producing output", () => {
+    const { registry, tui, keybindings } = setup(12);
+    const [runId] = addRuns(registry, 1);
+    if (runId === undefined) throw new Error("run did not initialize");
+    const detail = new ChildRunDetailComponent(
+      registry,
+      runId,
+      tui,
+      keybindings,
+      () => {},
+    );
+    detail.render(80);
+
+    addTranscript(registry, runId, 20);
+    const lines = detail.render(80);
+    expect(detail.isFollowing()).toBe(true);
+    expect(detail.getOffset()).toBeGreaterThan(0);
+    expect(lines[0]).toContain("LIVE");
+  });
+
+  test("keeps the last transcript line reachable on tiny terminals", () => {
+    for (const [rows, expectedHeight] of [
+      [4, 2],
+      [3, 1],
+    ] as const) {
+      const { registry, tui, keybindings } = setup(rows);
+      const [runId] = addRuns(registry, 1);
+      if (runId === undefined) throw new Error("run did not initialize");
+      addTranscript(registry, runId, 6);
+      registry.finishRun(runId, {
+        status: "succeeded",
+        reason: "completed",
+        endedAt: 100,
+      });
+      const detail = new ChildRunDetailComponent(
+        registry,
+        runId,
+        tui,
+        keybindings,
+        () => {},
+      );
+      detail.render(40);
+      detail.handleInput("end");
+
+      const lines = detail.render(40);
+      expect(lines).toHaveLength(expectedHeight);
+      expect(lines.join("\n")).toContain("line 5");
+    }
+  });
+
+  test("scrolls one fixed transcript without moving the resident list selection", () => {
+    const { registry, component, tui, keybindings, inspected } = setup(12);
+    const runIds = addRuns(registry, 2);
+    const runId = runAt(runIds, 1);
+    addTranscript(registry, runId, 30);
+    registry.finishRun(runId, {
+      status: "succeeded",
+      reason: "completed",
+      endedAt: 100,
+    });
+    component.render(80);
+    component.handleInput("down");
+    component.handleInput("enter");
+    const detail = new ChildRunDetailComponent(
+      registry,
+      runAt(inspected, 0),
+      tui,
+      keybindings,
+      () => {},
+    );
+    detail.render(80);
+
+    detail.handleInput("down");
+    detail.handleInput("pagedown");
+    expect(detail.getOffset()).toBeGreaterThan(0);
+    expect(component.getSelectedRunId()).toBe(runId);
+
+    detail.handleInput("home");
+    expect(detail.getOffset()).toBe(0);
+    detail.handleInput("end");
+    expect(detail.isFollowing()).toBe(true);
+    expect(component.getSelectedRunId()).toBe(runId);
+  });
+
+  test("sanitizes and width-bounds assistant transcript rendering", () => {
+    const { registry, tui, keybindings } = setup();
+    const { runIds } = registry.beginInvocation({
+      toolCallId: "parent",
+      source: "subagent",
+      mode: "single",
+      label: "subagent",
+      runs: [
+        {
+          agent: "worker\u001b]2;spoof\u0007",
+          task: "inspect 界😀",
+          taskIndex: 0,
+        },
+      ],
+    });
+    const runId = runAt(runIds, 0);
+    registry.observe(runId, { type: "process_started", at: 1 });
+    registry.observe(runId, {
+      type: "assistant_final",
+      text: "answer\u001b[31m red\u001b[0m 界😀".repeat(10),
+      at: 2,
+    });
+    registry.finishRun(runId, {
+      status: "succeeded",
+      reason: "completed",
+      endedAt: 3,
+    });
+    const detail = new ChildRunDetailComponent(
+      registry,
+      runId,
+      tui,
+      keybindings,
+      () => {},
+    );
+
+    const lines = detail.render(28);
+    expect(lines.join("\n")).toContain("answer red");
+    expect(lines.join("\n")).not.toContain("\u001b");
+    expect(lines.every((item) => visibleWidth(item) <= 28)).toBe(true);
+  });
+
+  test("pauses live follow on upward scroll and resumes with End", () => {
+    const { registry, tui, keybindings } = setup();
+    const { runIds } = registry.beginInvocation({
+      toolCallId: "parent",
+      source: "subagent",
+      mode: "single",
+      label: "subagent",
+      runs: [{ agent: "worker", task: "inspect", taskIndex: 0 }],
+    });
+    const runId = runAt(runIds, 0);
+    addTranscript(registry, runId, 30);
+    const detail = new ChildRunDetailComponent(
+      registry,
+      runId,
+      tui,
+      keybindings,
+      () => {},
+    );
+    detail.render(40);
+
+    detail.handleInput("up");
+    expect(detail.render(40)[0]).toContain("PAUSED");
+    detail.handleInput("end");
+    expect(detail.render(40)[0]).toContain("LIVE");
+  });
+
+  test("Escape, Left, and b close the detail viewer", () => {
+    const { registry, tui, keybindings } = setup();
+    const [runId] = addRuns(registry, 1);
+    if (runId === undefined) throw new Error("run did not initialize");
+    let closes = 0;
+    const detail = new ChildRunDetailComponent(
+      registry,
+      runId,
+      tui,
+      keybindings,
+      () => closes++,
+    );
+
+    detail.handleInput("escape");
+    detail.handleInput("left");
+    detail.handleInput("b");
+    expect(closes).toBe(3);
   });
 });


### PR DESCRIPTION
## Summary

- keep the resident child-run panel focused on run selection and open transcripts in a dedicated near-full-screen overlay
- route raw and Kitty keyboard input so transcript arrows scroll the selected run without moving the underlying list
- preserve live follow, focus restoration, bounded rendering, and tiny-terminal reachability
- document the interaction and add unit, layout, and controller-level regression coverage

## Verification

- `bun test` (880 passed, 2 skipped)
- `bun run tsc`
- `bun run check:pi-imports`
- `bun run lint` (0 errors)
- independent read-only review found no remaining actionable correctness issues