### PR TITLE
feat(pi): gate self-updates on compatibility checks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@earendil-works/pi-ai": "0.80.7",
         "@earendil-works/pi-coding-agent": "0.80.7",
+        "@earendil-works/pi-tui": "0.80.7",
         "@prettier/plugin-oxc": "0.0.4",
         "@tskm/compiler": "0.4.1",
         "@tskm/core": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -15,15 +15,18 @@
     "check:codex-agents": "bun scripts/sync-codex-agents.ts --check",
     "check:codex-rules": "bun scripts/check-codex-rules.ts",
     "check:pi-rules": "bun scripts/check-pi-rules.ts",
+    "check:pi-baseline": "bun scripts/pi-compat/baseline.ts",
     "check:pi-imports": "bun scripts/check-pi-imports.ts",
     "check:pi-schemas": "bun scripts/gen-pi-schemas.ts --check",
+    "check:pi-compat": "bun scripts/check-pi-compat.ts",
     "check:pi-version": "bun scripts/check-pi-version.ts",
+    "update:pi": "bun scripts/update-pi.ts",
     "gen:pi-schemas": "bun scripts/gen-pi-schemas.ts",
     "format": "prettier --write .",
     "lint:fix": "oxlint --fix",
     "tsc": "tsgo --noEmit",
     "setup:git-filters": "bash scripts/setup-git-filters.sh",
-    "run-all": "bun run setup:git-filters && bun run check:pi-schemas && bun run format && bun run check:codex-agents && bun run check:codex-rules && bun run check:pi-rules && bun run check:pi-imports && bun run lint && bun run lint:sh && bun run tsc && bun test",
+    "run-all": "bun run setup:git-filters && bun run check:pi-baseline && bun run check:pi-schemas && bun run format && bun run check:codex-agents && bun run check:codex-rules && bun run check:pi-rules && bun run check:pi-imports && bun run lint && bun run lint:sh && bun run tsc && bun test",
     "install:local": "bun link"
   },
   "dependencies": {
@@ -38,6 +41,7 @@
   "devDependencies": {
     "@earendil-works/pi-ai": "0.80.7",
     "@earendil-works/pi-coding-agent": "0.80.7",
+    "@earendil-works/pi-tui": "0.80.7",
     "@prettier/plugin-oxc": "0.0.4",
     "@tskm/compiler": "0.4.1",
     "@tskm/core": "0.3.0",

--- a/pi/README.md
+++ b/pi/README.md
@@ -21,11 +21,28 @@ child-process behavior): `tests/fixtures/pi-harness/raw/`.
 ## Install
 
 ```bash
-bun install -g @earendil-works/pi-coding-agent@0.80.7   # keep in sync with package.json pin
+bun install --frozen-lockfile                           # reproducible local test baseline
+bun install -g @earendil-works/pi-coding-agent@0.80.7  # initial known-good global install
 bun run src/index.ts install                            # deploys the symlinks
 pi                                                      # /login → provider of choice
-bun run check:pi-version                                # host smoke: pin matches binary
+bun run check:pi-compat                                 # compile + offline real-pi RPC smoke
+bun run update:pi                                       # preflight, update, verify, auto-rollback
 ```
+
+The exact versions in `package.json`/`bun.lock` are the **local development
+baseline**, not a global-version allowlist. A newer global pi is accepted when
+its public declarations compile the self-contained extensions and its real CLI
+passes the isolated RPC probe. `check:pi-version` remains as a backward-
+compatible alias for `check:pi-compat`.
+
+Prefer `bun run update:pi` over raw `pi update`. It verifies the current install
+before mutation, locks concurrent updates, runs pi's self-update with the
+captured Bun installation, and checks the candidate. An incompatible candidate
+is automatically reinstalled at the previous version and verified again.
+Rollback is best-effort because Bun's registry/cache can be unavailable; a
+recovery journal and exact manual command are retained when restoration fails.
+The compatibility smoke uses temporary HOME/config/session directories, runs
+no model turn/provider request, and never reads user auth or sessions.
 
 Billing note (measured 2026-07-10): Claude Pro/Max OAuth from pi is billed as
 **extra usage** (per token, not plan limits). ChatGPT Plus/Pro (Codex) OAuth
@@ -192,7 +209,8 @@ retention).
 Automated coverage lives in `tests/pi-harness/` + `tests/hooks/pi-harness/`
 (`bun test`). Host-dependent checks:
 
-- [x] `bun run check:pi-version` passes
+- [x] `bun run check:pi-baseline` passes (local lock/install integrity)
+- [x] `bun run check:pi-compat` passes (global declarations + isolated RPC)
 - [x] pi startup shows no pi-harness load errors
 - [x] Phase 2: `npx prettier` blocked; `bit issue claim` blocked; "ultracode"
       prompt injects the codex mandate (verified 2026-07-10)
@@ -209,6 +227,7 @@ Automated coverage lives in `tests/pi-harness/` + `tests/hooks/pi-harness/`
       creation → task_completed close-verified on a real repo (2026-07-11);
       fork shadows the shared skill on name collision (V7 settled)
 - [ ] TUI-only: Claude-equivalent custom footer renders in an interactive pi
-      session (`session_start`); asuku toast visually confirmed
+      session (`session_start`); resident child browser Down/focus behavior and
+      asuku toast visually confirmed after a pi update
 - [ ] Anthropic-transport provider-log response records (once extra-usage
       balance exists)

--- a/pi/extensions/codex-web/index.ts
+++ b/pi/extensions/codex-web/index.ts
@@ -1,3 +1,10 @@
+import type {
+  AgentToolResult,
+  AgentToolUpdateCallback,
+  ExtensionAPI,
+  ExtensionFactory,
+} from "@earendil-works/pi-coding-agent";
+import type { TSchema } from "typebox";
 import {
   requestCodexWeb,
   type CodexAuthInput,
@@ -40,12 +47,8 @@ interface ToolContextLike {
   ui: ToolUiLike;
 }
 
-interface ToolUpdateLike {
-  content: { type: "text"; text: string }[];
-  details?: Record<string, unknown>;
-}
-
-type ToolUpdateCallbackLike = (update: ToolUpdateLike) => void;
+type ToolDetailsLike = Record<string, unknown> | undefined;
+type ToolUpdateCallbackLike = AgentToolUpdateCallback<ToolDetailsLike>;
 
 interface ToolDefinitionLike {
   name: string;
@@ -54,14 +57,14 @@ interface ToolDefinitionLike {
   description: string;
   promptSnippet: string;
   promptGuidelines: string[];
-  parameters: unknown;
+  parameters: TSchema;
   execute(
     toolCallId: string,
     params: unknown,
     signal: AbortSignal | undefined,
     onUpdate: ToolUpdateCallbackLike | undefined,
     ctx: ToolContextLike,
-  ): Promise<unknown>;
+  ): Promise<AgentToolResult<ToolDetailsLike>>;
 }
 
 interface ExtensionApiLike {
@@ -263,5 +266,12 @@ const setupCodexWeb = (pi: ExtensionApiLike): void => {
   });
 };
 
+type Assert<T extends true> = T;
+type _CodexWebApiContract = Assert<
+  ExtensionAPI extends ExtensionApiLike ? true : false
+>;
+
+const codexWeb: ExtensionFactory = (pi): void => setupCodexWeb(pi);
+
 export { setupCodexWeb };
-export default setupCodexWeb;
+export default codexWeb;

--- a/pi/extensions/pi-harness/features/bit-task/index.ts
+++ b/pi/extensions/pi-harness/features/bit-task/index.ts
@@ -169,6 +169,7 @@ const commandFailure = (description: string, result: CommandResult): Error =>
 
 const textResult = (text: string) => ({
   content: [{ type: "text" as const, text }],
+  details: undefined,
 });
 
 const verificationSkipped = (taskId: string, reason: string) =>

--- a/pi/extensions/pi-harness/features/child-runs/README.md
+++ b/pi/extensions/pi-harness/features/child-runs/README.md
@@ -20,6 +20,12 @@ resident full-width TUI browser between the chat editor and statusline.
   retain native Down handling and use `/subagents` or `Ctrl+Alt+S` for explicit
   focus. Remapped Down is honored when the editor's runtime keybindings manager
   is detectable; otherwise default terminal sequences are used.
+- pi currently has a public focus setter but no public focus getter. The one
+  private getter seam is capability-isolated. If a pi update removes or changes
+  it, the resident list becomes passive, Down is left entirely to the editor,
+  and `/subagents` / `Ctrl+Alt+S` opens a fresh public `ui.custom` overlay. The
+  degradation warns once and never disables child execution or other harness
+  features.
 - `Esc` returns focus to the main editor while leaving the browser visible.
 - `q` hides the browser. A new child run, `/subagents`, or the shortcut shows
   it again.
@@ -78,5 +84,7 @@ raw source data.
 6. Press Escape and confirm focus returns to the resident list, then Escape
    again and confirm normal editor input continues.
 7. Press `q` in the list, then run `/subagents` and confirm it reappears.
-8. Resume the parent session and confirm completed transcripts open from the
+8. With the private focus capability disabled in a test runtime, confirm Down
+   remains native and `/subagents` opens/closes the public overlay fallback.
+9. Resume the parent session and confirm completed transcripts open from the
    beginning and remain scrollable within the documented retention bounds.

--- a/pi/extensions/pi-harness/features/child-runs/focus-capability.ts
+++ b/pi/extensions/pi-harness/features/child-runs/focus-capability.ts
@@ -1,0 +1,66 @@
+import type { ComponentLike } from "./presentation";
+
+export interface FocusTuiLike {
+  setFocus?(component: ComponentLike | null): void;
+}
+
+interface PrivateFocusTuiLike extends FocusTuiLike {
+  focusedComponent?: unknown;
+}
+
+export type FocusReadResult =
+  | { supported: true; component: ComponentLike | null }
+  | { supported: false; reason: string };
+
+const isComponentLike = (value: unknown): value is ComponentLike =>
+  value !== null &&
+  typeof value === "object" &&
+  typeof (value as { render?: unknown }).render === "function" &&
+  typeof (value as { invalidate?: unknown }).invalidate === "function";
+
+/**
+ * The only adapter allowed to inspect pi-tui's private focus state.
+ *
+ * `setFocus` is public, but pi 0.80.x has no public focus getter. Callers must
+ * treat any failed read as a permanent capability loss and stop consuming
+ * editor input; a missing restoration target must never be guessed.
+ */
+export const readFocusedComponent = (tui: FocusTuiLike): FocusReadResult => {
+  if (typeof tui.setFocus !== "function") {
+    return { supported: false, reason: "TUI setFocus is unavailable" };
+  }
+
+  try {
+    if (!("focusedComponent" in tui)) {
+      return {
+        supported: false,
+        reason: "TUI focus inspection is unavailable",
+      };
+    }
+    const component = (tui as PrivateFocusTuiLike).focusedComponent;
+    if (component === null || component === undefined) {
+      return { supported: true, component: null };
+    }
+    if (!isComponentLike(component)) {
+      return { supported: false, reason: "TUI focus target has changed shape" };
+    }
+    return { supported: true, component };
+  } catch {
+    return { supported: false, reason: "TUI focus inspection failed" };
+  }
+};
+
+export const setFocusSafely = (
+  tui: FocusTuiLike,
+  component: ComponentLike | null,
+): { ok: true } | { ok: false; reason: string } => {
+  if (typeof tui.setFocus !== "function") {
+    return { ok: false, reason: "TUI setFocus is unavailable" };
+  }
+  try {
+    tui.setFocus(component);
+    return { ok: true };
+  } catch {
+    return { ok: false, reason: "TUI focus change failed" };
+  }
+};

--- a/pi/extensions/pi-harness/features/child-runs/ui.ts
+++ b/pi/extensions/pi-harness/features/child-runs/ui.ts
@@ -11,6 +11,11 @@ import type {
   LiveChildRun,
   TranscriptItem,
 } from "./model";
+import {
+  readFocusedComponent,
+  setFocusSafely,
+  type FocusTuiLike,
+} from "./focus-capability";
 import { statusIcon, type ComponentLike } from "./presentation";
 import { ChildRunRegistry } from "./registry";
 
@@ -26,14 +31,9 @@ interface EditorLike extends ComponentLike {
   keybindings?: KeybindingsLike;
 }
 
-interface TuiLike {
+interface TuiLike extends FocusTuiLike {
   terminal: { rows: number };
   requestRender(force?: boolean): void;
-  setFocus?(component: ComponentLike | null): void;
-  // pi-tui has no public focus getter. The widget needs the currently focused
-  // editor so it can preserve native Down handling and restore focus after
-  // browsing. Keep this private runtime seam isolated to this adapter.
-  focusedComponent?: ComponentLike | null;
 }
 
 interface WidgetUiLike {
@@ -527,6 +527,10 @@ export class ChildRunsPanelController {
   private unsubscribeInput: (() => void) | undefined;
   private detailClose: (() => void) | undefined;
   private detailPromise: Promise<void> | undefined;
+  private fallbackClose: (() => void) | undefined;
+  private fallbackPromise: Promise<void> | undefined;
+  private focusDegraded = false;
+  private focusWarningShown = false;
   private readonly keybindings: KeybindingsLike = {
     matches: (data, keybinding) =>
       this.editor?.keybindings?.matches(data, keybinding) ??
@@ -540,14 +544,18 @@ export class ChildRunsPanelController {
   }
 
   async showAndFocus(ctx: BrowserContextLike): Promise<void> {
-    this.show(ctx, true);
+    if (!this.show(ctx, false)) return;
+    if (this.focusBrowser()) return;
+    await this.openFallbackBrowser();
   }
 
   dispose(): void {
     if (this.state === "disposed") return;
     this.detailClose?.();
     this.detailClose = undefined;
-    if (this.tui?.focusedComponent === this.component) this.restoreFocus();
+    this.fallbackClose?.();
+    this.fallbackClose = undefined;
+    if (this.isResidentFocused()) this.restoreFocus();
     if (this.state === "mounted") {
       this.ui?.setWidget(CHILD_RUNS_WIDGET_KEY, undefined);
     }
@@ -568,7 +576,7 @@ export class ChildRunsPanelController {
   private show(ctx: BrowserContextLike, focus: boolean): boolean {
     if (ctx.mode !== "tui" || this.state === "disposed") return false;
     if (this.state === "mounted") {
-      if (focus) this.focusBrowser();
+      if (focus && !this.focusBrowser()) void this.openFallbackBrowser();
       return true;
     }
 
@@ -580,7 +588,7 @@ export class ChildRunsPanelController {
         CHILD_RUNS_WIDGET_KEY,
         (tui) => {
           this.tui = tui;
-          this.captureFocusTarget(tui.focusedComponent);
+          this.captureCurrentFocus();
           const component = new ChildRunsBrowserComponent(
             this.registry,
             tui,
@@ -598,7 +606,7 @@ export class ChildRunsPanelController {
         throw new Error("widget factory did not mount a component");
       }
       this.state = "mounted";
-      if (focus) this.focusBrowser();
+      if (focus && !this.focusBrowser()) void this.openFallbackBrowser();
       return true;
     } catch (error) {
       this.state = "unmounted";
@@ -610,6 +618,73 @@ export class ChildRunsPanelController {
       );
       return false;
     }
+  }
+
+  private async openFallbackBrowser(): Promise<void> {
+    const { ui } = this;
+    if (ui?.custom === undefined || this.state !== "mounted") {
+      ui?.notify(
+        "Child-session browser focus requires custom TUI support on this pi version.",
+        "warning",
+      );
+      return;
+    }
+    if (this.fallbackPromise !== undefined) return this.fallbackPromise;
+
+    let fallbackPromise: Promise<void>;
+    try {
+      fallbackPromise = ui.custom<void>(
+        (tui, _theme, keybindings, done) => {
+          let closed = false;
+          const close = () => {
+            if (closed) return;
+            closed = true;
+            done(undefined);
+          };
+          this.fallbackClose = close;
+          return new ChildRunsBrowserComponent(
+            this.registry,
+            tui,
+            keybindings,
+            (runId) => this.openDetail(runId),
+            close,
+            () => {
+              this.hide();
+              close();
+            },
+          );
+        },
+        {
+          overlay: true,
+          overlayOptions: {
+            width: "100%",
+            maxHeight: "100%",
+            anchor: "center",
+            margin: 1,
+          },
+        },
+      );
+    } catch (error) {
+      ui.notify(
+        `Child-session browser fallback could not open: ${String(error)}`,
+        "warning",
+      );
+      return;
+    }
+
+    this.fallbackPromise = fallbackPromise;
+    await fallbackPromise
+      .catch((error) => {
+        ui.notify(
+          `Child-session browser fallback could not open: ${String(error)}`,
+          "warning",
+        );
+      })
+      .finally(() => {
+        if (this.fallbackPromise !== fallbackPromise) return;
+        this.fallbackPromise = undefined;
+        this.fallbackClose = undefined;
+      });
   }
 
   private openDetail(runId: string): void {
@@ -676,7 +751,11 @@ export class ChildRunsPanelController {
   }
 
   private installInputListener(ui: WidgetUiLike): void {
-    if (this.unsubscribeInput !== undefined || ui.onTerminalInput === undefined)
+    if (
+      this.focusDegraded ||
+      this.unsubscribeInput !== undefined ||
+      ui.onTerminalInput === undefined
+    )
       return;
     this.unsubscribeInput = ui.onTerminalInput((data) =>
       this.handleTerminalInput(data),
@@ -694,8 +773,9 @@ export class ChildRunsPanelController {
       return undefined;
     }
 
-    const focused = this.tui.focusedComponent;
-    if (focused === this.component || !isEditorLike(focused)) return undefined;
+    const focused = this.readCurrentFocus();
+    if (focused === undefined || focused === this.component) return undefined;
+    if (!isEditorLike(focused)) return undefined;
     this.captureFocusTarget(focused);
     const editor = focused;
     if (editor.isShowingAutocomplete?.() === true) return undefined;
@@ -726,22 +806,73 @@ export class ChildRunsPanelController {
     if (isEditorLike(candidate)) this.editor = candidate;
   }
 
-  private focusBrowser(): void {
-    if (this.state !== "mounted" || this.component === undefined) return;
-    this.captureFocusTarget(this.tui?.focusedComponent);
-    this.tui?.setFocus?.(this.component);
-    this.tui?.requestRender();
+  private focusBrowser(): boolean {
+    if (
+      this.state !== "mounted" ||
+      this.component === undefined ||
+      this.focusDegraded
+    )
+      return false;
+    const focused = this.readCurrentFocus();
+    if (focused === undefined || focused === null) return false;
+    this.captureFocusTarget(focused);
+    if (this.returnFocus === undefined || this.tui === undefined) return false;
+    const result = setFocusSafely(this.tui, this.component);
+    if (!result.ok) {
+      this.degradeFocus(result.reason);
+      return false;
+    }
+    this.tui.requestRender();
+    return true;
   }
 
   private restoreFocus(): void {
-    if (this.returnFocus === undefined) return;
-    this.tui?.setFocus?.(this.returnFocus);
-    this.tui?.requestRender();
+    if (this.returnFocus === undefined || this.tui === undefined) return;
+    const result = setFocusSafely(this.tui, this.returnFocus);
+    if (!result.ok) {
+      this.degradeFocus(result.reason);
+      return;
+    }
+    this.tui.requestRender();
+  }
+
+  private captureCurrentFocus(): void {
+    const focused = this.readCurrentFocus();
+    if (focused !== undefined) this.captureFocusTarget(focused);
+  }
+
+  private readCurrentFocus(): ComponentLike | null | undefined {
+    if (this.tui === undefined || this.focusDegraded) return undefined;
+    const result = readFocusedComponent(this.tui);
+    if (!result.supported) {
+      this.degradeFocus(result.reason);
+      return undefined;
+    }
+    return result.component;
+  }
+
+  private isResidentFocused(): boolean {
+    if (this.component === undefined) return false;
+    return this.readCurrentFocus() === this.component;
+  }
+
+  private degradeFocus(reason: string): void {
+    if (!this.focusDegraded) {
+      this.focusDegraded = true;
+      this.unsubscribeInput?.();
+      this.unsubscribeInput = undefined;
+    }
+    if (this.focusWarningShown) return;
+    this.focusWarningShown = true;
+    this.ui?.notify(
+      `Child-session browser focus degraded: ${reason}. Use /subagents or Ctrl+Alt+S for the public overlay fallback.`,
+      "warning",
+    );
   }
 
   private hide(): void {
     if (this.state !== "mounted") return;
-    this.restoreFocus();
+    if (this.isResidentFocused()) this.restoreFocus();
     this.state = "unmounted";
     this.component = undefined;
     this.ui?.setWidget(CHILD_RUNS_WIDGET_KEY, undefined);

--- a/pi/extensions/pi-harness/features/statusline/render.ts
+++ b/pi/extensions/pi-harness/features/statusline/render.ts
@@ -4,6 +4,7 @@ import type {
   ThemeColorLike,
   ThemeLike,
 } from "../../lib/pi-like";
+import { visibleWidth } from "../../lib/terminal-text";
 
 export const STATUSLINE_WIDGET_KEY = "pi-harness-statusline";
 
@@ -82,103 +83,13 @@ const checkStatus = (
     : "pending";
 };
 
-// Keep these classifiers aligned with pi-tui 0.80.6's graphemeWidth.
-const ZERO_WIDTH_GRAPHEME =
-  /^(?:\p{Default_Ignorable_Code_Point}|\p{Control}|\p{Mark}|\p{Surrogate})+$/v;
-const LEADING_NON_PRINTING =
-  /^[\p{Default_Ignorable_Code_Point}\p{Control}\p{Format}\p{Mark}\p{Surrogate}]+/v;
-const RGI_EMOJI = /^\p{RGI_Emoji}$/v;
-
-const couldBeEmoji = (grapheme: string): boolean => {
-  const codePoint = grapheme.codePointAt(0) ?? 0;
-  return (
-    (codePoint >= 0x1f000 && codePoint <= 0x1fbff) ||
-    (codePoint >= 0x2300 && codePoint <= 0x23ff) ||
-    (codePoint >= 0x2600 && codePoint <= 0x27bf) ||
-    (codePoint >= 0x2b50 && codePoint <= 0x2b55) ||
-    grapheme.includes("\uFE0F") ||
-    grapheme.length > 2
-  );
-};
-
-// Fullwidth + wide ranges from the same Unicode EastAsianWidth table used by
-// pi-tui 0.80.6's get-east-asian-width dependency. Keeping the compact table
-// local preserves pi-harness's no-runtime-dependency deployment contract.
-const EAST_ASIAN_WIDE_RANGES: readonly number[] = [
-  12_288, 12_288, 65_281, 65_376, 65_504, 65_510, 4_352, 4_447, 8_986, 8_987,
-  9_001, 9_002, 9_193, 9_196, 9_200, 9_200, 9_203, 9_203, 9_725, 9_726, 9_748,
-  9_749, 9_776, 9_783, 9_800, 9_811, 9_855, 9_855, 9_866, 9_871, 9_875, 9_875,
-  9_889, 9_889, 9_898, 9_899, 9_917, 9_918, 9_924, 9_925, 9_934, 9_934, 9_940,
-  9_940, 9_962, 9_962, 9_970, 9_971, 9_973, 9_973, 9_978, 9_978, 9_981, 9_981,
-  9_989, 9_989, 9_994, 9_995, 10_024, 10_024, 10_060, 10_060, 10_062, 10_062,
-  10_067, 10_069, 10_071, 10_071, 10_133, 10_135, 10_160, 10_160, 10_175,
-  10_175, 11_035, 11_036, 11_088, 11_088, 11_093, 11_093, 11_904, 11_929,
-  11_931, 12_019, 12_032, 12_245, 12_272, 12_287, 12_289, 12_350, 12_353,
-  12_438, 12_441, 12_543, 12_549, 12_591, 12_593, 12_686, 12_688, 12_773,
-  12_783, 12_830, 12_832, 12_871, 12_880, 42_124, 42_128, 42_182, 43_360,
-  43_388, 44_032, 55_203, 63_744, 64_255, 65_040, 65_049, 65_072, 65_106,
-  65_108, 65_126, 65_128, 65_131, 94_176, 94_180, 94_192, 94_198, 94_208,
-  101_589, 101_631, 101_662, 101_760, 101_874, 110_576, 110_579, 110_581,
-  110_587, 110_589, 110_590, 110_592, 110_882, 110_898, 110_898, 110_928,
-  110_930, 110_933, 110_933, 110_948, 110_951, 110_960, 111_355, 119_552,
-  119_638, 119_648, 119_670, 126_980, 126_980, 127_183, 127_183, 127_374,
-  127_374, 127_377, 127_386, 127_488, 127_490, 127_504, 127_547, 127_552,
-  127_560, 127_568, 127_569, 127_584, 127_589, 127_744, 127_776, 127_789,
-  127_797, 127_799, 127_868, 127_870, 127_891, 127_904, 127_946, 127_951,
-  127_955, 127_968, 127_984, 127_988, 127_988, 127_992, 128_062, 128_064,
-  128_064, 128_066, 128_252, 128_255, 128_317, 128_331, 128_334, 128_336,
-  128_359, 128_378, 128_378, 128_405, 128_406, 128_420, 128_420, 128_507,
-  128_591, 128_640, 128_709, 128_716, 128_716, 128_720, 128_722, 128_725,
-  128_728, 128_732, 128_735, 128_747, 128_748, 128_756, 128_764, 128_992,
-  129_003, 129_008, 129_008, 129_292, 129_338, 129_340, 129_349, 129_351,
-  129_535, 129_648, 129_660, 129_664, 129_674, 129_678, 129_734, 129_736,
-  129_736, 129_741, 129_756, 129_759, 129_770, 129_775, 129_784, 131_072,
-  196_605, 196_608, 262_141,
-];
-
-const isWide = (codePoint: number): boolean => {
-  for (let index = 0; index < EAST_ASIAN_WIDE_RANGES.length; index += 2) {
-    const lower = EAST_ASIAN_WIDE_RANGES[index];
-    const upper = EAST_ASIAN_WIDE_RANGES[index + 1];
-    if (lower !== undefined && upper !== undefined) {
-      if (codePoint >= lower && codePoint <= upper) return true;
-    }
-  }
-  return false;
-};
-
 const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 const graphemes = (value: string): string[] =>
   [...segmenter.segment(value)].map(({ segment }) => segment);
 
-const graphemeWidth = (grapheme: string): number => {
-  if (ZERO_WIDTH_GRAPHEME.test(grapheme)) return 0;
-  if (couldBeEmoji(grapheme) && RGI_EMOJI.test(grapheme)) return 2;
+const graphemeWidth = (grapheme: string): number => visibleWidth(grapheme);
 
-  const base = grapheme.replace(LEADING_NON_PRINTING, "");
-  const codePoint = base.codePointAt(0);
-  if (codePoint === undefined) return 0;
-  if (codePoint >= 0x1f1e6 && codePoint <= 0x1f1ff) return 2;
-
-  let width = isWide(codePoint) ? 2 : 1;
-  if (grapheme.length > 1) {
-    for (const character of grapheme.slice(1)) {
-      const trailing = character.codePointAt(0) ?? 0;
-      if (trailing >= 0xff00 && trailing <= 0xffef) {
-        width += isWide(trailing) ? 2 : 1;
-      } else if (trailing === 0x0e33 || trailing === 0x0eb3) {
-        width += 1;
-      }
-    }
-  }
-  return width;
-};
-
-export const visibleStatuslineWidth = (value: string): number =>
-  graphemes(value).reduce(
-    (width, grapheme) => width + graphemeWidth(grapheme),
-    0,
-  );
+export const visibleStatuslineWidth = visibleWidth;
 
 const appendSpan = (spans: Span[], span: Span): void => {
   if (span.text === "") return;

--- a/pi/extensions/pi-harness/features/subagent/index.ts
+++ b/pi/extensions/pi-harness/features/subagent/index.ts
@@ -419,7 +419,10 @@ const setupSubagent = (
           }
           return {
             content: [
-              { type: "text", text: capText(previous || "(no output)") },
+              {
+                type: "text" as const,
+                text: capText(previous || "(no output)"),
+              },
             ],
             details: { mode: "chain", results } satisfies SubagentDetails,
           };
@@ -473,7 +476,7 @@ const setupSubagent = (
           return {
             content: [
               {
-                type: "text",
+                type: "text" as const,
                 text: capText(
                   `Parallel: ${results.length}/${results.length} succeeded\n\n${summaries.join("\n\n---\n\n")}`,
                 ),
@@ -492,7 +495,7 @@ const setupSubagent = (
           return {
             content: [
               {
-                type: "text",
+                type: "text" as const,
                 text: capText(result.output || "(no output)"),
               },
             ],

--- a/pi/extensions/pi-harness/features/workflow/index.ts
+++ b/pi/extensions/pi-harness/features/workflow/index.ts
@@ -500,7 +500,7 @@ const setupWorkflow = (
         return {
           content: [
             {
-              type: "text",
+              type: "text" as const,
               text: capText(`${summary}\n\n${stageDigest}${worktreeNote}`),
             },
           ],

--- a/pi/extensions/pi-harness/index.ts
+++ b/pi/extensions/pi-harness/index.ts
@@ -9,6 +9,7 @@
  * In child pi processes (PI_HARNESS_CHILD=1) only the safety layer stays
  * active — see config.ts.
  */
+import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
 import type { PiLike } from "./lib/pi-like";
 import { loadConfig, type HarnessConfig } from "./config";
 import setupPermissionPolicy from "./features/permission-policy/index";
@@ -44,7 +45,7 @@ const setupHarness = (pi: PiLike, config: HarnessConfig): void => {
   if (config.features["ask-user-question"]) setupAskUserQuestion(pi);
 };
 
-const piHarness = (pi: PiLike): void => {
+const piHarness: ExtensionFactory = (pi): void => {
   setupHarness(pi, loadConfig());
 };
 

--- a/pi/extensions/pi-harness/lib/pi-like.ts
+++ b/pi/extensions/pi-harness/lib/pi-like.ts
@@ -1,3 +1,10 @@
+import type {
+  AgentToolResult,
+  ExtensionAPI,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import type { TSchema } from "typebox";
+
 /**
  * Structural types for the subset of pi's ExtensionAPI that pi-harness uses.
  *
@@ -184,22 +191,31 @@ export type PiEventHandler<K extends PiEventName> = (
 
 export interface ToolDefLike {
   name: string;
-  label?: string;
+  label: string;
   description: string;
   promptSnippet?: string;
   promptGuidelines?: string[];
   executionMode?: "parallel" | "sequential";
-  parameters: unknown;
+  parameters: TSchema;
   execute: (
     toolCallId: string,
     params: never,
     signal: AbortSignal | undefined,
     onUpdate: unknown,
     ctx: CtxLike,
-  ) => Promise<unknown>;
+  ) => Promise<AgentToolResult<unknown>>;
 }
 
 export interface PiLike {
   on<K extends PiEventName>(event: K, handler: PiEventHandler<K>): void;
   registerTool(tool: ToolDefLike): void;
 }
+
+// Compile-only contracts against pi's documented public API. Keeping these
+// next to the narrow seam makes local and global declaration compilation fail
+// when the real runtime can no longer supply what the harness expects.
+type Assert<T extends true> = T;
+type _PiApiContract = Assert<ExtensionAPI extends PiLike ? true : false>;
+type _PiContextContract = Assert<
+  ExtensionContext extends CtxLike ? true : false
+>;

--- a/pi/extensions/pi-harness/lib/terminal-text.ts
+++ b/pi/extensions/pi-harness/lib/terminal-text.ts
@@ -1,3 +1,9 @@
+import {
+  truncateToWidth as piTruncateToWidth,
+  visibleWidth,
+  wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
+
 const consumeCsi = (value: string, start: number): number => {
   for (let index = start; index < value.length; index += 1) {
     const code = value.charCodeAt(index);
@@ -101,38 +107,10 @@ export const capUtf8 = (value: string, maxBytes: number): string => {
   return `${value.slice(0, end)}${includeSuffix ? TRUNCATION_SUFFIX : ""}`;
 };
 
-const isZeroWidth = (code: number): boolean =>
-  (code >= 0x300 && code <= 0x36f) ||
-  (code >= 0x1ab0 && code <= 0x1aff) ||
-  (code >= 0x1dc0 && code <= 0x1dff) ||
-  (code >= 0x20d0 && code <= 0x20ff) ||
-  (code >= 0xfe00 && code <= 0xfe0f) ||
-  (code >= 0xfe20 && code <= 0xfe2f) ||
-  code === 0x200d;
-
-const isWide = (code: number): boolean =>
-  code >= 0x1100 &&
-  (code <= 0x115f ||
-    code === 0x2329 ||
-    code === 0x232a ||
-    (code >= 0x2e80 && code <= 0xa4cf && code !== 0x303f) ||
-    (code >= 0xac00 && code <= 0xd7a3) ||
-    (code >= 0xf900 && code <= 0xfaff) ||
-    (code >= 0xfe10 && code <= 0xfe19) ||
-    (code >= 0xfe30 && code <= 0xfe6f) ||
-    (code >= 0xff00 && code <= 0xff60) ||
-    (code >= 0xffe0 && code <= 0xffe6) ||
-    (code >= 0x1f000 && code <= 0x1faff) ||
-    (code >= 0x20000 && code <= 0x3fffd));
-
-const runeWidth = (rune: string): number => {
-  const code = rune.codePointAt(0) ?? 0;
-  if (isZeroWidth(code)) return 0;
-  return isWide(code) ? 2 : 1;
-};
-
-export const visibleWidth = (value: string): number =>
-  Array.from(value).reduce((width, rune) => width + runeWidth(rune), 0);
+// pi aliases this documented package root to the TUI implementation bundled
+// with the running binary. Re-export width behavior through this local adapter
+// so sanitization/privacy logic stays local while Unicode behavior follows pi.
+export { visibleWidth };
 
 export const truncateToWidth = (
   value: string,
@@ -140,43 +118,13 @@ export const truncateToWidth = (
   suffix: string = "…",
 ): string => {
   if (width <= 0) return "";
-  if (visibleWidth(value) <= width) return value;
-  const suffixWidth = visibleWidth(suffix);
-  const available = Math.max(0, width - suffixWidth);
-  let output = "";
-  let used = 0;
-  for (const rune of value) {
-    const next = runeWidth(rune);
-    if (used + next > available) break;
-    output += rune;
-    used += next;
-  }
-  return `${output}${suffixWidth <= width ? suffix : ""}`;
+  return stripTerminalControls(piTruncateToWidth(value, width, suffix));
 };
 
 /** Wrap already-sanitized plain text. Every returned line fits width. */
 export const wrapPlainText = (value: string, width: number): string[] => {
   if (width <= 0) return [""];
-  const lines: string[] = [];
-  for (const sourceLine of value.split("\n")) {
-    if (sourceLine === "") {
-      lines.push("");
-      continue;
-    }
-    let current = "";
-    let used = 0;
-    for (const rune of sourceLine) {
-      const next = runeWidth(rune);
-      if (used > 0 && used + next > width) {
-        lines.push(current);
-        current = "";
-        used = 0;
-      }
-      if (next > width) continue;
-      current += rune;
-      used += next;
-    }
-    lines.push(current);
-  }
-  return lines.length === 0 ? [""] : lines;
+  return wrapTextWithAnsi(value, width).map((line) =>
+    stripTerminalControls(line),
+  );
 };

--- a/scripts/check-pi-compat.ts
+++ b/scripts/check-pi-compat.ts
@@ -1,0 +1,3 @@
+import { main } from "./check-pi-version";
+
+process.exit(await main());

--- a/scripts/check-pi-imports.ts
+++ b/scripts/check-pi-imports.ts
@@ -4,7 +4,8 @@
  * must not import repo code outside its own directory. Allowed runtime imports:
  *   (a) relative paths that stay inside that extension's directory
  *   (b) node: builtins
- *   (c) @earendil-works/* — type-only imports only (erased at runtime)
+ *   (c) @earendil-works/* — type-only imports, plus exact documented
+ *       runtime roots explicitly allowlisted per extension
  *
  * Detection is syntax-aware via Bun.Transpiler (static + dynamic import,
  * require, require.resolve — literal specifiers), so strings/comments never
@@ -27,6 +28,13 @@ export const EXTENSION_ROOTS = [
   EXTENSION_ROOT,
   CODEX_WEB_EXTENSION_ROOT,
 ] as const;
+
+// pi's extension loader aliases this documented root import to the copy bundled
+// with the running pi process. Keep this allowlist exact: subpaths, lookalikes,
+// other pi packages, and codex-web runtime imports remain denied.
+const RUNTIME_IMPORTS_BY_ROOT = new Map<string, ReadonlySet<string>>([
+  [EXTENSION_ROOT, new Set(["@earendil-works/pi-tui"])],
+]);
 
 const transpiler = new Bun.Transpiler({ loader: "ts" });
 
@@ -199,10 +207,11 @@ export const collectViolations = (
   for (const specifier of specifiers) {
     if (specifier.startsWith("node:")) continue;
     if (specifier.startsWith("@earendil-works/")) {
-      // Only type-only @earendil-works imports are allowed; the transpiler
-      // erases those, so anything reaching here is a runtime import.
+      // Type-only imports are erased before this scan. Runtime imports are
+      // limited to exact roots virtualized by pi for this extension.
+      if (RUNTIME_IMPORTS_BY_ROOT.get(root)?.has(specifier) === true) continue;
       violations.push(
-        `${relFile}: runtime import of ${specifier} (type-only imports allowed)`,
+        `${relFile}: runtime import of ${specifier} (type-only imports and explicitly bundled roots only)`,
       );
       continue;
     }

--- a/scripts/check-pi-version.ts
+++ b/scripts/check-pi-version.ts
@@ -1,17 +1,16 @@
 /**
- * Verifies the globally installed pi CLI matches the version pinned in
- * package.json devDependencies. Host-dependent (requires the pi binary), so
- * this is NOT part of run-all — it belongs to the machine smoke checklist in
- * pi/README.md.
+ * Backward-compatible entrypoint for the old exact-version check.
+ *
+ * The local package pin is now a reproducible test baseline, not a global
+ * allowlist. The command succeeds for a different global version only after
+ * public declaration compilation and an isolated real-pi RPC smoke pass.
  */
 import { posix, win32 } from "node:path";
-import packageJson from "../package.json";
+import { checkPiCompatibility } from "./pi-compat/index";
 
-const PIN_KEY = "@earendil-works/pi-coding-agent";
+type VersionCommandRunner = (argv: string[]) => Promise<string>;
 
-type CommandRunner = (argv: string[]) => Promise<string>;
-
-const runCommand: CommandRunner = async (argv) => {
+const runVersionCommand: VersionCommandRunner = async (argv) => {
   const child = Bun.spawn(argv, { stdout: "pipe", stderr: "ignore" });
   const output = await new Response(child.stdout).text();
   if ((await child.exited) !== 0) throw new Error(`command failed: ${argv[0]}`);
@@ -19,7 +18,7 @@ const runCommand: CommandRunner = async (argv) => {
 };
 
 const readGlobalPiVersion = async (
-  run: CommandRunner = runCommand,
+  run: VersionCommandRunner = runVersionCommand,
   bunExecutable = process.execPath,
   platform = process.platform,
 ): Promise<string> => {
@@ -33,34 +32,23 @@ const readGlobalPiVersion = async (
 };
 
 const main = async (): Promise<number> => {
-  const pinned: string | undefined = packageJson.devDependencies?.[PIN_KEY];
-  if (pinned === undefined) {
-    console.error(
-      `check-pi-version: ${PIN_KEY} is not pinned in package.json devDependencies`,
-    );
-    return 1;
-  }
-
-  let installed: string;
   try {
-    installed = await readGlobalPiVersion();
-  } catch {
-    console.error(
-      `check-pi-version: global pi binary not found. Install with: bun install -g ${PIN_KEY}@${pinned}`,
+    const { baseline, installation } = await checkPiCompatibility();
+    const baselineVersion = baseline.packages.find(
+      ({ name }) => name === "@earendil-works/pi-coding-agent",
+    )?.lockedVersion;
+    const drift =
+      baselineVersion === installation.packageVersion
+        ? ""
+        : `; local baseline ${baselineVersion ?? "unknown"}`;
+    console.log(
+      `check-pi-compat: OK (global ${installation.packageVersion}${drift})`,
     );
+    return 0;
+  } catch (error) {
+    console.error(`check-pi-compat: FAILED: ${String(error)}`);
     return 1;
   }
-
-  if (installed !== pinned) {
-    console.error(
-      `check-pi-version: globally installed pi ${installed} != pinned ${pinned}. ` +
-        `Update the pin or run: bun install -g ${PIN_KEY}@${pinned}`,
-    );
-    return 1;
-  }
-
-  console.log(`check-pi-version: OK (${installed})`);
-  return 0;
 };
 
 if (import.meta.main) process.exit(await main());

--- a/scripts/pi-compat/baseline.ts
+++ b/scripts/pi-compat/baseline.ts
@@ -1,0 +1,171 @@
+import { readFile, realpath } from "node:fs/promises";
+import { join, relative, resolve } from "node:path";
+
+export const PI_BASELINE_PACKAGES = [
+  "@earendil-works/pi-coding-agent",
+  "@earendil-works/pi-ai",
+  "@earendil-works/pi-agent-core",
+  "@earendil-works/pi-tui",
+  "typebox",
+] as const;
+
+const DIRECT_PI_PINS = [
+  "@earendil-works/pi-coding-agent",
+  "@earendil-works/pi-ai",
+  "@earendil-works/pi-tui",
+] as const;
+const DIRECT_PI_PIN_SET = new Set<string>(DIRECT_PI_PINS);
+const EXACT_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+
+type BaselinePackage = (typeof PI_BASELINE_PACKAGES)[number];
+
+interface PackageManifest {
+  name?: string;
+  version?: string;
+  devDependencies?: Record<string, string | undefined>;
+}
+
+interface Lockfile {
+  workspaces?: {
+    ""?: {
+      devDependencies?: Record<string, string | undefined>;
+    };
+  };
+  packages?: Record<string, unknown>;
+}
+
+export interface PiBaselinePackageState {
+  name: BaselinePackage;
+  lockedVersion?: string;
+  installedVersion?: string;
+  installedRoot?: string;
+}
+
+export interface PiBaselineResult {
+  ok: boolean;
+  issues: string[];
+  packages: PiBaselinePackageState[];
+}
+
+const readJsonc = async <T>(path: string): Promise<T> => {
+  // Bun 1.3 exposes JSONC at runtime; the repository's intentionally pinned
+  // Bun 1.2 type package does not declare it yet.
+  const { JSONC } = Bun as unknown as {
+    JSONC: { parse(source: string): unknown };
+  };
+  return JSONC.parse(await readFile(path, "utf8")) as T;
+};
+
+const versionFromLockEntry = (
+  name: string,
+  entry: unknown,
+): string | undefined => {
+  if (!Array.isArray(entry) || typeof entry[0] !== "string") return undefined;
+  const prefix = `${name}@`;
+  return entry[0].startsWith(prefix)
+    ? entry[0].slice(prefix.length)
+    : undefined;
+};
+
+const installedPackage = async (
+  repoRoot: string,
+  name: BaselinePackage,
+): Promise<{ root?: string; version?: string }> => {
+  const root = join(repoRoot, "node_modules", ...name.split("/"));
+  try {
+    const canonicalRoot = await realpath(root);
+    const canonicalModules = await realpath(join(repoRoot, "node_modules"));
+    if (relative(canonicalModules, canonicalRoot).startsWith("..")) return {};
+    const manifest = await readJsonc<PackageManifest>(
+      join(canonicalRoot, "package.json"),
+    );
+    return { root: canonicalRoot, version: manifest.version };
+  } catch {
+    return {};
+  }
+};
+
+export const checkLocalPiBaseline = async (
+  repoRoot: string = resolve(import.meta.dir, "../.."),
+): Promise<PiBaselineResult> => {
+  const packageJson = await readJsonc<PackageManifest>(
+    join(repoRoot, "package.json"),
+  );
+  const lock = await readJsonc<Lockfile>(join(repoRoot, "bun.lock"));
+  const issues: string[] = [];
+  const workspacePins = lock.workspaces?.[""]?.devDependencies ?? {};
+
+  for (const name of DIRECT_PI_PINS) {
+    const manifestPin = packageJson.devDependencies?.[name];
+    const lockPin = workspacePins[name];
+    if (manifestPin === undefined) {
+      issues.push(`direct-pin: ${name} is missing from package.json`);
+    } else if (!EXACT_VERSION.test(manifestPin)) {
+      issues.push(
+        `direct-pin: ${name} must use an exact version (${manifestPin})`,
+      );
+    } else if (lockPin !== manifestPin) {
+      issues.push(
+        `lock-pin: ${name} package.json=${manifestPin} bun.lock=${lockPin ?? "missing"}`,
+      );
+    }
+  }
+
+  const packages: PiBaselinePackageState[] = [];
+  for (const name of PI_BASELINE_PACKAGES) {
+    const lockedVersion = versionFromLockEntry(name, lock.packages?.[name]);
+    const installed = await installedPackage(repoRoot, name);
+    packages.push({
+      name,
+      lockedVersion,
+      installedVersion: installed.version,
+      installedRoot: installed.root,
+    });
+    const directPin = packageJson.devDependencies?.[name];
+    if (
+      DIRECT_PI_PIN_SET.has(name) &&
+      lockedVersion !== undefined &&
+      directPin !== undefined &&
+      lockedVersion !== directPin
+    ) {
+      issues.push(
+        `resolved-pin: ${name} resolved=${lockedVersion} direct=${directPin}`,
+      );
+    }
+    if (lockedVersion === undefined) {
+      issues.push(`lock-tree: ${name} has no resolved bun.lock entry`);
+    } else if (installed.version === undefined) {
+      issues.push(`installed-tree: ${name} is not installed`);
+    } else if (installed.version !== lockedVersion) {
+      issues.push(
+        `installed-tree: ${name} installed=${installed.version} locked=${lockedVersion}`,
+      );
+    }
+  }
+
+  return { ok: issues.length === 0, issues, packages };
+};
+
+export const assertLocalPiBaseline = async (
+  repoRoot?: string,
+): Promise<PiBaselineResult> => {
+  const result = await checkLocalPiBaseline(repoRoot);
+  if (!result.ok) {
+    throw new Error(
+      `pi baseline is inconsistent:\n${result.issues.map((issue) => `  - ${issue}`).join("\n")}\nRun: bun install --frozen-lockfile`,
+    );
+  }
+  return result;
+};
+
+if (import.meta.main) {
+  try {
+    const result = await assertLocalPiBaseline();
+    console.log(
+      `check-pi-baseline: OK (${result.packages.map(({ name, lockedVersion }) => `${name}@${lockedVersion}`).join(", ")})`,
+    );
+  } catch (error) {
+    console.error(`check-pi-baseline: ${String(error)}`);
+    process.exit(1);
+  }
+}

--- a/scripts/pi-compat/compile.ts
+++ b/scripts/pi-compat/compile.ts
@@ -1,0 +1,135 @@
+import { cp, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+import { PI_BASELINE_PACKAGES } from "./baseline";
+import type { PiInstallation } from "./installation";
+import { runCommand, type CommandRunner } from "./process";
+
+export interface CompileGlobalOptions {
+  repoRoot?: string;
+  run?: CommandRunner;
+  keepTemp?: boolean;
+}
+
+export const assertNoLocalPiResolution = (
+  files: string[],
+  repoRoot: string,
+  installation: PiInstallation,
+): void => {
+  const localModules = join(repoRoot, "node_modules");
+  const globalRoots = new Set(
+    Object.values(installation.corePackages).map(({ root }) => resolve(root)),
+  );
+  for (const file of files) {
+    const absolute = resolve(file);
+    if (
+      absolute.startsWith(`${localModules}/@earendil-works/`) ||
+      absolute.startsWith(`${localModules}/typebox/`)
+    ) {
+      throw new Error(
+        `global contract resolved repository-local pi types: ${file}`,
+      );
+    }
+    if (!absolute.includes("node_modules")) continue;
+    if (!/node_modules\/(?:@earendil-works\/pi-|typebox\/)/.test(absolute)) {
+      continue;
+    }
+    const belongsToGlobal = [...globalRoots].some(
+      (root) => absolute === root || absolute.startsWith(`${root}/`),
+    );
+    if (!belongsToGlobal) {
+      throw new Error(
+        `global contract escaped captured package roots: ${file}`,
+      );
+    }
+  }
+};
+
+export const compileExtensionsAgainstGlobalPi = async (
+  installation: PiInstallation,
+  options: CompileGlobalOptions = {},
+): Promise<void> => {
+  const repoRoot = resolve(options.repoRoot ?? join(import.meta.dir, "../.."));
+  const run = options.run ?? runCommand;
+  const tempRoot = await mkdtemp(join(tmpdir(), "pi-compat-types-"));
+  try {
+    const sourceRoot = join(tempRoot, "extensions");
+    await cp(
+      join(repoRoot, "pi/extensions/pi-harness"),
+      join(sourceRoot, "pi-harness"),
+      {
+        recursive: true,
+      },
+    );
+    await cp(
+      join(repoRoot, "pi/extensions/codex-web"),
+      join(sourceRoot, "codex-web"),
+      {
+        recursive: true,
+      },
+    );
+
+    // Recreate only pi's captured package closure under a temporary
+    // node_modules. TypeScript now honors package exports/types normally.
+    const tempModules = join(tempRoot, "node_modules");
+    for (const name of PI_BASELINE_PACKAGES) {
+      const pkg = installation.corePackages[name];
+      if (pkg === undefined)
+        throw new Error(`global type package missing: ${name}`);
+      const target = join(tempModules, ...name.split("/"));
+      await mkdir(resolve(target, ".."), { recursive: true });
+      await symlink(pkg.root, target, "dir");
+    }
+
+    const tsconfigPath = join(tempRoot, "tsconfig.json");
+    await writeFile(
+      tsconfigPath,
+      JSON.stringify(
+        {
+          compilerOptions: {
+            target: "ES2022",
+            module: "ESNext",
+            moduleResolution: "bundler",
+            lib: ["ES2022", "DOM", "DOM.Iterable"],
+            strict: true,
+            skipLibCheck: true,
+            noEmit: true,
+            isolatedModules: true,
+            resolveJsonModule: true,
+            typeRoots: [
+              join(repoRoot, "node_modules/@types"),
+              join(repoRoot, "node_modules"),
+            ],
+            types: ["bun-types"],
+          },
+          include: [join(sourceRoot, "**/*.ts")],
+        },
+        null,
+        2,
+      ),
+    );
+
+    const compiler = join(repoRoot, "node_modules/.bin/tsgo");
+    const result = await run(
+      [compiler, "--project", tsconfigPath, "--noEmit", "--listFiles"],
+      { cwd: tempRoot, timeoutMs: 60_000, maxOutputBytes: 2 * 1024 * 1024 },
+    );
+    const files = result.stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => isAbsolute(line));
+    assertNoLocalPiResolution(files, repoRoot, installation);
+    if (result.timedOut || result.exitCode !== 0) {
+      throw new Error(
+        `global pi declaration contract failed${result.timedOut ? " (timed out)" : ""}:\n${result.stdout}${result.stderr}`,
+      );
+    }
+    if (files.length === 0) {
+      throw new Error(
+        "global pi declaration compiler returned no resolution list",
+      );
+    }
+  } finally {
+    if (!options.keepTemp) await rm(tempRoot, { recursive: true, force: true });
+  }
+};

--- a/scripts/pi-compat/index.ts
+++ b/scripts/pi-compat/index.ts
@@ -1,0 +1,40 @@
+import { resolve } from "node:path";
+import { assertLocalPiBaseline, type PiBaselineResult } from "./baseline";
+import { compileExtensionsAgainstGlobalPi } from "./compile";
+import { discoverPiInstallation, type PiInstallation } from "./installation";
+import { smokeGlobalPiRpc } from "./rpc-smoke";
+
+export interface PiCompatibilityResult {
+  baseline: PiBaselineResult;
+  installation: PiInstallation;
+}
+
+export interface PiCompatibilityDependencies {
+  checkBaseline?: (repoRoot: string) => Promise<PiBaselineResult>;
+  discover?: () => Promise<PiInstallation>;
+  compile?: (installation: PiInstallation, repoRoot: string) => Promise<void>;
+  smoke?: (installation: PiInstallation, repoRoot: string) => Promise<void>;
+}
+
+export const checkPiCompatibility = async (
+  repoRoot: string = resolve(import.meta.dir, "../.."),
+  dependencies: PiCompatibilityDependencies = {},
+): Promise<PiCompatibilityResult> => {
+  const checkBaseline =
+    dependencies.checkBaseline ?? ((root) => assertLocalPiBaseline(root));
+  const discover = dependencies.discover ?? (() => discoverPiInstallation());
+  const compile =
+    dependencies.compile ??
+    ((installation, root) =>
+      compileExtensionsAgainstGlobalPi(installation, { repoRoot: root }));
+  const smoke =
+    dependencies.smoke ??
+    ((installation, root) =>
+      smokeGlobalPiRpc(installation, { repoRoot: root }));
+
+  const baseline = await checkBaseline(repoRoot);
+  const installation = await discover();
+  await compile(installation, repoRoot);
+  await smoke(installation, repoRoot);
+  return { baseline, installation };
+};

--- a/scripts/pi-compat/installation.ts
+++ b/scripts/pi-compat/installation.ts
@@ -1,0 +1,221 @@
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { readFile, realpath } from "node:fs/promises";
+import { PI_BASELINE_PACKAGES } from "./baseline";
+import {
+  runCommand,
+  type CommandRunner,
+  type RunCommandOptions,
+} from "./process";
+
+interface PackageManifest {
+  name?: string;
+  version?: string;
+  bin?: Record<string, string>;
+  main?: string;
+  types?: string;
+  dependencies?: Record<string, string>;
+}
+
+export interface PiCorePackage {
+  root: string;
+  version: string;
+  manifest: PackageManifest;
+}
+
+export interface PiInstallation {
+  bunExecutable: string;
+  globalBin: string;
+  binaryPath: string;
+  binaryRealPath: string;
+  packageRoot: string;
+  packageName: string;
+  packageVersion: string;
+  corePackages: Record<string, PiCorePackage>;
+}
+
+export interface DiscoverInstallationOptions {
+  bunExecutable?: string;
+  platform?: NodeJS.Platform;
+  run?: CommandRunner;
+  commandOptions?: RunCommandOptions;
+}
+
+const readManifest = async (root: string): Promise<PackageManifest> =>
+  JSON.parse(
+    await readFile(join(root, "package.json"), "utf8"),
+  ) as PackageManifest;
+
+const findPackageRoot = async (
+  entry: string,
+  expectedName: string,
+): Promise<string> => {
+  let current = dirname(entry);
+  while (true) {
+    try {
+      const manifest = await readManifest(current);
+      if (manifest.name === expectedName) return realpath(current);
+    } catch {
+      // Continue toward the filesystem root.
+    }
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  throw new Error(`could not locate package root for ${expectedName}`);
+};
+
+const findNodeModulesRoot = (packageRoot: string): string => {
+  let current = packageRoot;
+  while (true) {
+    if (basename(current) === "node_modules") return current;
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  throw new Error(
+    `global pi package is not inside node_modules: ${packageRoot}`,
+  );
+};
+
+const parseVersion = (value: string): [number, number, number] | undefined => {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(value);
+  if (match === null) return undefined;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+};
+
+const compareVersion = (
+  left: [number, number, number],
+  right: [number, number, number],
+): number => {
+  for (let index = 0; index < 3; index += 1) {
+    const difference = (left[index] ?? 0) - (right[index] ?? 0);
+    if (difference !== 0) return difference;
+  }
+  return 0;
+};
+
+/** Minimal fail-closed support for the exact/caret ranges in pi manifests. */
+export const satisfiesManifestRange = (
+  version: string,
+  range: string,
+): boolean => {
+  const actual = parseVersion(version);
+  const caret = range.startsWith("^");
+  const expected = parseVersion(caret ? range.slice(1) : range);
+  if (actual === undefined || expected === undefined) return false;
+  if (!caret) return compareVersion(actual, expected) === 0;
+  if (compareVersion(actual, expected) < 0) return false;
+  if (expected[0] > 0) return actual[0] === expected[0];
+  if (expected[1] > 0) {
+    return actual[0] === 0 && actual[1] === expected[1];
+  }
+  return actual[0] === 0 && actual[1] === 0 && actual[2] === expected[2];
+};
+
+const assertSuccess = (
+  label: string,
+  result: Awaited<ReturnType<CommandRunner>>,
+) => {
+  if (result.timedOut || result.exitCode !== 0) {
+    throw new Error(
+      `${label} failed${result.timedOut ? " (timed out)" : ""}: ${result.stderr.trim()}`,
+    );
+  }
+  return result.stdout.trim();
+};
+
+export const discoverPiInstallation = async (
+  options: DiscoverInstallationOptions = {},
+): Promise<PiInstallation> => {
+  const bunExecutable = resolve(options.bunExecutable ?? process.execPath);
+  const platform = options.platform ?? process.platform;
+  const run = options.run ?? runCommand;
+  const globalBin = assertSuccess(
+    "bun global bin discovery",
+    await run([bunExecutable, "pm", "bin", "--global"], options.commandOptions),
+  );
+  if (!isAbsolute(globalBin)) {
+    throw new Error("Bun global bin directory is not absolute");
+  }
+
+  const executable = platform === "win32" ? "pi.exe" : "pi";
+  const binaryPath = join(globalBin, executable);
+  const binaryRealPath = await realpath(binaryPath);
+  const packageRoot = await findPackageRoot(
+    binaryRealPath,
+    "@earendil-works/pi-coding-agent",
+  );
+  const codingManifest = await readManifest(packageRoot);
+  const packageName = codingManifest.name;
+  const packageVersion = codingManifest.version;
+  if (packageName === undefined || packageVersion === undefined) {
+    throw new Error("global pi package manifest lacks name/version");
+  }
+  const binTarget = codingManifest.bin?.pi;
+  if (binTarget === undefined)
+    throw new Error("global pi manifest lacks bin.pi");
+  if ((await realpath(join(packageRoot, binTarget))) !== binaryRealPath) {
+    throw new Error(
+      "global pi binary does not belong to the discovered package",
+    );
+  }
+  const binaryVersion = assertSuccess(
+    "global pi version",
+    await run([binaryPath, "--version"], options.commandOptions),
+  );
+  if (binaryVersion !== packageVersion) {
+    throw new Error(
+      `global pi binary ${binaryVersion} != package ${packageVersion}`,
+    );
+  }
+
+  const globalModules = findNodeModulesRoot(packageRoot);
+  const corePackages: Record<string, PiCorePackage> = {};
+  for (const name of PI_BASELINE_PACKAGES) {
+    const root =
+      name === packageName
+        ? packageRoot
+        : await realpath(join(globalModules, ...name.split("/")));
+    const manifest = await readManifest(root);
+    if (manifest.name !== name) {
+      throw new Error(`global package root mismatch: expected ${name}`);
+    }
+    if (manifest.version === undefined) {
+      throw new Error(`${name} manifest lacks a version`);
+    }
+    corePackages[name] = {
+      root,
+      version: manifest.version,
+      manifest,
+    };
+  }
+
+  const cohortNames = new Set<string>(PI_BASELINE_PACKAGES);
+  for (const [owner, pkg] of Object.entries(corePackages)) {
+    for (const [dependency, range] of Object.entries(
+      pkg.manifest.dependencies ?? {},
+    )) {
+      if (!cohortNames.has(dependency)) continue;
+      const installed = corePackages[dependency];
+      if (
+        installed === undefined ||
+        !satisfiesManifestRange(installed.version, range)
+      ) {
+        throw new Error(
+          `${owner} requires ${dependency}@${range}, installed ${installed?.version ?? "missing"}`,
+        );
+      }
+    }
+  }
+
+  return {
+    bunExecutable,
+    globalBin: await realpath(globalBin),
+    binaryPath,
+    binaryRealPath,
+    packageRoot,
+    packageName,
+    packageVersion,
+    corePackages,
+  };
+};

--- a/scripts/pi-compat/process.ts
+++ b/scripts/pi-compat/process.ts
@@ -1,0 +1,189 @@
+import { spawn } from "node:child_process";
+import { StringDecoder } from "node:string_decoder";
+
+const DEFAULT_MAX_OUTPUT = 256 * 1024;
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export interface CommandResult {
+  argv: string[];
+  exitCode: number | null;
+  signal?: NodeJS.Signals;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+  truncated: boolean;
+}
+
+export interface RunCommandOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+  maxOutputBytes?: number;
+}
+
+export type CommandRunner = (
+  argv: string[],
+  options?: RunCommandOptions,
+) => Promise<CommandResult>;
+
+const appendBounded = (
+  current: string,
+  chunk: string,
+  maxBytes: number,
+): { value: string; truncated: boolean } => {
+  const combined = `${current}${chunk}`;
+  if (Buffer.byteLength(combined) <= maxBytes) {
+    return { value: combined, truncated: false };
+  }
+  const bytes = Buffer.from(combined);
+  return {
+    value: bytes.subarray(0, maxBytes).toString("utf8"),
+    truncated: true,
+  };
+};
+
+export const runCommand: CommandRunner = async (argv, options = {}) => {
+  if (argv.length === 0) throw new Error("command argv must not be empty");
+  const maxOutputBytes = options.maxOutputBytes ?? DEFAULT_MAX_OUTPUT;
+  const child = spawn(argv[0] ?? "", argv.slice(1), {
+    cwd: options.cwd,
+    env: options.env,
+    shell: false,
+    detached: true,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  let truncated = false;
+  child.stdout.on("data", (chunk: Buffer | string) => {
+    const next = appendBounded(stdout, String(chunk), maxOutputBytes);
+    stdout = next.value;
+    truncated ||= next.truncated;
+  });
+  child.stderr.on("data", (chunk: Buffer | string) => {
+    const next = appendBounded(stderr, String(chunk), maxOutputBytes);
+    stderr = next.value;
+    truncated ||= next.truncated;
+  });
+
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  let timedOut = false;
+  let killTimer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    terminateProcessGroup(child.pid, "SIGTERM");
+    killTimer = setTimeout(
+      () => terminateProcessGroup(child.pid, "SIGKILL"),
+      2_000,
+    );
+    killTimer.unref?.();
+  }, timeoutMs);
+  timeout.unref?.();
+
+  const result = await new Promise<{
+    exitCode: number | null;
+    signal?: NodeJS.Signals;
+  }>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (exitCode, signal) =>
+      resolve({ exitCode, signal: signal ?? undefined }),
+    );
+  }).finally(() => {
+    clearTimeout(timeout);
+    if (killTimer !== undefined) clearTimeout(killTimer);
+  });
+
+  return {
+    argv: [...argv],
+    ...result,
+    stdout,
+    stderr,
+    timedOut,
+    truncated,
+  };
+};
+
+export interface JsonlDecoderOptions {
+  maxLineBytes?: number;
+  maxRecords?: number;
+}
+
+/** Strict LF-only streaming JSONL decoder for pi RPC. */
+export class StrictJsonlDecoder {
+  private readonly decoder = new StringDecoder("utf8");
+  private readonly maxLineBytes: number;
+  private readonly maxRecords: number;
+  private buffer = "";
+  private records = 0;
+
+  constructor(options: JsonlDecoderOptions = {}) {
+    this.maxLineBytes = options.maxLineBytes ?? 256 * 1024;
+    this.maxRecords = options.maxRecords ?? 2_000;
+  }
+
+  push(chunk: Uint8Array | string): unknown[] {
+    this.buffer +=
+      typeof chunk === "string"
+        ? chunk
+        : this.decoder.write(Buffer.from(chunk));
+    return this.drain(false);
+  }
+
+  finish(): unknown[] {
+    this.buffer += this.decoder.end();
+    return this.drain(true);
+  }
+
+  private drain(final: boolean): unknown[] {
+    const output: unknown[] = [];
+    while (true) {
+      const newline = this.buffer.indexOf("\n");
+      if (newline === -1) break;
+      let line = this.buffer.slice(0, newline);
+      this.buffer = this.buffer.slice(newline + 1);
+      if (line.endsWith("\r")) line = line.slice(0, -1);
+      if (line === "") continue;
+      output.push(this.parseLine(line));
+    }
+    if (Buffer.byteLength(this.buffer) > this.maxLineBytes) {
+      throw new Error("RPC JSONL record exceeds byte limit");
+    }
+    if (final && this.buffer !== "") {
+      throw new Error("RPC JSONL ended with an incomplete record");
+    }
+    return output;
+  }
+
+  private parseLine(line: string): unknown {
+    if (Buffer.byteLength(line) > this.maxLineBytes) {
+      throw new Error("RPC JSONL record exceeds byte limit");
+    }
+    this.records += 1;
+    if (this.records > this.maxRecords) {
+      throw new Error("RPC JSONL record count exceeds limit");
+    }
+    try {
+      return JSON.parse(line) as unknown;
+    } catch {
+      throw new Error("RPC emitted malformed JSONL");
+    }
+  }
+}
+
+export const terminateProcessGroup = (
+  pid: number | undefined,
+  signal: NodeJS.Signals,
+): void => {
+  if (pid === undefined) return;
+  try {
+    process.kill(-pid, signal);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+      try {
+        process.kill(pid, signal);
+      } catch {
+        // The child already exited.
+      }
+    }
+  }
+};

--- a/scripts/pi-compat/rpc-smoke.ts
+++ b/scripts/pi-compat/rpc-smoke.ts
@@ -1,0 +1,274 @@
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { PiInstallation } from "./installation";
+import { StrictJsonlDecoder, terminateProcessGroup } from "./process";
+
+const EXPECTED_TOOLS = [
+  "subagent",
+  "workflow",
+  "worktree_create",
+  "worktree_remove",
+  "task_completed",
+  "AskUserQuestion",
+  "web_search",
+  "web_fetch",
+];
+
+export interface RpcSmokeOptions {
+  repoRoot: string;
+  timeoutMs?: number;
+  keepTemp?: boolean;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const appendBounded = (current: string, chunk: string, max = 256 * 1024) => {
+  const combined = `${current}${chunk}`;
+  if (Buffer.byteLength(combined) <= max) return combined;
+  return Buffer.from(combined).subarray(0, max).toString("utf8");
+};
+
+const probeSource = (command: string, marker: string): string => `
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export default function compatProbe(pi: ExtensionAPI): void {
+  pi.registerProvider("pi-compat-smoke", {
+    name: "pi compatibility smoke (never invoked)",
+    baseUrl: "http://127.0.0.1:9",
+    apiKey: "compat-smoke-never-send",
+    api: "openai-responses",
+    models: [{
+      id: "never-invoked",
+      name: "Compatibility Smoke",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 1024,
+      maxTokens: 64,
+    }],
+  });
+
+  pi.registerCommand(${JSON.stringify(command)}, {
+    description: "Internal compatibility probe",
+    handler: async (_args, ctx) => {
+      const tools = new Set(pi.getAllTools().map((tool) => tool.name));
+      const missing = ${JSON.stringify(EXPECTED_TOOLS)}.filter((name) => !tools.has(name));
+      if (missing.length > 0) throw new Error("missing tools: " + missing.join(", "));
+      if (ctx.mode !== "rpc" || !ctx.hasUI || typeof ctx.shutdown !== "function") {
+        throw new Error("incompatible extension context");
+      }
+      ctx.ui.notify(${JSON.stringify(marker)}, "info");
+      ctx.shutdown();
+    },
+  });
+}
+`;
+
+export const smokeGlobalPiRpc = async (
+  installation: PiInstallation,
+  options: RpcSmokeOptions,
+): Promise<void> => {
+  const tempRoot = await mkdtemp(join(tmpdir(), "pi-compat-rpc-"));
+  const nonce = crypto.randomUUID();
+  const command = `pi-compat-${nonce}`;
+  const marker = `PI_COMPAT_OK:${nonce}`;
+  let child: ReturnType<typeof spawn> | undefined;
+  try {
+    const home = join(tempRoot, "home");
+    const agentDir = join(tempRoot, "agent");
+    const cwd = join(tempRoot, "cwd");
+    await Promise.all([
+      mkdir(home, { recursive: true }),
+      mkdir(agentDir, { recursive: true }),
+      mkdir(cwd, { recursive: true }),
+    ]);
+    const probe = join(tempRoot, "probe.ts");
+    await writeFile(probe, probeSource(command, marker), { mode: 0o600 });
+
+    const args = [
+      installation.binaryRealPath,
+      "--mode",
+      "rpc",
+      "--no-session",
+      "--no-approve",
+      "--no-extensions",
+      "--no-skills",
+      "--no-prompt-templates",
+      "--no-themes",
+      "--no-context-files",
+      "--provider",
+      "pi-compat-smoke",
+      "--model",
+      "never-invoked",
+      "-e",
+      join(options.repoRoot, "pi/extensions/pi-harness/index.ts"),
+      "-e",
+      join(options.repoRoot, "pi/extensions/codex-web/index.ts"),
+      "-e",
+      probe,
+    ];
+    const env: NodeJS.ProcessEnv = {
+      HOME: home,
+      PATH: "/usr/bin:/bin",
+      TMPDIR: tempRoot,
+      PI_CODING_AGENT_DIR: agentDir,
+      PI_CODING_AGENT_SESSION_DIR: join(tempRoot, "sessions"),
+      PI_OFFLINE: "1",
+      PI_SKIP_VERSION_CHECK: "1",
+      PI_TELEMETRY: "0",
+      LANG: "C.UTF-8",
+    };
+    child = spawn(installation.bunExecutable, args, {
+      cwd,
+      env,
+      shell: false,
+      detached: true,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const { stdin, stdout, stderr: stderrStream } = child;
+    if (stdin === null || stdout === null || stderrStream === null) {
+      throw new Error("pi RPC pipes were not created");
+    }
+
+    const decoder = new StrictJsonlDecoder();
+    let stderr = "";
+    let commandFound = false;
+    let markerFound = false;
+    let promptSucceeded = false;
+    let failure: Error | undefined;
+    const setFailure = (error: Error) => {
+      failure ??= error;
+    };
+    const sendRpc = (payload: Record<string, unknown>): void => {
+      if (stdin.destroyed || !stdin.writable) {
+        setFailure(new Error("pi RPC stdin closed before request"));
+        return;
+      }
+      stdin.write(`${JSON.stringify(payload)}\n`, (error) => {
+        if (error !== null && error !== undefined) setFailure(error);
+      });
+    };
+    stdin.on("error", (error) => setFailure(error));
+
+    stderrStream.on("data", (chunk: Buffer | string) => {
+      stderr = appendBounded(stderr, String(chunk));
+    });
+    stdout.on("data", (chunk: Buffer | string) => {
+      try {
+        for (const raw of decoder.push(chunk)) {
+          if (!isRecord(raw)) continue;
+          const type = raw.type;
+          if (type === "extension_error") {
+            setFailure(new Error(`pi extension error: ${JSON.stringify(raw)}`));
+          }
+          if (
+            type === "agent_start" ||
+            type === "turn_start" ||
+            type === "before_provider_request"
+          ) {
+            setFailure(
+              new Error(`compatibility probe reached agent/provider: ${type}`),
+            );
+          }
+          if (
+            type === "extension_ui_request" &&
+            raw.method === "notify" &&
+            raw.message === marker
+          ) {
+            markerFound = true;
+          }
+          if (type !== "response") continue;
+          if (raw.id === "commands") {
+            const data = raw.data;
+            const commands =
+              isRecord(data) && Array.isArray(data.commands)
+                ? data.commands
+                : [];
+            commandFound = commands.some(
+              (item) => isRecord(item) && item.name === command,
+            );
+            if (!commandFound) {
+              setFailure(new Error("compatibility probe command did not load"));
+              terminateProcessGroup(child?.pid, "SIGTERM");
+              continue;
+            }
+            sendRpc({
+              id: "probe",
+              type: "prompt",
+              message: `/${command}`,
+            });
+          } else if (raw.id === "probe") {
+            promptSucceeded = raw.success === true;
+            if (!promptSucceeded) {
+              setFailure(
+                new Error(
+                  `compatibility probe command failed: ${JSON.stringify(raw)}`,
+                ),
+              );
+            }
+          }
+        }
+      } catch (error) {
+        setFailure(error instanceof Error ? error : new Error(String(error)));
+        terminateProcessGroup(child?.pid, "SIGTERM");
+      }
+    });
+
+    sendRpc({ id: "commands", type: "get_commands" });
+
+    const timeoutMs = options.timeoutMs ?? 15_000;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const exit = await Promise.race([
+      new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+        (resolveExit, rejectExit) => {
+          child?.once("error", rejectExit);
+          child?.once("close", (code, signal) => resolveExit({ code, signal }));
+        },
+      ),
+      new Promise<never>((_, rejectTimeout) => {
+        timeout = setTimeout(() => {
+          terminateProcessGroup(child?.pid, "SIGTERM");
+          rejectTimeout(new Error("pi RPC compatibility smoke timed out"));
+        }, timeoutMs);
+        timeout.unref?.();
+      }),
+    ]).finally(() => {
+      if (timeout !== undefined) clearTimeout(timeout);
+    });
+
+    try {
+      decoder.finish();
+    } catch (error) {
+      setFailure(error instanceof Error ? error : new Error(String(error)));
+    }
+    if (failure !== undefined) throw failure;
+    if (!commandFound || !markerFound || !promptSucceeded) {
+      throw new Error(
+        `pi RPC compatibility probe incomplete: command=${commandFound} marker=${markerFound} response=${promptSucceeded} stderr=${stderr}`,
+      );
+    }
+    if (exit.code !== 0 && exit.signal === null) {
+      throw new Error(`pi RPC exited ${exit.code}: ${stderr}`);
+    }
+    if (/extension|failed|error/i.test(stderr)) {
+      throw new Error(`pi RPC reported startup diagnostics: ${stderr}`);
+    }
+  } finally {
+    if (
+      child !== undefined &&
+      child.exitCode === null &&
+      child.signalCode === null
+    ) {
+      terminateProcessGroup(child.pid, "SIGTERM");
+      await Bun.sleep(200);
+      if (child.exitCode === null && child.signalCode === null) {
+        terminateProcessGroup(child.pid, "SIGKILL");
+        await Bun.sleep(50);
+      }
+    }
+    if (!options.keepTemp) await rm(tempRoot, { recursive: true, force: true });
+  }
+};

--- a/scripts/pi-compat/update-state.ts
+++ b/scripts/pi-compat/update-state.ts
@@ -1,0 +1,327 @@
+import { dirname, isAbsolute, join } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import { mkdir, open, readFile, rename, rm, writeFile } from "node:fs/promises";
+import type { PiCompatibilityResult } from "./index";
+import type { PiInstallation } from "./installation";
+import { runCommand, type CommandResult, type CommandRunner } from "./process";
+
+interface RecoveryJournal {
+  schema: "pi-harness/update-recovery";
+  version: 1;
+  createdAt: string;
+  packageName: string;
+  previousVersion: string;
+  previousSignature: string;
+  rollbackArgv: string[];
+}
+
+export interface UpdatePiDependencies {
+  checkCompatibility(): Promise<PiCompatibilityResult>;
+  discover(): Promise<PiInstallation>;
+  run?: CommandRunner;
+  lockPath?: string;
+  journalPath?: string;
+  pid?: number;
+}
+
+export interface UpdatePiResult {
+  ok: boolean;
+  updated: boolean;
+  rolledBack: boolean;
+  previousVersion?: string;
+  currentVersion?: string;
+  message: string;
+  manualRecoveryArgv?: string[];
+}
+
+interface UpdateLock {
+  release(): Promise<void>;
+}
+
+const processAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+};
+
+export const acquireUpdateLock = async (
+  path: string,
+  pid = process.pid,
+): Promise<UpdateLock> => {
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const handle = await open(path, "wx", 0o600);
+      await handle.writeFile(`${pid}\n`);
+      await handle.close();
+      let released = false;
+      return {
+        async release() {
+          if (released) return;
+          released = true;
+          await rm(path, { force: true });
+        },
+      };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      let owner = Number.NaN;
+      try {
+        owner = Number((await readFile(path, "utf8")).trim());
+      } catch {
+        // Treat an unreadable lock as active rather than deleting blindly.
+      }
+      if (!Number.isInteger(owner) || owner <= 0) {
+        throw new Error("pi update lock exists but has no valid owner pid");
+      }
+      if (processAlive(owner)) {
+        throw new Error(`another pi update is active (pid ${owner})`);
+      }
+      if (attempt === 0) {
+        await rm(path, { force: true });
+        continue;
+      }
+      throw new Error("could not recover stale pi update lock");
+    }
+  }
+  throw new Error("could not acquire pi update lock");
+};
+
+const defaultLockPath = (): string =>
+  join(tmpdir(), `pi-harness-update-${process.getuid?.() ?? "user"}.lock`);
+const defaultJournalPath = (): string =>
+  join(homedir(), ".cache", "pi-harness", "pi-update-recovery.json");
+
+const writeJournal = async (
+  path: string,
+  journal: RecoveryJournal,
+): Promise<void> => {
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+  const temporary = `${path}.${process.pid}.tmp`;
+  await writeFile(temporary, `${JSON.stringify(journal, null, 2)}\n`, {
+    mode: 0o600,
+  });
+  await rename(temporary, path);
+};
+
+const readJournal = async (
+  path: string,
+): Promise<RecoveryJournal | undefined> => {
+  try {
+    const value = JSON.parse(await readFile(path, "utf8")) as RecoveryJournal;
+    if (
+      value.schema !== "pi-harness/update-recovery" ||
+      value.version !== 1 ||
+      typeof value.packageName !== "string" ||
+      typeof value.previousVersion !== "string" ||
+      typeof value.previousSignature !== "string" ||
+      !Array.isArray(value.rollbackArgv) ||
+      value.rollbackArgv.some((item) => typeof item !== "string") ||
+      value.rollbackArgv.length !== 5 ||
+      !isAbsolute(value.rollbackArgv[0] ?? "") ||
+      value.rollbackArgv[1] !== "install" ||
+      value.rollbackArgv[2] !== "-g" ||
+      value.rollbackArgv[3] !== "--ignore-scripts" ||
+      value.rollbackArgv[4] !== `${value.packageName}@${value.previousVersion}`
+    ) {
+      throw new Error("invalid pi update recovery journal");
+    }
+    return value;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+};
+
+const successful = (result: CommandResult): boolean =>
+  !result.timedOut && result.exitCode === 0;
+
+const installationSignature = (installation: PiInstallation): string =>
+  JSON.stringify({
+    packageRoot: installation.packageRoot,
+    binaryRealPath: installation.binaryRealPath,
+    packageName: installation.packageName,
+    packageVersion: installation.packageVersion,
+    core: Object.fromEntries(
+      Object.entries(installation.corePackages)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([name, pkg]) => [name, { root: pkg.root, version: pkg.version }]),
+    ),
+  });
+
+const rollback = async (
+  journal: RecoveryJournal,
+  dependencies: UpdatePiDependencies,
+  run: CommandRunner,
+  journalPath: string,
+): Promise<UpdatePiResult> => {
+  const result = await run(journal.rollbackArgv, {
+    timeoutMs: 5 * 60_000,
+    maxOutputBytes: 512 * 1024,
+  });
+  if (!successful(result)) {
+    return {
+      ok: false,
+      updated: false,
+      rolledBack: false,
+      previousVersion: journal.previousVersion,
+      message: `automatic rollback failed: ${result.stderr || result.stdout}`,
+      manualRecoveryArgv: journal.rollbackArgv,
+    };
+  }
+  try {
+    const restored = await dependencies.checkCompatibility();
+    if (restored.installation.packageVersion !== journal.previousVersion) {
+      throw new Error(
+        `restored version ${restored.installation.packageVersion} != ${journal.previousVersion}`,
+      );
+    }
+    await rm(journalPath, { force: true });
+    return {
+      ok: false,
+      updated: false,
+      rolledBack: true,
+      previousVersion: journal.previousVersion,
+      currentVersion: restored.installation.packageVersion,
+      message: `candidate was incompatible; restored pi ${journal.previousVersion}`,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      updated: false,
+      rolledBack: false,
+      previousVersion: journal.previousVersion,
+      message: `rollback installed but verification failed: ${String(error)}`,
+      manualRecoveryArgv: journal.rollbackArgv,
+    };
+  }
+};
+
+export const updatePiSafely = async (
+  dependencies: UpdatePiDependencies,
+): Promise<UpdatePiResult> => {
+  const run = dependencies.run ?? runCommand;
+  const lockPath = dependencies.lockPath ?? defaultLockPath();
+  const journalPath = dependencies.journalPath ?? defaultJournalPath();
+  const lock = await acquireUpdateLock(lockPath, dependencies.pid);
+  try {
+    const unfinished = await readJournal(journalPath);
+    if (unfinished !== undefined) {
+      try {
+        const current = await dependencies.discover();
+        const verified = await dependencies.checkCompatibility();
+        if (
+          installationSignature(current) === unfinished.previousSignature &&
+          installationSignature(verified.installation) ===
+            unfinished.previousSignature
+        ) {
+          await rm(journalPath, { force: true });
+          return {
+            ok: false,
+            updated: false,
+            rolledBack: true,
+            previousVersion: unfinished.previousVersion,
+            currentVersion: verified.installation.packageVersion,
+            message:
+              "verified an already-restored installation and cleared its recovery journal; rerun update:pi to update",
+          };
+        }
+      } catch {
+        // The interrupted state is not known-good; reinstall below.
+      }
+      return rollback(unfinished, dependencies, run, journalPath);
+    }
+
+    // Establish a known-good rollback target before any global mutation.
+    const preflight = await dependencies.checkCompatibility();
+    const previous = preflight.installation;
+    const rollbackArgv = [
+      previous.bunExecutable,
+      "install",
+      "-g",
+      "--ignore-scripts",
+      `${previous.packageName}@${previous.packageVersion}`,
+    ];
+    const journal: RecoveryJournal = {
+      schema: "pi-harness/update-recovery",
+      version: 1,
+      createdAt: new Date().toISOString(),
+      packageName: previous.packageName,
+      previousVersion: previous.packageVersion,
+      previousSignature: installationSignature(previous),
+      rollbackArgv,
+    };
+    await writeJournal(journalPath, journal);
+
+    const updateEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      PATH: `${dirname(previous.bunExecutable)}:${process.env.PATH ?? ""}`,
+    };
+    const updateResult = await run(
+      [previous.bunExecutable, previous.binaryRealPath, "update", "--self"],
+      {
+        env: updateEnv,
+        timeoutMs: 10 * 60_000,
+        maxOutputBytes: 512 * 1024,
+      },
+    );
+
+    let discovered: PiInstallation | undefined;
+    try {
+      discovered = await dependencies.discover();
+    } catch {
+      // A partial update can make discovery fail; rollback below.
+    }
+    const changed =
+      discovered === undefined ||
+      installationSignature(discovered) !== installationSignature(previous);
+
+    if (!successful(updateResult) && !changed) {
+      try {
+        const verified = await dependencies.checkCompatibility();
+        if (
+          installationSignature(verified.installation) ===
+          installationSignature(previous)
+        ) {
+          await rm(journalPath, { force: true });
+          return {
+            ok: false,
+            updated: false,
+            rolledBack: false,
+            previousVersion: previous.packageVersion,
+            currentVersion: previous.packageVersion,
+            message: `pi update failed without changing the verified installation: ${updateResult.stderr || updateResult.stdout}`,
+          };
+        }
+      } catch {
+        // Metadata can stay unchanged after a partial in-place mutation.
+      }
+      return rollback(journal, dependencies, run, journalPath);
+    }
+
+    if (successful(updateResult)) {
+      try {
+        const candidate = await dependencies.checkCompatibility();
+        await rm(journalPath, { force: true });
+        return {
+          ok: true,
+          updated:
+            installationSignature(candidate.installation) !==
+            installationSignature(previous),
+          rolledBack: false,
+          previousVersion: previous.packageVersion,
+          currentVersion: candidate.installation.packageVersion,
+          message: `pi ${candidate.installation.packageVersion} passed compatibility checks`,
+        };
+      } catch {
+        // Candidate is incompatible; rollback below.
+      }
+    }
+
+    return rollback(journal, dependencies, run, journalPath);
+  } finally {
+    await lock.release();
+  }
+};

--- a/scripts/update-pi.ts
+++ b/scripts/update-pi.ts
@@ -1,0 +1,24 @@
+import { resolve } from "node:path";
+import { checkPiCompatibility } from "./pi-compat/index";
+import { discoverPiInstallation } from "./pi-compat/installation";
+import { updatePiSafely } from "./pi-compat/update-state";
+
+const repoRoot = resolve(import.meta.dir, "..");
+
+try {
+  const result = await updatePiSafely({
+    checkCompatibility: () => checkPiCompatibility(repoRoot),
+    discover: () => discoverPiInstallation(),
+  });
+  const log = result.ok ? console.log : console.error;
+  log(`update-pi: ${result.message}`);
+  if (result.manualRecoveryArgv !== undefined) {
+    console.error(
+      `Manual recovery: ${result.manualRecoveryArgv.map((part) => JSON.stringify(part)).join(" ")}`,
+    );
+  }
+  process.exit(result.ok ? 0 : 1);
+} catch (error) {
+  console.error(`update-pi: FAILED before update: ${String(error)}`);
+  process.exit(1);
+}

--- a/tests/pi-harness/check-pi-baseline.test.ts
+++ b/tests/pi-harness/check-pi-baseline.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  assertLocalPiBaseline,
+  checkLocalPiBaseline,
+  PI_BASELINE_PACKAGES,
+} from "../../scripts/pi-compat/baseline";
+
+const roots: string[] = [];
+const versions: Record<(typeof PI_BASELINE_PACKAGES)[number], string> = {
+  "@earendil-works/pi-coding-agent": "1.2.3",
+  "@earendil-works/pi-ai": "1.2.3",
+  "@earendil-works/pi-agent-core": "1.2.3",
+  "@earendil-works/pi-tui": "1.2.3",
+  typebox: "9.8.7",
+};
+
+const setupBaseline = async (): Promise<string> => {
+  const root = await mkdtemp(join(tmpdir(), "pi-baseline-"));
+  roots.push(root);
+
+  const direct = {
+    "@earendil-works/pi-coding-agent": "1.2.3",
+    "@earendil-works/pi-ai": "1.2.3",
+    "@earendil-works/pi-tui": "1.2.3",
+  };
+  await writeFile(
+    join(root, "package.json"),
+    JSON.stringify({ devDependencies: direct }),
+  );
+  const packages = Object.fromEntries(
+    PI_BASELINE_PACKAGES.map((name) => [name, [`${name}@${versions[name]}`]]),
+  );
+  await writeFile(
+    join(root, "bun.lock"),
+    JSON.stringify({
+      workspaces: { "": { devDependencies: direct } },
+      packages,
+    }),
+  );
+
+  for (const name of PI_BASELINE_PACKAGES) {
+    const packageRoot = join(root, "node_modules", ...name.split("/"));
+    await mkdir(packageRoot, { recursive: true });
+    await writeFile(
+      join(packageRoot, "package.json"),
+      JSON.stringify({ name, version: versions[name] }),
+    );
+  }
+  return root;
+};
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true })),
+  );
+});
+
+describe("local pi baseline", () => {
+  test("accepts a coherent direct pin, lock, and installed cohort", async () => {
+    const root = await setupBaseline();
+    const result = await checkLocalPiBaseline(root);
+    expect(result.ok).toBe(true);
+    expect(result.issues).toEqual([]);
+    expect(result.packages.map((item) => item.name)).toEqual([
+      ...PI_BASELINE_PACKAGES,
+    ]);
+  });
+
+  test("reports direct pin, lock, and stale installed tree separately", async () => {
+    const root = await setupBaseline();
+    await writeFile(
+      join(root, "package.json"),
+      JSON.stringify({
+        devDependencies: {
+          "@earendil-works/pi-coding-agent": "2.0.0",
+          "@earendil-works/pi-ai": "1.2.3",
+        },
+      }),
+    );
+    await writeFile(
+      join(root, "node_modules/@earendil-works/pi-ai/package.json"),
+      JSON.stringify({
+        name: "@earendil-works/pi-ai",
+        version: "1.2.2",
+      }),
+    );
+
+    const result = await checkLocalPiBaseline(root);
+    expect(result.ok).toBe(false);
+    expect(result.issues.join("\n")).toContain(
+      "lock-pin: @earendil-works/pi-coding-agent",
+    );
+    expect(result.issues.join("\n")).toContain(
+      "direct-pin: @earendil-works/pi-tui",
+    );
+    expect(result.issues.join("\n")).toContain(
+      "installed-tree: @earendil-works/pi-ai",
+    );
+  });
+
+  test("rejects non-exact direct pins and resolved versions that differ", async () => {
+    const root = await setupBaseline();
+    const direct = {
+      "@earendil-works/pi-coding-agent": "^1.2.3",
+      "@earendil-works/pi-ai": "1.2.3",
+      "@earendil-works/pi-tui": "1.2.3",
+    };
+    await writeFile(
+      join(root, "package.json"),
+      JSON.stringify({ devDependencies: direct }),
+    );
+    const resolved = {
+      ...versions,
+      "@earendil-works/pi-coding-agent": "1.2.4",
+    };
+    await writeFile(
+      join(root, "bun.lock"),
+      JSON.stringify({
+        workspaces: { "": { devDependencies: direct } },
+        packages: Object.fromEntries(
+          PI_BASELINE_PACKAGES.map((name) => [
+            name,
+            [`${name}@${resolved[name]}`],
+          ]),
+        ),
+      }),
+    );
+    await writeFile(
+      join(root, "node_modules/@earendil-works/pi-coding-agent/package.json"),
+      JSON.stringify({
+        name: "@earendil-works/pi-coding-agent",
+        version: "1.2.4",
+      }),
+    );
+
+    const checked = await checkLocalPiBaseline(root);
+    expect(checked.issues.join("\n")).toContain("must use an exact version");
+    expect(checked.issues.join("\n")).toContain("resolved-pin:");
+  });
+
+  test("fails with frozen-install remediation", async () => {
+    const root = await setupBaseline();
+    await rm(join(root, "node_modules/typebox"), { recursive: true });
+    await expect(assertLocalPiBaseline(root)).rejects.toThrow(
+      "bun install --frozen-lockfile",
+    );
+  });
+});

--- a/tests/pi-harness/check-pi-compat.test.ts
+++ b/tests/pi-harness/check-pi-compat.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { assertNoLocalPiResolution } from "../../scripts/pi-compat/compile";
+import { checkPiCompatibility } from "../../scripts/pi-compat/index";
+import {
+  satisfiesManifestRange,
+  type PiInstallation,
+} from "../../scripts/pi-compat/installation";
+import {
+  runCommand,
+  StrictJsonlDecoder,
+} from "../../scripts/pi-compat/process";
+
+const installation = (version = "0.99.0"): PiInstallation => ({
+  bunExecutable: "/tools/bun",
+  globalBin: "/global/bin",
+  binaryPath: "/global/bin/pi",
+  binaryRealPath:
+    "/global/node_modules/@earendil-works/pi-coding-agent/dist/cli.js",
+  packageRoot: "/global/node_modules/@earendil-works/pi-coding-agent",
+  packageName: "@earendil-works/pi-coding-agent",
+  packageVersion: version,
+  corePackages: {
+    "@earendil-works/pi-coding-agent": {
+      root: "/global/node_modules/@earendil-works/pi-coding-agent",
+      version,
+      manifest: {},
+    },
+    "@earendil-works/pi-ai": {
+      root: "/global/node_modules/@earendil-works/pi-ai",
+      version,
+      manifest: {},
+    },
+    "@earendil-works/pi-agent-core": {
+      root: "/global/node_modules/@earendil-works/pi-agent-core",
+      version,
+      manifest: {},
+    },
+    "@earendil-works/pi-tui": {
+      root: "/global/node_modules/@earendil-works/pi-tui",
+      version,
+      manifest: {},
+    },
+    typebox: {
+      root: "/global/node_modules/typebox",
+      version: "1.1.38",
+      manifest: {},
+    },
+  },
+});
+
+describe("pi compatibility policy", () => {
+  test("accepts global version drift when compile and runtime contracts pass", async () => {
+    const calls: string[] = [];
+    const result = await checkPiCompatibility("/repo", {
+      checkBaseline: async () => ({
+        ok: true,
+        issues: [],
+        packages: [
+          {
+            name: "@earendil-works/pi-coding-agent",
+            lockedVersion: "0.80.7",
+          },
+        ],
+      }),
+      discover: async () => installation("0.99.0"),
+      compile: async () => {
+        calls.push("compile");
+      },
+      smoke: async () => {
+        calls.push("smoke");
+      },
+    });
+
+    expect(result.installation.packageVersion).toBe("0.99.0");
+    expect(calls).toEqual(["compile", "smoke"]);
+  });
+
+  test("stops before discovery when the local baseline is stale", async () => {
+    let discovered = false;
+    await expect(
+      checkPiCompatibility("/repo", {
+        checkBaseline: async () => {
+          throw new Error("stale baseline");
+        },
+        discover: async () => {
+          discovered = true;
+          return installation();
+        },
+      }),
+    ).rejects.toThrow("stale baseline");
+    expect(discovered).toBe(false);
+  });
+});
+
+describe("strict pi RPC JSONL framing", () => {
+  test("handles fragmented UTF-8 and keeps Unicode line separators inside JSON", () => {
+    const decoder = new StrictJsonlDecoder();
+    const bytes = Buffer.from('{"text":"a b😀"}\n{"ok":true}\r\n');
+    const split = bytes.indexOf(Buffer.from("😀")) + 1;
+    expect(decoder.push(bytes.subarray(0, split))).toEqual([]);
+    expect(decoder.push(bytes.subarray(split))).toEqual([
+      { text: "a b😀" },
+      { ok: true },
+    ]);
+    expect(decoder.finish()).toEqual([]);
+  });
+
+  test("fails closed on malformed, oversized, incomplete, and excess records", () => {
+    expect(() => new StrictJsonlDecoder().push("not-json\n")).toThrow(
+      "malformed",
+    );
+    expect(() =>
+      new StrictJsonlDecoder({ maxLineBytes: 2 }).push('{"x":1}'),
+    ).toThrow("byte limit");
+    const incomplete = new StrictJsonlDecoder();
+    incomplete.push('{"x":1}');
+    expect(() => incomplete.finish()).toThrow("incomplete");
+    expect(() =>
+      new StrictJsonlDecoder({ maxRecords: 1 }).push("{}\n{}\n"),
+    ).toThrow("record count");
+  });
+});
+
+describe("bounded compatibility subprocesses", () => {
+  test("a timeout kills the spawned process group before returning", async () => {
+    if (process.platform === "win32") return;
+    const root = await mkdtemp(join(tmpdir(), "pi-process-group-"));
+    const pidFile = join(root, "grandchild.pid");
+    try {
+      const command = `(trap '' TERM; echo $BASHPID > ${JSON.stringify(pidFile)}; while true; do sleep 1; done) & wait`;
+      const commandResult = await runCommand(["bash", "-c", command], {
+        timeoutMs: 20,
+      });
+      expect(commandResult.timedOut).toBe(true);
+      const pid = Number((await readFile(pidFile, "utf8")).trim());
+      expect(() => process.kill(pid, 0)).toThrow();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("global declaration resolution guard", () => {
+  test("rejects repository-local pi declarations", () => {
+    expect(() =>
+      assertNoLocalPiResolution(
+        [join("/repo", "node_modules/@earendil-works/pi-tui/dist/index.d.ts")],
+        "/repo",
+        installation(),
+      ),
+    ).toThrow("repository-local");
+  });
+
+  test("accepts files from the captured global package roots", () => {
+    expect(() =>
+      assertNoLocalPiResolution(
+        ["/global/node_modules/@earendil-works/pi-tui/dist/index.d.ts"],
+        "/repo",
+        installation(),
+      ),
+    ).not.toThrow();
+  });
+});
+
+describe("pi manifest ranges", () => {
+  test("supports exact and caret ranges used by the pi package cohort", () => {
+    expect(satisfiesManifestRange("0.80.9", "^0.80.7")).toBe(true);
+    expect(satisfiesManifestRange("0.81.0", "^0.80.7")).toBe(false);
+    expect(satisfiesManifestRange("1.4.0", "^1.2.3")).toBe(true);
+    expect(satisfiesManifestRange("2.0.0", "^1.2.3")).toBe(false);
+    expect(satisfiesManifestRange("1.1.38", "1.1.38")).toBe(true);
+  });
+});

--- a/tests/pi-harness/check-pi-imports.test.ts
+++ b/tests/pi-harness/check-pi-imports.test.ts
@@ -39,10 +39,31 @@ describe("check-pi-imports self-containment analysis", () => {
     );
   });
 
-  test("flags a runtime @earendil-works import", () => {
-    expect(check('import { x } from "@earendil-works/pi-ai";')[0]).toContain(
-      "runtime import of @earendil-works",
+  test("allows only pi-tui's documented root runtime import in pi-harness", () => {
+    expect(
+      check('import { visibleWidth } from "@earendil-works/pi-tui";'),
+    ).toEqual([]);
+
+    for (const specifier of [
+      "@earendil-works/pi-ai",
+      "@earendil-works/pi-tui/dist/index.js",
+      "@earendil-works/pi-tui-evil",
+    ]) {
+      expect(
+        check(`import { x } from ${JSON.stringify(specifier)};`)[0],
+      ).toContain(`runtime import of ${specifier}`);
+    }
+  });
+
+  test("does not grant the pi-harness runtime allowlist to codex-web", () => {
+    const source = 'import { visibleWidth } from "@earendil-works/pi-tui";';
+    const violations = collectViolations(
+      "index.ts",
+      join(CODEX_WEB_EXTENSION_ROOT, "index.ts"),
+      source,
+      CODEX_WEB_EXTENSION_ROOT,
     );
+    expect(violations[0]).toContain("runtime import of @earendil-works/pi-tui");
   });
 
   test("flags a relative import that escapes the extension root", () => {

--- a/tests/pi-harness/child-run-integration.test.ts
+++ b/tests/pi-harness/child-run-integration.test.ts
@@ -117,6 +117,7 @@ const createRuntime = (cwd: string) => {
     | ((data: string) => { consume?: boolean; data?: string } | undefined)
     | undefined;
   let branch: unknown[] = [];
+  const notifications: string[] = [];
 
   const ctx = {
     cwd,
@@ -127,7 +128,7 @@ const createRuntime = (cwd: string) => {
       select: async () => undefined,
       confirm: async () => false,
       input: async () => undefined,
-      notify: () => {},
+      notify: (message: string) => notifications.push(message),
       setWidget(
         _key: string,
         content:
@@ -227,6 +228,8 @@ const createRuntime = (cwd: string) => {
     getCustomCalls: () => customCalls,
     getCustomComponent: () => customComponent,
     getCustomOptions: () => customOptions,
+    getNotifications: () => [...notifications],
+    hasTerminalInputHandler: () => terminalInputHandler !== undefined,
     setEditorState(lines: string[], line: number, col: number) {
       editorLines = [...lines];
       editorCursor = { line, col };
@@ -729,6 +732,30 @@ describe("child-run subagent integration", () => {
     runtime.getComponent()?.handleInput?.("q");
     expect(runtime.tui.focusedComponent).toBe(customEditor);
     expect(runtime.getComponent()).toBeUndefined();
+  });
+
+  test("falls back to public custom UI when private focus inspection is absent", async () => {
+    const runtime = createRuntime("/tmp/pi-child-focus-fallback");
+    delete (runtime.tui as { focusedComponent?: RuntimeComponent | null })
+      .focusedComponent;
+    const childRuns = setupChildRuns(runtime.pi);
+
+    childRuns.ensureVisible(runtime.ctx);
+    expect(runtime.getComponent()).toBeDefined();
+    expect(runtime.hasTerminalInputHandler()).toBe(false);
+    expect(runtime.getNotifications()).toHaveLength(1);
+    childRuns.ensureVisible(runtime.ctx);
+    expect(runtime.getNotifications()).toHaveLength(1);
+
+    const command = runtime.commands.get("subagents");
+    if (command === undefined) throw new Error("subagents command missing");
+    const pending = command.handler("", runtime.ctx);
+    await Bun.sleep(0);
+    expect(runtime.getCustomCalls()).toBe(1);
+    expect(runtime.getCustomOptions()?.overlay).toBe(true);
+    runtime.getCustomComponent()?.handleInput?.("\u001b");
+    await pending;
+    expect(runtime.getCustomComponent()).toBeUndefined();
   });
 
   test("explicit focus refresh replaces a stale pre-mount focus target", async () => {

--- a/tests/pi-harness/child-run-ui.test.ts
+++ b/tests/pi-harness/child-run-ui.test.ts
@@ -1,11 +1,75 @@
 import { describe, expect, test } from "bun:test";
 
+import {
+  readFocusedComponent,
+  setFocusSafely,
+} from "../../pi/extensions/pi-harness/features/child-runs/focus-capability";
 import { ChildRunRegistry } from "../../pi/extensions/pi-harness/features/child-runs/registry";
 import {
   ChildRunDetailComponent,
   ChildRunsBrowserComponent,
 } from "../../pi/extensions/pi-harness/features/child-runs/ui";
 import { visibleWidth } from "../../pi/extensions/pi-harness/lib/terminal-text";
+
+describe("child-session private focus capability", () => {
+  const component = { render: () => ["x"], invalidate() {} };
+
+  test("reads a valid focus target and changes focus through the public setter", () => {
+    let focused = component;
+    const tui = {
+      get focusedComponent() {
+        return focused;
+      },
+      setFocus(next: typeof component | null) {
+        if (next !== null) focused = next;
+      },
+    };
+
+    expect(readFocusedComponent(tui)).toEqual({
+      supported: true,
+      component,
+    });
+    expect(setFocusSafely(tui, component)).toEqual({ ok: true });
+  });
+
+  test("fails closed for absent, throwing, and changed-shape focus state", () => {
+    expect(readFocusedComponent({ setFocus() {} })).toEqual({
+      supported: false,
+      reason: "TUI focus inspection is unavailable",
+    });
+    const throwingTui = {
+      get focusedComponent(): unknown {
+        throw new Error("private API changed");
+      },
+      setFocus() {},
+    };
+    expect(readFocusedComponent(throwingTui)).toEqual({
+      supported: false,
+      reason: "TUI focus inspection failed",
+    });
+    const changedTui = {
+      focusedComponent: "not-a-component",
+      setFocus() {},
+    };
+    expect(readFocusedComponent(changedTui)).toEqual({
+      supported: false,
+      reason: "TUI focus target has changed shape",
+    });
+  });
+
+  test("contains a throwing public focus setter", () => {
+    expect(
+      setFocusSafely(
+        {
+          setFocus() {
+            throw new Error("focus failed");
+          },
+        },
+        component,
+      ),
+    ).toEqual({ ok: false, reason: "TUI focus change failed" });
+  });
+});
 
 const setup = (rows = 20) => {
   let id = 0;

--- a/tests/pi-harness/update-pi.test.ts
+++ b/tests/pi-harness/update-pi.test.ts
@@ -1,0 +1,286 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { PiCompatibilityResult } from "../../scripts/pi-compat/index";
+import type { PiInstallation } from "../../scripts/pi-compat/installation";
+import type { CommandResult } from "../../scripts/pi-compat/process";
+import {
+  acquireUpdateLock,
+  updatePiSafely,
+} from "../../scripts/pi-compat/update-state";
+
+const roots: string[] = [];
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true })),
+  );
+});
+
+const installation = (version: string): PiInstallation => ({
+  bunExecutable: "/tools/bun",
+  globalBin: "/global/bin",
+  binaryPath: "/global/bin/pi",
+  binaryRealPath: "/global/node_modules/pi/dist/cli.js",
+  packageRoot: "/global/node_modules/pi",
+  packageName: "@earendil-works/pi-coding-agent",
+  packageVersion: version,
+  corePackages: {
+    "@earendil-works/pi-coding-agent": {
+      root: "/global/node_modules/pi",
+      version,
+      manifest: {},
+    },
+  },
+});
+
+const compatible = (value: PiInstallation): PiCompatibilityResult => ({
+  baseline: { ok: true, issues: [], packages: [] },
+  installation: value,
+});
+
+const result = (exitCode = 0, stderr = ""): CommandResult => ({
+  argv: [],
+  exitCode,
+  stdout: "",
+  stderr,
+  timedOut: false,
+  truncated: false,
+});
+
+const paths = async () => {
+  const root = await mkdtemp(join(tmpdir(), "pi-update-test-"));
+  roots.push(root);
+  return {
+    lockPath: join(root, "update.lock"),
+    journalPath: join(root, "recovery.json"),
+  };
+};
+
+describe("safe pi updater", () => {
+  test("aborts before mutation when preflight is not known-good", async () => {
+    const temp = await paths();
+    let runs = 0;
+    await expect(
+      updatePiSafely({
+        ...temp,
+        checkCompatibility: async () => {
+          throw new Error("preflight failed");
+        },
+        discover: async () => installation("0.80.7"),
+        run: async () => {
+          runs += 1;
+          return result();
+        },
+      }),
+    ).rejects.toThrow("preflight failed");
+    expect(runs).toBe(0);
+  });
+
+  test("accepts an updated candidate after compatibility verification", async () => {
+    const temp = await paths();
+    let current = installation("0.80.7");
+    const calls: string[] = [];
+    const update = await updatePiSafely({
+      ...temp,
+      checkCompatibility: async () => compatible(current),
+      discover: async () => current,
+      run: async (argv) => {
+        calls.push(argv.includes("update") ? "update" : "rollback");
+        current = installation("0.81.0");
+        return result();
+      },
+    });
+
+    expect(update).toMatchObject({
+      ok: true,
+      updated: true,
+      rolledBack: false,
+      previousVersion: "0.80.7",
+      currentVersion: "0.81.0",
+    });
+    expect(calls).toEqual(["update"]);
+  });
+
+  test("does not reinstall when update fails without changing installation", async () => {
+    const temp = await paths();
+    const current = installation("0.80.7");
+    const calls: string[] = [];
+    const update = await updatePiSafely({
+      ...temp,
+      checkCompatibility: async () => compatible(current),
+      discover: async () => current,
+      run: async (argv) => {
+        calls.push(argv.includes("update") ? "update" : "rollback");
+        return result(1, "updater failed");
+      },
+    });
+
+    expect(update).toMatchObject({ ok: false, rolledBack: false });
+    expect(update.message).toContain("without changing");
+    expect(calls).toEqual(["update"]);
+  });
+
+  test("rolls back a nonzero update when metadata is unchanged but verification fails", async () => {
+    const temp = await paths();
+    const current = installation("0.80.7");
+    let broken = false;
+    const calls: string[] = [];
+    const update = await updatePiSafely({
+      ...temp,
+      checkCompatibility: async () => {
+        if (broken) throw new Error("package files are incomplete");
+        return compatible(current);
+      },
+      discover: async () => current,
+      run: async (argv) => {
+        if (argv.includes("update")) {
+          calls.push("update");
+          broken = true;
+          return result(1, "partial update");
+        }
+        calls.push("rollback");
+        broken = false;
+        return result();
+      },
+    });
+
+    expect(update).toMatchObject({ ok: false, rolledBack: true });
+    expect(calls).toEqual(["update", "rollback"]);
+  });
+
+  test("automatically restores and verifies an incompatible candidate", async () => {
+    const temp = await paths();
+    let current = installation("0.80.7");
+    const calls: string[] = [];
+    const update = await updatePiSafely({
+      ...temp,
+      checkCompatibility: async () => {
+        if (current.packageVersion === "0.81.0") {
+          throw new Error("candidate incompatible");
+        }
+        return compatible(current);
+      },
+      discover: async () => current,
+      run: async (argv) => {
+        if (argv.includes("update")) {
+          calls.push("update");
+          current = installation("0.81.0");
+        } else {
+          calls.push("rollback");
+          current = installation("0.80.7");
+        }
+        return result();
+      },
+    });
+
+    expect(update).toMatchObject({
+      ok: false,
+      rolledBack: true,
+      currentVersion: "0.80.7",
+    });
+    expect(calls).toEqual(["update", "rollback"]);
+  });
+
+  test("preserves a manual recovery journal when rollback fails", async () => {
+    const temp = await paths();
+    let current = installation("0.80.7");
+    const update = await updatePiSafely({
+      ...temp,
+      checkCompatibility: async () => {
+        if (current.packageVersion !== "0.80.7")
+          throw new Error("bad candidate");
+        return compatible(current);
+      },
+      discover: async () => current,
+      run: async (argv) => {
+        if (argv.includes("update")) {
+          current = installation("0.81.0");
+          return result();
+        }
+        return result(1, "registry unavailable");
+      },
+    });
+
+    expect(update).toMatchObject({ ok: false, rolledBack: false });
+    expect(update.manualRecoveryArgv?.join(" ")).toContain("0.80.7");
+    const journal = await readFile(temp.journalPath, "utf8");
+    expect(journal).toContain("pi-harness/update-recovery");
+  });
+
+  test("clears an unfinished journal when restoration already completed", async () => {
+    const temp = await paths();
+    let current = installation("0.80.7");
+    let calls = 0;
+    const dependencies = {
+      ...temp,
+      checkCompatibility: async () => {
+        if (current.packageVersion !== "0.80.7")
+          throw new Error("bad candidate");
+        return compatible(current);
+      },
+      discover: async () => current,
+      run: async (argv: string[]) => {
+        calls += 1;
+        if (argv.includes("update")) {
+          current = installation("0.81.0");
+          return result();
+        }
+        return result(1, "rollback process was interrupted after install");
+      },
+    };
+
+    const failed = await updatePiSafely(dependencies);
+    expect(failed.manualRecoveryArgv).toBeDefined();
+    current = installation("0.80.7");
+    const callsBeforeRecovery = calls;
+    const recovered = await updatePiSafely(dependencies);
+    expect(recovered).toMatchObject({ ok: false, rolledBack: true });
+    expect(recovered.message).toContain("already-restored");
+    expect(calls).toBe(callsBeforeRecovery);
+  });
+
+  test("recovers an unfinished journal before attempting another update", async () => {
+    const temp = await paths();
+    let current = installation("0.80.7");
+    let rollbackAvailable = false;
+    const dependencies = {
+      ...temp,
+      checkCompatibility: async () => {
+        if (current.packageVersion !== "0.80.7")
+          throw new Error("bad candidate");
+        return compatible(current);
+      },
+      discover: async () => current,
+      run: async (argv: string[]) => {
+        if (argv.includes("update")) {
+          current = installation("0.81.0");
+          return result();
+        }
+        if (!rollbackAvailable) return result(1, "temporary registry failure");
+        current = installation("0.80.7");
+        return result();
+      },
+    };
+
+    const failed = await updatePiSafely(dependencies);
+    expect(failed.manualRecoveryArgv).toBeDefined();
+    rollbackAvailable = true;
+    const recovered = await updatePiSafely(dependencies);
+    expect(recovered).toMatchObject({ ok: false, rolledBack: true });
+    expect(current.packageVersion).toBe("0.80.7");
+  });
+
+  test("rejects a concurrent lock and reclaims a stale lock", async () => {
+    const temp = await paths();
+    const lock = await acquireUpdateLock(temp.lockPath, process.pid);
+    await expect(acquireUpdateLock(temp.lockPath, process.pid)).rejects.toThrow(
+      "another pi update",
+    );
+    await lock.release();
+
+    await writeFile(temp.lockPath, "999999999\n");
+    const stale = await acquireUpdateLock(temp.lockPath, process.pid);
+    await stale.release();
+  });
+});


### PR DESCRIPTION
## Summary

- replace exact global pi version matching with a reproducible local baseline plus global declaration and offline RPC compatibility checks
- add a locked, journaled self-update path that verifies candidates and automatically restores and re-verifies the previous version
- move extension contracts toward public pi APIs while capability-isolating the child browser's private focus seam with a public UI fallback

## Validation

- `bun run check:pi-compat`
- `bun run lint`
- `bun run lint:sh`
- `bun run tsc`
- `bun run check:pi-imports`
- `bun run check:pi-schemas`
- focused compatibility/updater tests: 21 passed
- full suite: 925 passed, 2 skipped; the existing statusline lock concurrency test failed during the combined run and passed immediately in isolation (4 passed)
