### PR TITLE
fix(pi): refresh statusline for active worktrees

### DIFF
--- a/claude/.claude/hooks/lib/statusline_checks_lib.sh
+++ b/claude/.claude/hooks/lib/statusline_checks_lib.sh
@@ -31,6 +31,24 @@ statusline_cache_dir() {
     echo "${STATUSLINE_CACHE_DIR:-${TMPDIR:-/tmp}/claude-statusline-checks}"
 }
 
+# Echo a decimal device:inode pair for a file or directory. GNU and BSD stat
+# use different format flags; callers fail closed when neither is available.
+file_identity() {
+    local path=$1
+    local identity=''
+    if identity=$(stat -c '%d:%i' -- "$path" 2>/dev/null); then
+        :
+    elif identity=$(stat -f '%d:%i' "$path" 2>/dev/null); then
+        :
+    else
+        return 1
+    fi
+    case "$identity" in
+        *[!0-9:]* | :* | *: | *:*:*) return 1 ;;
+    esac
+    printf '%s\n' "$identity"
+}
+
 # walks up from CWD until project marker is found; echoes the abs path or empty.
 find_project_root() {
     local dir=$1

--- a/claude/.claude/hooks/lib/statusline_checks_run.sh
+++ b/claude/.claude/hooks/lib/statusline_checks_run.sh
@@ -4,6 +4,8 @@
 #   $1 project cwd (any path within or at the project root)
 #   $2 (optional) canonical trusted-root boundary — the discovered project root
 #      must stay within it, else the run is refused (fail-closed).
+#   $3/$4 (optional, inseparable) expected decimal device/inode for a linked
+#      worktree root. When present, cwd is pinned before identity verification.
 # Behaviour: detect project, acquire lockdir, execute TTL-expired checks
 # sequentially, write JSON cache atomically. All stdout/stderr from checks
 # is discarded so that callers running this under `async: true` hooks
@@ -13,29 +15,54 @@ set -u
 
 PROJECT_ROOT_ARG=${1:-}
 TRUST_BOUNDARY=${2:-}
+EXPECTED_ROOT_DEV=${3:-}
+EXPECTED_ROOT_INO=${4:-}
 [ -z "$PROJECT_ROOT_ARG" ] && exit 0
 
 LIB_DIR=$(cd "$(dirname "$0")" && pwd)
 # shellcheck source=claude/.claude/hooks/lib/statusline_checks_lib.sh
 source "$LIB_DIR/statusline_checks_lib.sh"
 
-PROJECT_ROOT=$(find_project_root "$PROJECT_ROOT_ARG")
-[ -z "$PROJECT_ROOT" ] && exit 0
+PINNED_CWD=0
+if [ -z "$EXPECTED_ROOT_DEV" ] && [ -z "$EXPECTED_ROOT_INO" ]; then
+    PROJECT_ROOT=$(find_project_root "$PROJECT_ROOT_ARG")
+    [ -z "$PROJECT_ROOT" ] && exit 0
+    EXEC_ROOT=$PROJECT_ROOT
 
-# Trust boundary: this runner executes repository-defined commands, so a project
-# root discovered by walking up from the cwd must not escape the canonical
-# trusted root the caller verified. Without this, a missing in-trust marker lets
-# find_project_root ascend into an untrusted parent and run its scripts (TOCTOU).
-if [ -n "$TRUST_BOUNDARY" ]; then
-    canon_root=$(cd "$PROJECT_ROOT" 2>/dev/null && pwd -P) || exit 0
-    canon_boundary=$(cd "$TRUST_BOUNDARY" 2>/dev/null && pwd -P) || exit 0
-    case "$canon_root" in
-        "$canon_boundary" | "$canon_boundary"/*) : ;;
+    # Legacy/direct-trust mode: a discovered root must not escape the canonical
+    # boundary. Identity mode below instead pins the tool-created root itself.
+    if [ -n "$TRUST_BOUNDARY" ]; then
+        canon_root=$(cd "$PROJECT_ROOT" 2>/dev/null && pwd -P) || exit 0
+        canon_boundary=$(cd "$TRUST_BOUNDARY" 2>/dev/null && pwd -P) || exit 0
+        case "$canon_root" in
+            "$canon_boundary" | "$canon_boundary"/*) : ;;
+            *) exit 0 ;;
+        esac
+    fi
+else
+    # A partial or malformed identity must never fall back to legacy mode.
+    [ -n "$EXPECTED_ROOT_DEV" ] && [ -n "$EXPECTED_ROOT_INO" ] || exit 0
+    case "$EXPECTED_ROOT_DEV:$EXPECTED_ROOT_INO" in
+        *[!0-9:]* | :* | *: | *:*:*) exit 0 ;;
+    esac
+    [ -n "$TRUST_BOUNDARY" ] || exit 0
+    case "$PROJECT_ROOT_ARG" in
+        "$TRUST_BOUNDARY" | "$TRUST_BOUNDARY"/*) : ;;
         *) exit 0 ;;
     esac
+
+    # Pin cwd first. If the pathname was replaced before cd, the identity check
+    # rejects it; if it is renamed/replaced afterwards, relative `.` continues
+    # to address the opened original directory for command discovery/execution.
+    cd -P -- "$PROJECT_ROOT_ARG" 2>/dev/null || exit 0
+    observed_identity=$(file_identity .) || exit 0
+    [ "$observed_identity" = "$EXPECTED_ROOT_DEV:$EXPECTED_ROOT_INO" ] || exit 0
+    PINNED_CWD=1
+    PROJECT_ROOT=$PROJECT_ROOT_ARG
+    EXEC_ROOT=.
 fi
 
-LANG_TYPE=$(detect_project_type "$PROJECT_ROOT")
+LANG_TYPE=$(detect_project_type "$EXEC_ROOT")
 [ -z "$LANG_TYPE" ] && exit 0
 
 LABEL=$(project_label "$LANG_TYPE")
@@ -138,9 +165,9 @@ resolve_cmd() {
             ;;
         ts)
             local pm script
-            pm=$(detect_package_manager "$PROJECT_ROOT")
+            pm=$(detect_package_manager "$EXEC_ROOT")
             [ -z "$pm" ] && return 0
-            script=$(resolve_script_key "$slot" "$PROJECT_ROOT/package.json") || return 0
+            script=$(resolve_script_key "$slot" "$EXEC_ROOT/package.json") || return 0
             [ -z "$script" ] && return 0
             echo "$pm run $script"
             ;;
@@ -222,7 +249,11 @@ run_check() {
 
     tmo=$(statusline_check_timeout "$slot")
     result="ok"
-    (cd "$PROJECT_ROOT" && run_with_timeout "$tmo" bash -c "$cmd" > /dev/null 2>&1) || result="fail"
+    if [ "$PINNED_CWD" -eq 1 ]; then
+        (run_with_timeout "$tmo" bash -c "$cmd" > /dev/null 2>&1) || result="fail"
+    else
+        (cd "$EXEC_ROOT" && run_with_timeout "$tmo" bash -c "$cmd" > /dev/null 2>&1) || result="fail"
+    fi
 
     done_at=$(statusline_now)
     finish_slot "$slot" "$result" "$done_at"

--- a/codex/hooks/worktree/create.sh
+++ b/codex/hooks/worktree/create.sh
@@ -21,6 +21,26 @@ resolve_git_dir() {
   esac
 }
 
+file_identity() {
+  local path=$1
+  local identity=''
+
+  # GNU stat supports -c; BSD/macOS stat supports -f. Device and inode are
+  # emitted as decimal strings so the TypeScript caller can compare them as
+  # bigint values without JSON number rounding.
+  if identity=$(stat -c '%d:%i' -- "$path" 2>/dev/null); then
+    :
+  elif identity=$(stat -f '%d:%i' "$path" 2>/dev/null); then
+    :
+  else
+    return 1
+  fi
+  case "$identity" in
+    *[!0-9:]* | :* | *: | *:*:*) return 1 ;;
+  esac
+  printf '%s\n' "$identity"
+}
+
 sha1_text() {
   local value=$1
 
@@ -173,14 +193,6 @@ cleanup_create() {
   local status=$?
   local candidate_raw=''
   local candidate_path=''
-  local candidate_top_raw=''
-  local candidate_top=''
-  local candidate_git_raw=''
-  local candidate_git=''
-  local candidate_common_raw=''
-  local candidate_common=''
-  local candidate_branch=''
-  local candidate_valid=0
 
   trap - EXIT HUP INT TERM
   set +e
@@ -206,46 +218,27 @@ cleanup_create() {
     fi
 
     if [ -n "$candidate_path" ] && [ -d "$candidate_path" ]; then
-      candidate_top_raw=$(git -C "$candidate_path" rev-parse --show-toplevel 2>/dev/null)
-      candidate_top=$(canonical_dir "$candidate_top_raw" 2>/dev/null)
-      candidate_git_raw=$(git -C "$candidate_path" rev-parse --git-dir 2>/dev/null)
-      candidate_git=$(resolve_git_dir "$candidate_path" "$candidate_git_raw" 2>/dev/null)
-      candidate_common_raw=$(git -C "$candidate_path" rev-parse --git-common-dir 2>/dev/null)
-      candidate_common=$(resolve_git_dir "$candidate_path" "$candidate_common_raw" 2>/dev/null)
-      candidate_branch=$(git -C "$candidate_path" symbolic-ref --quiet --short HEAD 2>/dev/null)
-      if [ "$candidate_top" = "$candidate_path" ] && \
-        [ "$candidate_common" = "$SOURCE_COMMON" ] && \
-        [ "$candidate_branch" = "$NAME" ]; then
-        case "$candidate_git" in
-          "$SOURCE_COMMON"/worktrees/*) candidate_valid=1 ;;
-        esac
+      # Once a pathname may refer to a created worktree, abnormal cleanup never
+      # removes it. No path-based check can atomically bind `worktree remove`
+      # to the inode we created, so a concurrent replacement could otherwise
+      # turn rollback into recursive deletion of unrelated user data.
+      if [ -n "$MARKER_PATH" ] && [ -f "$MARKER_PATH" ] && [ ! -L "$MARKER_PATH" ] && \
+        jq -e --arg path "$candidate_path" --arg branch "$NAME" '
+          type == "object" and .path == $path and .branch == $branch
+        ' "$MARKER_PATH" >/dev/null 2>&1; then
+        rm -f "$MARKER_PATH"
       fi
-    fi
-
-    if [ "$CANCELLED" -eq 1 ] && [ "$candidate_valid" -eq 1 ] && \
-      install_marker "$candidate_path" "$NAME"; then
-      # The caller accepts one unique non-empty path line, so a duplicate write
-      # from a signal racing the normal printf remains unambiguous.
+      printf 'worktree create: retained path after abnormal exit; inspect manually: %s\n' \
+        "$candidate_path" >&2
       printf '%s\n' "$candidate_path"
       PUBLISHED=1
       ROLLBACK_ARMED=0
-    else
-      if [ "$candidate_valid" -eq 1 ]; then
-        if [ -n "$MARKER_PATH" ] && [ -f "$MARKER_PATH" ] && [ ! -L "$MARKER_PATH" ] && \
-          jq -e --arg path "$candidate_path" --arg branch "$NAME" '
-            type == "object" and .path == $path and .branch == $branch
-          ' "$MARKER_PATH" >/dev/null 2>&1; then
-          rm -f "$MARKER_PATH"
-        fi
-        git --git-dir="$SOURCE_COMMON" worktree remove --force "$candidate_path" >&2
-      fi
-
-      if [ "$BRANCH_OWNED" -eq 1 ] && \
-        ! git --git-dir="$SOURCE_COMMON" worktree list --porcelain 2>/dev/null | \
-          grep -Fqx "branch refs/heads/$NAME"; then
-        # Delete only the unchanged ref this invocation atomically reserved.
-        git -C "$SOURCE_TOP" update-ref -d "refs/heads/$NAME" "$SOURCE_HEAD"
-      fi
+    elif [ "$BRANCH_OWNED" -eq 1 ] && \
+      ! git --git-dir="$SOURCE_COMMON" worktree list --porcelain 2>/dev/null | \
+        grep -Fqx "branch refs/heads/$NAME"; then
+      # No path exists and no worktree uses the exact ref, so deleting only the
+      # unchanged ref this invocation reserved remains safe.
+      git -C "$SOURCE_TOP" update-ref -d "refs/heads/$NAME" "$SOURCE_HEAD"
     fi
   fi
 
@@ -329,6 +322,20 @@ fi
   || fail "gwq returned an empty worktree path for branch: $NAME"
 CREATED_PATH=$(canonical_dir "$CREATED_PATH_RAW") \
   || fail "created worktree path does not exist: $CREATED_PATH_RAW"
+if [ ! -d "$CREATED_PATH" ] || [ -L "$CREATED_PATH" ]; then
+  fail "created worktree root is not a plain directory: $CREATED_PATH"
+fi
+if [ ! -f "$CREATED_PATH/.git" ] || [ -L "$CREATED_PATH/.git" ]; then
+  fail "created linked worktree .git is not a plain file: $CREATED_PATH"
+fi
+ROOT_ID=$(file_identity "$CREATED_PATH") \
+  || fail "could not capture created worktree root identity: $CREATED_PATH"
+DOT_GIT_ID=$(file_identity "$CREATED_PATH/.git") \
+  || fail "could not capture created worktree .git identity: $CREATED_PATH"
+ROOT_DEV=${ROOT_ID%%:*}
+ROOT_INO=${ROOT_ID#*:}
+DOT_GIT_DEV=${DOT_GIT_ID%%:*}
+DOT_GIT_INO=${DOT_GIT_ID#*:}
 
 if ! TOP_RAW=$(git -C "$CREATED_PATH" rev-parse --show-toplevel 2>/dev/null); then
   fail "created path is not a Git worktree: $CREATED_PATH"
@@ -365,9 +372,65 @@ fi
 install_marker "$CREATED_PATH" "$BRANCH" \
   || fail "could not atomically install a safe-removal marker for: $CREATED_PATH"
 
+# Re-run the identity-bearing postconditions after marker publication. The
+# TypeScript caller compares this record once more before exposing it in hidden
+# tool-result details, closing the hook-exit/parent-validation replacement gap.
+if [ ! -d "$CREATED_PATH" ] || [ -L "$CREATED_PATH" ]; then
+  fail "created worktree root changed before publication: $CREATED_PATH"
+fi
+if [ ! -f "$CREATED_PATH/.git" ] || [ -L "$CREATED_PATH/.git" ]; then
+  fail "created worktree .git changed before publication: $CREATED_PATH"
+fi
+FINAL_ROOT_ID=$(file_identity "$CREATED_PATH") \
+  || fail "could not revalidate created worktree root identity: $CREATED_PATH"
+FINAL_DOT_GIT_ID=$(file_identity "$CREATED_PATH/.git") \
+  || fail "could not revalidate created worktree .git identity: $CREATED_PATH"
+[ "$FINAL_ROOT_ID" = "$ROOT_ID" ] \
+  || fail "created worktree root identity changed before publication: $CREATED_PATH"
+[ "$FINAL_DOT_GIT_ID" = "$DOT_GIT_ID" ] \
+  || fail "created worktree .git identity changed before publication: $CREATED_PATH"
+FINAL_TOP_RAW=$(git -C "$CREATED_PATH" rev-parse --show-toplevel 2>/dev/null) \
+  || fail "created worktree top-level changed before publication: $CREATED_PATH"
+FINAL_TOP=$(canonical_dir "$FINAL_TOP_RAW") \
+  || fail "could not revalidate the created worktree root: $CREATED_PATH"
+[ "$FINAL_TOP" = "$CREATED_PATH" ] \
+  || fail "created worktree root changed before publication: $CREATED_PATH"
+FINAL_GIT_DIR_RAW=$(git -C "$CREATED_PATH" rev-parse --git-dir 2>/dev/null) \
+  || fail "created worktree Git directory changed before publication: $CREATED_PATH"
+FINAL_GIT_DIR=$(resolve_git_dir "$CREATED_PATH" "$FINAL_GIT_DIR_RAW") \
+  || fail "could not revalidate the created worktree Git directory"
+[ "$FINAL_GIT_DIR" = "$GIT_DIR" ] \
+  || fail "created worktree Git directory identity changed before publication: $CREATED_PATH"
+FINAL_COMMON_DIR_RAW=$(git -C "$CREATED_PATH" rev-parse --git-common-dir 2>/dev/null) \
+  || fail "created worktree common directory changed before publication: $CREATED_PATH"
+FINAL_COMMON_DIR=$(resolve_git_dir "$CREATED_PATH" "$FINAL_COMMON_DIR_RAW") \
+  || fail "could not revalidate the created worktree common directory"
+[ "$FINAL_COMMON_DIR" = "$SOURCE_COMMON" ] \
+  || fail "created worktree repository identity changed before publication: $CREATED_PATH"
+FINAL_BRANCH=$(git -C "$CREATED_PATH" symbolic-ref --quiet --short HEAD 2>/dev/null) \
+  || fail "created worktree branch changed before publication: $CREATED_PATH"
+[ "$FINAL_BRANCH" = "$NAME" ] \
+  || fail "created worktree branch changed before publication: $CREATED_PATH"
+
+IDENTITY_JSON=$(jq -cn \
+  --arg path "$CREATED_PATH" \
+  --arg root_dev "$ROOT_DEV" \
+  --arg root_ino "$ROOT_INO" \
+  --arg dot_git_dev "$DOT_GIT_DEV" \
+  --arg dot_git_ino "$DOT_GIT_INO" \
+  --arg git_dir "$GIT_DIR" \
+  '{
+    version: 1,
+    path: $path,
+    root: {dev: $root_dev, ino: $root_ino},
+    dotGit: {dev: $dot_git_dev, ino: $dot_git_ino},
+    gitDir: $git_dir
+  }') || fail "could not encode created worktree identity: $CREATED_PATH"
+
 # stdout is the publication record consumed by the TypeScript caller. A signal
-# before this write publishes the same marker/path from cleanup_create.
-printf '%s\n' "$CREATED_PATH"
+# before this write publishes only the marker/path from cleanup_create; such an
+# interrupted result is retained for cleanup but never grants statusline trust.
+printf '%s\n%s\n' "$CREATED_PATH" "$IDENTITY_JSON"
 PUBLISHED=1
 ROLLBACK_ARMED=0
 LOCK_RELEASE_STATUS=0

--- a/pi/extensions/pi-harness/features/bit-task/index.ts
+++ b/pi/extensions/pi-harness/features/bit-task/index.ts
@@ -6,6 +6,12 @@ import { sanitizeChildEnv } from "../../lib/child-env";
 import type { CtxLike, PiLike } from "../../lib/pi-like";
 import { runHook as defaultRunHook } from "../../lib/run-hook";
 import {
+  matchesFileIdentity,
+  parseWorktreeIdentity,
+  type WorktreeIdentityV1,
+  worktreeIdentityDetails,
+} from "../../lib/worktree-identity";
+import {
   PROCESS_FORCE_SETTLE_MS,
   WORKTREE_CREATE_TERM_GRACE_MS,
 } from "../../lib/termination";
@@ -231,9 +237,9 @@ const commandFailure = (description: string, result: CommandResult): Error =>
     `${description} exited with code ${result.exitCode}: ${outputTail(result.stderr)}`,
   );
 
-const textResult = (text: string) => ({
+const textResult = (text: string, details?: unknown) => ({
   content: [{ type: "text" as const, text }],
-  details: undefined,
+  details,
 });
 
 const verificationSkipped = (taskId: string, reason: string) =>
@@ -260,19 +266,11 @@ const throwIfAborted = (signal: AbortSignal | undefined): void => {
   }
 };
 
-const validateReturnedWorktreePath = async (
-  stdout: string,
-): Promise<string> => {
-  const outputLines = stdout.trim().split(/\r?\n/).filter(Boolean);
-  const returnedPath = outputLines[0] ?? "";
+const returnedWorktreePath = (stdout: string): string => {
+  const returnedPath = stdout.trim().split(/\r?\n/, 1)[0] ?? "";
   if (returnedPath === "") {
     throw new Error(
       "worktree_create postcondition failed: hook returned an empty path",
-    );
-  }
-  if (outputLines.some((line) => line !== returnedPath)) {
-    throw new Error(
-      "worktree_create postcondition failed: hook returned multiple paths",
     );
   }
   if (!isAbsolute(returnedPath)) {
@@ -280,11 +278,57 @@ const validateReturnedWorktreePath = async (
       `worktree_create postcondition failed: hook returned a non-absolute path: ${returnedPath}`,
     );
   }
+  return returnedPath;
+};
+
+const parsePublishedWorktreeIdentity = (
+  stdout: string,
+  returnedPath: string,
+): WorktreeIdentityV1 => {
+  const outputLines = stdout.trim().split(/\r?\n/).filter(Boolean);
+  let identity: WorktreeIdentityV1 | undefined;
+  for (const line of outputLines.slice(1)) {
+    if (line === returnedPath) continue;
+    if (identity !== undefined) {
+      throw new Error(
+        "worktree_create postcondition failed: hook returned multiple identity records",
+      );
+    }
+    let decoded: unknown;
+    try {
+      decoded = JSON.parse(line);
+    } catch {
+      throw new Error(
+        "worktree_create postcondition failed: hook returned an invalid identity record",
+      );
+    }
+    identity = parseWorktreeIdentity(decoded);
+    if (identity === undefined || identity.path !== returnedPath) {
+      throw new Error(
+        "worktree_create postcondition failed: hook returned a malformed or mismatched identity record",
+      );
+    }
+  }
+  if (identity === undefined) {
+    throw new Error(
+      "worktree_create postcondition failed: successful hook omitted its creation identity",
+    );
+  }
+  return identity;
+};
+
+const validateReturnedWorktreePath = async (
+  stdout: string,
+): Promise<string> => {
+  const returnedPath = returnedWorktreePath(stdout);
   try {
     const canonicalPath = await realpath(returnedPath);
     const pathStat = await stat(canonicalPath);
     if (!pathStat.isDirectory()) {
       throw new Error("returned path is not a directory");
+    }
+    if (canonicalPath !== returnedPath) {
+      throw new Error("returned path is not canonical");
     }
     return canonicalPath;
   } catch (error) {
@@ -329,6 +373,7 @@ export const createValidatedWorktree = async (
   name: string,
   signal?: AbortSignal,
   onCreated?: (path: string) => void,
+  onIdentity?: (identity: WorktreeIdentityV1) => void,
 ): Promise<string> => {
   throwIfAborted(signal);
   const result = await creator.invokeHook(
@@ -346,10 +391,11 @@ export const createValidatedWorktree = async (
   if (result.exitCode !== 0 || result.timedOut) {
     // The create hook prints only after atomically publishing its removal
     // marker. Cancellation and timeout both terminate it with SIGTERM, so
-    // retain any validated published identity even when the process is nonzero.
+    // retain any validated published path even when the process is nonzero.
     if (result.stdout.trim() !== "") {
       try {
-        onCreated?.(await validateReturnedWorktreePath(result.stdout));
+        const retained = await validateReturnedWorktreePath(result.stdout);
+        onCreated?.(retained);
       } catch {
         // An interrupted hook may also print immediately before rolling back.
         // Never publish a path that no longer validates locally.
@@ -360,11 +406,65 @@ export const createValidatedWorktree = async (
   }
 
   const canonicalPath = await validateReturnedWorktreePath(result.stdout);
-  // The hook may have created the worktree immediately before cancellation.
-  // Publish its canonical identity after local filesystem validation but
-  // before honoring that abort, so background persistence can report the
-  // resource left behind without accepting an unvalidated hook path.
+  // Path publication is cleanup-only: an interrupted or malformed identity
+  // must still report the retained resource without granting statusline trust.
   onCreated?.(canonicalPath);
+  throwIfAborted(signal);
+  const identity = parsePublishedWorktreeIdentity(result.stdout, canonicalPath);
+  const validateCreationIdentity = async (): Promise<void> => {
+    const [rootStats, dotGitStats] = await Promise.all([
+      lstat(canonicalPath, { bigint: true }),
+      lstat(join(canonicalPath, ".git"), { bigint: true }),
+    ]);
+    if (
+      !rootStats.isDirectory() ||
+      !dotGitStats.isFile() ||
+      !matchesFileIdentity(rootStats, identity.root) ||
+      !matchesFileIdentity(dotGitStats, identity.dotGit)
+    ) {
+      throw new Error(
+        "worktree_create postcondition failed: created filesystem identity changed after hook publication",
+      );
+    }
+    const gitDirResult = await creator.invokeCommand(
+      "git",
+      ["-C", canonicalPath, "rev-parse", "--absolute-git-dir"],
+      {
+        cwd,
+        env: creator.env(),
+        timeoutMs: COMMAND_TIMEOUT_MS,
+        signal,
+      },
+    );
+    throwIfAborted(signal);
+    const rawGitDir = gitDirResult.stdout.trim();
+    if (gitDirResult.exitCode !== 0 || rawGitDir === "") {
+      throw new Error(
+        `worktree_create postcondition failed: ${commandFailure("could not resolve created worktree Git directory", gitDirResult).message}`,
+      );
+    }
+    const canonicalGitDir = await realpath(rawGitDir);
+    if (canonicalGitDir !== identity.gitDir) {
+      throw new Error(
+        "worktree_create postcondition failed: created Git admin identity changed after hook publication",
+      );
+    }
+    const [finalRootStats, finalDotGitStats] = await Promise.all([
+      lstat(canonicalPath, { bigint: true }),
+      lstat(join(canonicalPath, ".git"), { bigint: true }),
+    ]);
+    if (
+      !finalRootStats.isDirectory() ||
+      !finalDotGitStats.isFile() ||
+      !matchesFileIdentity(finalRootStats, identity.root) ||
+      !matchesFileIdentity(finalDotGitStats, identity.dotGit)
+    ) {
+      throw new Error(
+        "worktree_create postcondition failed: created filesystem identity changed during parent validation",
+      );
+    }
+  };
+  await validateCreationIdentity();
   throwIfAborted(signal);
 
   let listResult: CommandResult;
@@ -432,6 +532,8 @@ export const createValidatedWorktree = async (
       `worktree_create postcondition failed: created path belongs to a different repository (common-dir ${createdCommonDir} != ${repoCommonDir})`,
     );
   }
+  await validateCreationIdentity();
+  onIdentity?.(identity);
   return canonicalPath;
 };
 
@@ -472,16 +574,30 @@ export default function setupBitTask(
       const cwd = deps.cwd ?? ctx.cwd ?? process.cwd();
       const name = requireString(params, "name", "worktree_create");
       let createdPath: string | undefined;
+      let identity: WorktreeIdentityV1 | undefined;
       try {
-        return textResult(
-          await createValidatedWorktree(creator, cwd, name, signal, (path) => {
-            createdPath = path;
-          }),
+        const path = await createValidatedWorktree(
+          creator,
+          cwd,
+          name,
+          signal,
+          (publishedPath) => {
+            createdPath = publishedPath;
+          },
+          (publishedIdentity) => {
+            identity = publishedIdentity;
+          },
         );
+        if (identity === undefined) {
+          throw new Error(
+            "worktree_create postcondition failed: validated identity was not published",
+          );
+        }
+        return textResult(path, worktreeIdentityDetails(identity));
       } catch (error) {
         if (createdPath === undefined) throw error;
         throw new Error(
-          `${errorMessage(error)}\n\nA worktree was left in place at: ${createdPath}\nIt can be removed with the user-approved worktree_remove tool.`,
+          `${errorMessage(error)}\n\nA path was left in place at: ${createdPath}\nInspect it before cleanup. The user-approved worktree_remove tool may be used only when its harness safe-removal marker is still valid; otherwise manual recovery is required.`,
         );
       }
     },

--- a/pi/extensions/pi-harness/features/statusline/index.ts
+++ b/pi/extensions/pi-harness/features/statusline/index.ts
@@ -13,9 +13,9 @@
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, statSync } from "node:fs";
-import { readFile, realpath } from "node:fs/promises";
+import { lstat, readFile, realpath } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { basename, dirname, isAbsolute, join } from "node:path";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import type { HarnessConfig } from "../../config";
 import { sanitizeChildEnv } from "../../lib/child-env";
 import { launchDetached, type DetachedSpawnFunction } from "../../lib/detached";
@@ -226,15 +226,55 @@ const validateInheritedWorktree = async (
       realpath(worktreeGitDir?.trim() ?? ""),
     ]);
     const linkedGitDirRoot = join(canonicalSourceCommon, "worktrees");
-    return (
-      canonicalSourceCommon === canonicalWorktreeCommon &&
-      canonicalTop === worktreePath &&
-      gitDir !== linkedGitDirRoot &&
-      isPathWithin(gitDir, linkedGitDirRoot) &&
-      (list ?? "")
-        .split("\n")
-        .some((line) => line === `worktree ${worktreePath}`)
-    );
+    const registered = (list ?? "")
+      .split("\n")
+      .some((line) => line === `worktree ${worktreePath}`);
+    if (
+      canonicalSourceCommon !== canonicalWorktreeCommon ||
+      canonicalTop !== worktreePath ||
+      gitDir === linkedGitDirRoot ||
+      !isPathWithin(gitDir, linkedGitDirRoot) ||
+      !registered
+    ) {
+      return false;
+    }
+
+    // Only inspect admin metadata after Git has proved that `gitDir` is a
+    // registered linked-worktree directory inside the trusted common dir.
+    // This prevents an attacker-controlled replacement path from making us
+    // read an arbitrary path (or FIFO) before the containment checks run.
+    const worktreeDotGit = join(worktreePath, ".git");
+    const backlinkFile = join(gitDir, "gitdir");
+    const [dotGitStats, backlinkStats] = await Promise.all([
+      lstat(worktreeDotGit),
+      lstat(backlinkFile),
+    ]);
+    if (
+      !dotGitStats.isFile() ||
+      !backlinkStats.isFile() ||
+      backlinkStats.size > 4_096
+    ) {
+      return false;
+    }
+
+    const backlinkContents = await readFile(backlinkFile, "utf8");
+    const backlink = backlinkContents.trim();
+    if (
+      backlink === "" ||
+      backlink.includes("\0") ||
+      backlink.includes("\r") ||
+      backlink.includes("\n")
+    ) {
+      return false;
+    }
+    const backlinkTarget = isAbsolute(backlink)
+      ? backlink
+      : resolve(gitDir, backlink);
+    const [canonicalDotGit, canonicalBacklink] = await Promise.all([
+      realpath(worktreeDotGit),
+      realpath(backlinkTarget),
+    ]);
+    return canonicalDotGit === canonicalBacklink;
   } catch {
     return false;
   }

--- a/pi/extensions/pi-harness/features/statusline/index.ts
+++ b/pi/extensions/pi-harness/features/statusline/index.ts
@@ -13,14 +13,19 @@
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, statSync } from "node:fs";
-import { readFile } from "node:fs/promises";
+import { readFile, realpath } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { basename, dirname, isAbsolute, join } from "node:path";
 import type { HarnessConfig } from "../../config";
 import { sanitizeChildEnv } from "../../lib/child-env";
 import { launchDetached, type DetachedSpawnFunction } from "../../lib/detached";
-import type { CtxLike, PiLike, ThemeLike } from "../../lib/pi-like";
-import { matchedTrustedRoot } from "../../lib/trust";
+import type {
+  CtxLike,
+  PiLike,
+  ThemeLike,
+  ToolResultEvent,
+} from "../../lib/pi-like";
+import { isPathWithin, matchedTrustedRoot } from "../../lib/trust";
 import {
   formatModelName,
   type GitStatus,
@@ -37,7 +42,56 @@ interface StatuslineDeps {
   spawnDetached?: DetachedSpawnFunction;
   getGitStatus?: (cwd: string) => Promise<GitStatus>;
   getBranch?: (cwd: string) => Promise<string | undefined>;
+  validateInheritedWorktree?: (
+    sourceCwd: string,
+    worktreePath: string,
+  ) => Promise<boolean>;
 }
+
+interface ActiveWorktree {
+  path: string;
+  branch?: string;
+  sourceCwd: string;
+}
+
+const successfulToolResultText = (
+  event: ToolResultEvent,
+): string | undefined => {
+  if (event.isError === true || event.content?.length !== 1) return undefined;
+  const [block] = event.content;
+  if (block?.type !== "text" || typeof block.text !== "string") {
+    return undefined;
+  }
+  const text = block.text.trim();
+  return text !== "" && !text.includes("\n") ? text : undefined;
+};
+
+const toolInputString = (
+  event: ToolResultEvent,
+  key: string,
+): string | undefined => {
+  const input = event.input;
+  if (input === null || typeof input !== "object" || Array.isArray(input)) {
+    return undefined;
+  }
+  const value = Reflect.get(input, key);
+  return typeof value === "string" && value !== "" ? value : undefined;
+};
+
+const createdWorktreePath = (event: ToolResultEvent): string | undefined => {
+  if (event.toolName !== "worktree_create") return undefined;
+  const path = successfulToolResultText(event);
+  return path !== undefined && isAbsolute(path) ? path : undefined;
+};
+
+const removedWorktreePath = (event: ToolResultEvent): string | undefined => {
+  if (event.toolName !== "worktree_remove") return undefined;
+  const text = successfulToolResultText(event);
+  const prefix = "Removed worktree: ";
+  if (text === undefined || !text.startsWith(prefix)) return undefined;
+  const path = text.slice(prefix.length);
+  return isAbsolute(path) ? path : undefined;
+};
 
 const EMPTY_GIT_STATUS: GitStatus = {
   isRepository: false,
@@ -117,6 +171,75 @@ const gitOutput = (cwd: string, args: string[]): Promise<string | undefined> =>
     );
   });
 
+/**
+ * Revalidate the identity that worktree_create established before extending
+ * source-checkout trust to an external gwq path. Git registration, common-dir
+ * identity, linked-worktree git-dir placement, and the original canonical path
+ * must all still agree; stale metadata or a symlink replacement fails closed.
+ */
+const validateInheritedWorktree = async (
+  sourceCwd: string,
+  worktreePath: string,
+): Promise<boolean> => {
+  try {
+    if ((await realpath(worktreePath)) !== worktreePath) return false;
+    const [sourceCommon, worktreeCommon, worktreeTop, worktreeGitDir, list] =
+      await Promise.all([
+        gitOutput(sourceCwd, [
+          "rev-parse",
+          "--path-format=absolute",
+          "--git-common-dir",
+        ]),
+        gitOutput(worktreePath, [
+          "rev-parse",
+          "--path-format=absolute",
+          "--git-common-dir",
+        ]),
+        gitOutput(worktreePath, [
+          "rev-parse",
+          "--path-format=absolute",
+          "--show-toplevel",
+        ]),
+        gitOutput(worktreePath, ["rev-parse", "--absolute-git-dir"]),
+        gitOutput(sourceCwd, ["worktree", "list", "--porcelain"]),
+      ]);
+    const required = [
+      sourceCommon,
+      worktreeCommon,
+      worktreeTop,
+      worktreeGitDir,
+      list,
+    ];
+    if (required.some((value) => value === undefined || value.trim() === "")) {
+      return false;
+    }
+
+    const [
+      canonicalSourceCommon,
+      canonicalWorktreeCommon,
+      canonicalTop,
+      gitDir,
+    ] = await Promise.all([
+      realpath(sourceCommon?.trim() ?? ""),
+      realpath(worktreeCommon?.trim() ?? ""),
+      realpath(worktreeTop?.trim() ?? ""),
+      realpath(worktreeGitDir?.trim() ?? ""),
+    ]);
+    const linkedGitDirRoot = join(canonicalSourceCommon, "worktrees");
+    return (
+      canonicalSourceCommon === canonicalWorktreeCommon &&
+      canonicalTop === worktreePath &&
+      gitDir !== linkedGitDirRoot &&
+      isPathWithin(gitDir, linkedGitDirRoot) &&
+      (list ?? "")
+        .split("\n")
+        .some((line) => line === `worktree ${worktreePath}`)
+    );
+  } catch {
+    return false;
+  }
+};
+
 /** Extract the final org/repo pair from SSH, HTTPS, or file-style remotes. */
 export const parseOriginRepository = (origin: string): string | undefined => {
   const trimmed = origin.trim().replace(/\.git$/, "");
@@ -182,6 +305,8 @@ export default function setupStatusline(
   const spawnDetached = deps.spawnDetached ?? launchDetached;
   const getGitStatus = deps.getGitStatus ?? defaultGetGitStatus;
   const getBranch = deps.getBranch ?? defaultGetBranch;
+  const validateWorktree =
+    deps.validateInheritedWorktree ?? validateInheritedWorktree;
   const runner = join(
     config.paths.claudeHooksDir,
     "lib/statusline_checks_run.sh",
@@ -192,6 +317,7 @@ export default function setupStatusline(
     git: { ...EMPTY_GIT_STATUS },
   };
   let activeContext: CtxLike | undefined;
+  let activeWorktree: ActiveWorktree | undefined;
   let footerInstalled = false;
   let requestFooterRender: (() => void) | undefined;
 
@@ -215,7 +341,10 @@ export default function setupStatusline(
               return renderStatusline(
                 snapshot,
                 {
-                  branch: footerData.getGitBranch(),
+                  branch:
+                    activeWorktree === undefined
+                      ? footerData.getGitBranch()
+                      : activeWorktree.branch,
                   modelName: formatModelName(current?.model),
                   remainingContext: remainingContextPercent(
                     current?.getContextUsage?.(),
@@ -241,9 +370,12 @@ export default function setupStatusline(
 
     // RPC supports widgets but intentionally ignores component factories.
     // Git subprocesses remain trust-gated in this fallback too.
-    const branch = allowGit
-      ? await getBranch(ctx.cwd ?? process.cwd())
-      : undefined;
+    const branch =
+      activeWorktree === undefined
+        ? allowGit
+          ? await getBranch(ctx.cwd ?? process.cwd())
+          : undefined
+        : activeWorktree.branch;
     ctx.ui.setWidget?.(
       STATUSLINE_WIDGET_KEY,
       renderStatusline(
@@ -260,11 +392,26 @@ export default function setupStatusline(
   };
 
   const refresh = async (ctx: CtxLike, launchChecks: boolean) => {
-    const cwd = ctx.cwd ?? process.cwd();
-    // Pass the canonical trusted root down as a boundary: the runner executes
-    // repository-defined commands, and its own find_project_root can otherwise
-    // ascend past the trusted root into an untrusted parent.
-    const trustedRoot = matchedTrustedRoot(cwd, config.trust);
+    const cwd = activeWorktree?.path ?? ctx.cwd ?? process.cwd();
+    // A worktree created by the validated harness tool inherits the trust of
+    // its source checkout even though gwq places it outside that root. Keep
+    // re-checking the source path so a vanished or retargeted trust root fails
+    // closed. The worktree itself is the shell runner boundary.
+    const directlyTrustedRoot = matchedTrustedRoot(cwd, config.trust);
+    let trustedRoot = directlyTrustedRoot;
+    if (
+      trustedRoot === undefined &&
+      activeWorktree?.path === cwd &&
+      matchedTrustedRoot(activeWorktree.sourceCwd, config.trust) !== undefined
+    ) {
+      try {
+        if (await validateWorktree(activeWorktree.sourceCwd, cwd)) {
+          trustedRoot = cwd;
+        }
+      } catch {
+        trustedRoot = undefined;
+      }
+    }
     if (launchChecks && trustedRoot !== undefined && existsSync(runner)) {
       spawnDetached("bash", [runner, cwd, trustedRoot], { cwd });
     }
@@ -293,6 +440,13 @@ export default function setupStatusline(
       } catch {
         git = { ...EMPTY_GIT_STATUS };
       }
+      if (activeWorktree?.path === cwd) {
+        try {
+          activeWorktree.branch = await getBranch(cwd);
+        } catch {
+          activeWorktree.branch = undefined;
+        }
+      }
     }
     snapshot = {
       directory: basename(cwd),
@@ -304,7 +458,26 @@ export default function setupStatusline(
   };
 
   pi.on("session_start", async (_event, ctx) => {
+    activeWorktree = undefined;
     await refresh(ctx, false);
+  });
+  pi.on("tool_result", async (event, ctx) => {
+    const createdPath = createdWorktreePath(event);
+    if (createdPath !== undefined) {
+      activeWorktree = {
+        path: createdPath,
+        branch: toolInputString(event, "name"),
+        sourceCwd: ctx.cwd ?? process.cwd(),
+      };
+      await refresh(ctx, false);
+      return;
+    }
+
+    const removedPath = removedWorktreePath(event);
+    if (removedPath !== undefined && removedPath === activeWorktree?.path) {
+      activeWorktree = undefined;
+      await refresh(ctx, false);
+    }
   });
   pi.on("agent_settled", async (_event, ctx) => {
     await refresh(ctx, true);

--- a/pi/extensions/pi-harness/features/statusline/index.ts
+++ b/pi/extensions/pi-harness/features/statusline/index.ts
@@ -27,6 +27,11 @@ import type {
 } from "../../lib/pi-like";
 import { isPathWithin, matchedTrustedRoot } from "../../lib/trust";
 import {
+  matchesFileIdentity,
+  type WorktreeIdentityV1,
+  worktreeIdentityFromDetails,
+} from "../../lib/worktree-identity";
+import {
   formatModelName,
   type GitStatus,
   parseStatuslineCache,
@@ -42,9 +47,11 @@ interface StatuslineDeps {
   spawnDetached?: DetachedSpawnFunction;
   getGitStatus?: (cwd: string) => Promise<GitStatus>;
   getBranch?: (cwd: string) => Promise<string | undefined>;
+  gitOutput?: (cwd: string, args: string[]) => Promise<string | undefined>;
   validateInheritedWorktree?: (
     sourceCwd: string,
     worktreePath: string,
+    identity: WorktreeIdentityV1,
   ) => Promise<boolean>;
 }
 
@@ -52,6 +59,7 @@ interface ActiveWorktree {
   path: string;
   branch?: string;
   sourceCwd: string;
+  identity?: WorktreeIdentityV1;
 }
 
 const successfulToolResultText = (
@@ -174,34 +182,55 @@ const gitOutput = (cwd: string, args: string[]): Promise<string | undefined> =>
 /**
  * Revalidate the identity that worktree_create established before extending
  * source-checkout trust to an external gwq path. Git registration, common-dir
- * identity, linked-worktree git-dir placement, and the original canonical path
- * must all still agree; stale metadata or a symlink replacement fails closed.
+ * identity, linked-worktree git-dir placement, and the creation-time root,
+ * .git file, and admin git-dir must all still agree. This closes static path
+ * replacement; the later runner launch remains a separate best-effort TOCTOU
+ * boundary and therefore retains the runner's own trusted-root checks.
  */
 const validateInheritedWorktree = async (
   sourceCwd: string,
   worktreePath: string,
+  identity: WorktreeIdentityV1,
+  readGit: (
+    cwd: string,
+    args: string[],
+  ) => Promise<string | undefined> = gitOutput,
 ): Promise<boolean> => {
   try {
-    if ((await realpath(worktreePath)) !== worktreePath) return false;
+    const worktreeDotGit = join(worktreePath, ".git");
+    const [canonicalRoot, rootStats, dotGitStats] = await Promise.all([
+      realpath(worktreePath),
+      lstat(worktreePath, { bigint: true }),
+      lstat(worktreeDotGit, { bigint: true }),
+    ]);
+    if (
+      canonicalRoot !== worktreePath ||
+      !rootStats.isDirectory() ||
+      !dotGitStats.isFile() ||
+      !matchesFileIdentity(rootStats, identity.root) ||
+      !matchesFileIdentity(dotGitStats, identity.dotGit)
+    ) {
+      return false;
+    }
     const [sourceCommon, worktreeCommon, worktreeTop, worktreeGitDir, list] =
       await Promise.all([
-        gitOutput(sourceCwd, [
+        readGit(sourceCwd, [
           "rev-parse",
           "--path-format=absolute",
           "--git-common-dir",
         ]),
-        gitOutput(worktreePath, [
+        readGit(worktreePath, [
           "rev-parse",
           "--path-format=absolute",
           "--git-common-dir",
         ]),
-        gitOutput(worktreePath, [
+        readGit(worktreePath, [
           "rev-parse",
           "--path-format=absolute",
           "--show-toplevel",
         ]),
-        gitOutput(worktreePath, ["rev-parse", "--absolute-git-dir"]),
-        gitOutput(sourceCwd, ["worktree", "list", "--porcelain"]),
+        readGit(worktreePath, ["rev-parse", "--absolute-git-dir"]),
+        readGit(sourceCwd, ["worktree", "list", "--porcelain"]),
       ]);
     const required = [
       sourceCommon,
@@ -232,6 +261,7 @@ const validateInheritedWorktree = async (
     if (
       canonicalSourceCommon !== canonicalWorktreeCommon ||
       canonicalTop !== worktreePath ||
+      gitDir !== identity.gitDir ||
       gitDir === linkedGitDirRoot ||
       !isPathWithin(gitDir, linkedGitDirRoot) ||
       !registered
@@ -243,17 +273,9 @@ const validateInheritedWorktree = async (
     // registered linked-worktree directory inside the trusted common dir.
     // This prevents an attacker-controlled replacement path from making us
     // read an arbitrary path (or FIFO) before the containment checks run.
-    const worktreeDotGit = join(worktreePath, ".git");
     const backlinkFile = join(gitDir, "gitdir");
-    const [dotGitStats, backlinkStats] = await Promise.all([
-      lstat(worktreeDotGit),
-      lstat(backlinkFile),
-    ]);
-    if (
-      !dotGitStats.isFile() ||
-      !backlinkStats.isFile() ||
-      backlinkStats.size > 4_096
-    ) {
+    const backlinkStats = await lstat(backlinkFile);
+    if (!backlinkStats.isFile() || backlinkStats.size > 4_096) {
       return false;
     }
 
@@ -274,7 +296,21 @@ const validateInheritedWorktree = async (
       realpath(worktreeDotGit),
       realpath(backlinkTarget),
     ]);
-    return canonicalDotGit === canonicalBacklink;
+    if (canonicalDotGit !== canonicalBacklink) return false;
+
+    // Git and backlink discovery above are asynchronous. Re-check both inode
+    // identities at the end so a replacement during that interval cannot be
+    // trusted before the runner performs its own pinned-cwd verification.
+    const [finalRootStats, finalDotGitStats] = await Promise.all([
+      lstat(worktreePath, { bigint: true }),
+      lstat(worktreeDotGit, { bigint: true }),
+    ]);
+    return (
+      finalRootStats.isDirectory() &&
+      finalDotGitStats.isFile() &&
+      matchesFileIdentity(finalRootStats, identity.root) &&
+      matchesFileIdentity(finalDotGitStats, identity.dotGit)
+    );
   } catch {
     return false;
   }
@@ -346,7 +382,14 @@ export default function setupStatusline(
   const getGitStatus = deps.getGitStatus ?? defaultGetGitStatus;
   const getBranch = deps.getBranch ?? defaultGetBranch;
   const validateWorktree =
-    deps.validateInheritedWorktree ?? validateInheritedWorktree;
+    deps.validateInheritedWorktree ??
+    ((sourceCwd, worktreePath, identity) =>
+      validateInheritedWorktree(
+        sourceCwd,
+        worktreePath,
+        identity,
+        deps.gitOutput ?? gitOutput,
+      ));
   const runner = join(
     config.paths.claudeHooksDir,
     "lib/statusline_checks_run.sh",
@@ -439,21 +482,44 @@ export default function setupStatusline(
     // closed. The worktree itself is the shell runner boundary.
     const directlyTrustedRoot = matchedTrustedRoot(cwd, config.trust);
     let trustedRoot = directlyTrustedRoot;
+    let trustedWorktreeIdentity: WorktreeIdentityV1 | undefined;
     if (
       trustedRoot === undefined &&
       activeWorktree?.path === cwd &&
       matchedTrustedRoot(activeWorktree.sourceCwd, config.trust) !== undefined
     ) {
       try {
-        if (await validateWorktree(activeWorktree.sourceCwd, cwd)) {
+        if (
+          activeWorktree.identity !== undefined &&
+          (await validateWorktree(
+            activeWorktree.sourceCwd,
+            cwd,
+            activeWorktree.identity,
+          ))
+        ) {
           trustedRoot = cwd;
+          trustedWorktreeIdentity = activeWorktree.identity;
         }
       } catch {
         trustedRoot = undefined;
       }
     }
     if (launchChecks && trustedRoot !== undefined && existsSync(runner)) {
-      spawnDetached("bash", [runner, cwd, trustedRoot], { cwd });
+      spawnDetached(
+        "bash",
+        [
+          runner,
+          cwd,
+          trustedRoot,
+          ...(trustedWorktreeIdentity === undefined
+            ? []
+            : [
+                trustedWorktreeIdentity.root.dev,
+                trustedWorktreeIdentity.root.ino,
+              ]),
+        ],
+        { cwd },
+      );
     }
 
     // Print/JSON modes expose no-op UI methods. Preserve lifecycle checks, but
@@ -504,10 +570,12 @@ export default function setupStatusline(
   pi.on("tool_result", async (event, ctx) => {
     const createdPath = createdWorktreePath(event);
     if (createdPath !== undefined) {
+      const identity = worktreeIdentityFromDetails(event.details, createdPath);
       activeWorktree = {
         path: createdPath,
         branch: toolInputString(event, "name"),
         sourceCwd: ctx.cwd ?? process.cwd(),
+        ...(identity === undefined ? {} : { identity }),
       };
       await refresh(ctx, false);
       return;

--- a/pi/extensions/pi-harness/lib/worktree-identity.ts
+++ b/pi/extensions/pi-harness/lib/worktree-identity.ts
@@ -1,0 +1,108 @@
+import { isAbsolute } from "node:path";
+
+export interface FileSystemIdentityV1 {
+  readonly dev: string;
+  readonly ino: string;
+}
+
+export interface WorktreeIdentityV1 {
+  readonly version: 1;
+  readonly path: string;
+  readonly root: FileSystemIdentityV1;
+  readonly dotGit: FileSystemIdentityV1;
+  readonly gitDir: string;
+}
+
+export interface WorktreeIdentityDetailsV1 {
+  readonly worktreeIdentity: WorktreeIdentityV1;
+}
+
+const DECIMAL_ID = /^(?:0|[1-9][0-9]*)$/;
+const MAX_ID_DIGITS = 32;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const hasExactKeys = (
+  value: Record<string, unknown>,
+  expected: readonly string[],
+): boolean => {
+  const keys = Object.keys(value).sort();
+  return (
+    keys.length === expected.length &&
+    keys.every((key, index) => key === expected[index])
+  );
+};
+
+const safeAbsolutePath = (value: unknown): value is string =>
+  typeof value === "string" &&
+  value !== "" &&
+  value.length <= 16_384 &&
+  isAbsolute(value) &&
+  !value.includes("\0") &&
+  !value.includes("\r") &&
+  !value.includes("\n");
+
+const parseFileIdentity = (
+  value: unknown,
+): FileSystemIdentityV1 | undefined => {
+  if (!isRecord(value) || !hasExactKeys(value, ["dev", "ino"])) {
+    return undefined;
+  }
+  const { dev, ino } = value;
+  if (
+    typeof dev !== "string" ||
+    typeof ino !== "string" ||
+    dev.length > MAX_ID_DIGITS ||
+    ino.length > MAX_ID_DIGITS ||
+    !DECIMAL_ID.test(dev) ||
+    !DECIMAL_ID.test(ino)
+  ) {
+    return undefined;
+  }
+  return { dev, ino };
+};
+
+export const parseWorktreeIdentity = (
+  value: unknown,
+): WorktreeIdentityV1 | undefined => {
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, ["dotGit", "gitDir", "path", "root", "version"]) ||
+    value.version !== 1 ||
+    !safeAbsolutePath(value.path) ||
+    !safeAbsolutePath(value.gitDir)
+  ) {
+    return undefined;
+  }
+  const root = parseFileIdentity(value.root);
+  const dotGit = parseFileIdentity(value.dotGit);
+  if (root === undefined || dotGit === undefined) return undefined;
+  return {
+    version: 1,
+    path: value.path,
+    root,
+    dotGit,
+    gitDir: value.gitDir,
+  };
+};
+
+export const worktreeIdentityDetails = (
+  identity: WorktreeIdentityV1,
+): WorktreeIdentityDetailsV1 => ({ worktreeIdentity: identity });
+
+export const worktreeIdentityFromDetails = (
+  details: unknown,
+  expectedPath: string,
+): WorktreeIdentityV1 | undefined => {
+  if (!isRecord(details)) return undefined;
+  const identity = parseWorktreeIdentity(details.worktreeIdentity);
+  return identity?.path === expectedPath ? identity : undefined;
+};
+
+export const matchesFileIdentity = (
+  stats: { readonly dev: bigint; readonly ino: bigint },
+  identity: FileSystemIdentityV1,
+): boolean =>
+  stats.dev.toString(10) === identity.dev &&
+  stats.ino.toString(10) === identity.ino;

--- a/tests/hooks/codex-harness/worktree.test.ts
+++ b/tests/hooks/codex-harness/worktree.test.ts
@@ -3,6 +3,10 @@ import { createHash } from "node:crypto";
 import { promises as fs } from "node:fs";
 import { join, resolve } from "node:path";
 import { runHook } from "../../../pi/extensions/pi-harness/lib/run-hook";
+import {
+  matchesFileIdentity,
+  parseWorktreeIdentity,
+} from "../../../pi/extensions/pi-harness/lib/worktree-identity";
 import { cleanupTestDirectory, setupTestDirectory } from "../../test-helpers";
 
 const ROOT = resolve(import.meta.dir, "../../..");
@@ -77,6 +81,21 @@ const pathExists = async (path: string): Promise<boolean> => {
   } catch {
     return false;
   }
+};
+
+const parseCreateOutput = (stdout: string) => {
+  const [path = "", identityLine, ...extra] = stdout
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean);
+  expect(extra).toEqual([]);
+  return {
+    path,
+    identity:
+      identityLine === undefined
+        ? undefined
+        : parseWorktreeIdentity(JSON.parse(identityLine)),
+  };
 };
 
 const createFixture = async (): Promise<WorktreeFixture> => {
@@ -295,7 +314,22 @@ describe("Codex worktree removal safety", () => {
     });
 
     expect(created.exitCode).toBe(0);
-    expect(created.stdout).toBe(worktree);
+    const publication = parseCreateOutput(created.stdout);
+    expect(publication.path).toBe(worktree);
+    expect(publication.identity).toBeDefined();
+    const { identity } = publication;
+    if (identity === undefined) throw new Error("missing creation identity");
+    const [rootStats, dotGitStats] = await Promise.all([
+      fs.lstat(worktree, { bigint: true }),
+      fs.lstat(join(worktree, ".git"), { bigint: true }),
+    ]);
+    expect(matchesFileIdentity(rootStats, identity.root)).toBe(true);
+    expect(matchesFileIdentity(dotGitStats, identity.dotGit)).toBe(true);
+    const gitDirResult = await runGit(
+      ["rev-parse", "--absolute-git-dir"],
+      worktree,
+    );
+    expect(identity.gitDir).toBe(await fs.realpath(gitDirResult.stdout));
     const commonDirectory = await fs.realpath(join(repository, ".git"));
     const pathSha1 = createHash("sha1").update(worktree).digest("hex");
     const markerPath = join(
@@ -324,6 +358,89 @@ describe("Codex worktree removal safety", () => {
     });
     expect(removed.exitCode).toBe(0);
     expect(await pathExists(worktree)).toBe(false);
+    expect(await pathExists(markerPath)).toBe(false);
+  });
+
+  test("rejects replacement between initial and final hook identity checks", async () => {
+    const value = await createCreateHookFixture("codex-worktree-identity-swap");
+    temporaryDirectories.push(value.root);
+    const branch = "harness-identity-swap-test";
+    const worktree = join(value.root, "linked-worktree");
+    const statCount = join(value.root, "stat-count");
+    const realStat = Bun.which("stat");
+    const realRm = Bun.which("rm");
+    if (realStat === null || realRm === null) {
+      throw new Error("stat and rm are required for this test");
+    }
+    await fs.writeFile(
+      join(value.binDirectory, "gwq"),
+      [
+        "#!/usr/bin/env bash",
+        'if [ "$1" = "add" ]; then',
+        '  exec "$REAL_GIT" -C "$GWQ_REPOSITORY" worktree add -q "$GWQ_WORKTREE" "$2"',
+        "fi",
+        String.raw`if [ "$1" = "get" ]; then printf "%s\n" "$GWQ_WORKTREE"; exit 0; fi`,
+        "exit 1",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    await fs.writeFile(
+      join(value.binDirectory, "stat"),
+      [
+        "#!/usr/bin/env bash",
+        "set -uo pipefail",
+        'output=$("$REAL_STAT" "$@" 2>/dev/null)',
+        "status=$?",
+        '[ "$status" -eq 0 ] || exit "$status"',
+        String.raw`printf '%s\n' "$output"`,
+        "last=$" + "{!#}",
+        'if [ "$last" = "$GWQ_WORKTREE" ] || [ "$last" = "$GWQ_WORKTREE/.git" ]; then',
+        '  count=$(cat "$STAT_COUNT" 2>/dev/null || printf 0)',
+        "  count=$((count + 1))",
+        String.raw`  printf "%s\n" "$count" > "$STAT_COUNT"`,
+        '  if [ "$count" -eq 2 ]; then',
+        '    dot_git=$(cat "$GWQ_WORKTREE/.git")',
+        '    "$REAL_RM" -rf -- "$GWQ_WORKTREE"',
+        '    "$REAL_MKDIR" -- "$GWQ_WORKTREE"',
+        String.raw`    printf "%s\n" "$dot_git" > "$GWQ_WORKTREE/.git"`,
+        "  fi",
+        "fi",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const result = await runCommand(["bash", CREATE_HOOK], {
+      cwd: value.repository,
+      env: {
+        PATH: `${value.binDirectory}:${process.env.PATH ?? ""}`,
+        REAL_GIT: value.realGit,
+        REAL_MKDIR: value.realMkdir,
+        REAL_RM: realRm,
+        REAL_STAT: realStat,
+        GWQ_REPOSITORY: value.repository,
+        GWQ_WORKTREE: worktree,
+        STAT_COUNT: statCount,
+      },
+      input: JSON.stringify({ name: branch }),
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain(
+      "created worktree root identity changed before publication",
+    );
+    expect(parseCreateOutput(result.stdout).path).toBe(worktree);
+    expect(await pathExists(worktree)).toBe(true);
+    const branchLookup = await runCommand(
+      ["git", "show-ref", "--verify", `refs/heads/${branch}`],
+      { cwd: value.repository },
+    );
+    expect(branchLookup.exitCode).toBe(0);
+    const commonDirectory = await fs.realpath(join(value.repository, ".git"));
+    const markerPath = join(
+      commonDirectory,
+      "codex-harness-worktrees",
+      `${createHash("sha1").update(worktree).digest("hex")}.json`,
+    );
     expect(await pathExists(markerPath)).toBe(false);
   });
 
@@ -755,7 +872,7 @@ describe("Codex worktree removal safety", () => {
 
     expect(result.exitCode).toBe(130);
     expect(result.timedOut).toBe(false);
-    expect(result.stdout.trim()).toBe(worktree);
+    expect(parseCreateOutput(result.stdout).path).toBe(worktree);
     expect(await pathExists(signalSent)).toBe(true);
     expect(await pathExists(worktree)).toBe(true);
     expect(await pathExists(markerPath)).toBe(true);
@@ -846,7 +963,7 @@ describe("Codex worktree removal safety", () => {
 
     expect(result.exitCode).not.toBe(0);
     expect(result.stderr).toContain("could not release worktree create lock");
-    expect(result.stdout.trim()).toBe(worktree);
+    expect(parseCreateOutput(result.stdout).path).toBe(worktree);
     expect(await pathExists(markerPath)).toBe(true);
     expect(
       (await fs.readdir(lockParent)).filter((name) =>
@@ -918,7 +1035,7 @@ describe("Codex worktree removal safety", () => {
     ).toBe(head);
   });
 
-  test("cancellation publishes a removable worktree created mid-hook", async () => {
+  test("cancellation retains an unmarked worktree created mid-hook", async () => {
     const root = await fs.realpath(
       await setupTestDirectory("codex-worktree-cancel"),
     );
@@ -990,7 +1107,7 @@ describe("Codex worktree removal safety", () => {
     expect(createdBeforeAbort).toBe(true);
     expect(result.exitCode).not.toBe(0);
     expect(result.timedOut).toBe(false);
-    expect(result.stdout.trim()).toBe(worktree);
+    expect(parseCreateOutput(result.stdout).path).toBe(worktree);
     expect(await pathExists(worktree)).toBe(true);
     const branchLookup = await runCommand(
       ["git", "show-ref", "--verify", `refs/heads/${branch}`],
@@ -1004,18 +1121,7 @@ describe("Codex worktree removal safety", () => {
       "codex-harness-worktrees",
       `${pathSha1}.json`,
     );
-    expect(await pathExists(markerPath)).toBe(true);
-    expect(JSON.parse(await fs.readFile(markerPath, "utf8"))).toEqual({
-      path: worktree,
-      branch,
-    });
-
-    const removed = await runRemoveHook(
-      { root, repository, worktree, commonDirectory, markerPath },
-      { worktree_path: worktree, confirmed: true },
-    );
-    expect(removed.exitCode).toBe(0);
-    expect(await pathExists(worktree)).toBe(false);
     expect(await pathExists(markerPath)).toBe(false);
+    expect(await pathExists(worktree)).toBe(true);
   });
 });

--- a/tests/hooks/pi-harness/bit-task-integration.test.ts
+++ b/tests/hooks/pi-harness/bit-task-integration.test.ts
@@ -4,6 +4,10 @@ import { join, resolve } from "node:path";
 import type { HarnessConfig } from "../../../pi/extensions/pi-harness/config";
 import setupBitTask from "../../../pi/extensions/pi-harness/features/bit-task/index";
 import { resolvePaths } from "../../../pi/extensions/pi-harness/lib/paths";
+import {
+  matchesFileIdentity,
+  worktreeIdentityFromDetails,
+} from "../../../pi/extensions/pi-harness/lib/worktree-identity";
 import type {
   CtxLike,
   ToolDefLike,
@@ -228,6 +232,19 @@ describe("pi-harness bit-task integration", () => {
     );
 
     expect(readTextResult(result)).toBe(expected);
+    const details =
+      result !== null && typeof result === "object"
+        ? Reflect.get(result, "details")
+        : undefined;
+    const identity = worktreeIdentityFromDetails(details, expected);
+    expect(identity).toBeDefined();
+    if (identity === undefined) throw new Error("missing worktree identity");
+    const [rootStats, dotGitStats] = await Promise.all([
+      fs.lstat(expected, { bigint: true }),
+      fs.lstat(join(expected, ".git"), { bigint: true }),
+    ]);
+    expect(matchesFileIdentity(rootStats, identity.root)).toBe(true);
+    expect(matchesFileIdentity(dotGitStats, identity.dotGit)).toBe(true);
   });
 
   test("rejects a successful create hook that returns a nonexistent path", async () => {
@@ -254,6 +271,51 @@ describe("pi-harness bit-task integration", () => {
         pi.ctx,
       ),
     ).rejects.toThrow(/worktree_create postcondition failed/i);
+  });
+
+  test("rejects replacement after hook publication before parent validation", async () => {
+    const fixture = await setupRepo("feature/pi-bit-task-race");
+    const hooks = join(fixture.directory, "race-hooks");
+    await fs.mkdir(join(hooks, "worktree"), { recursive: true });
+    await fs.writeFile(
+      join(hooks, "worktree/create.sh"),
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        'output=$(bash "$REAL_CREATE_HOOK")',
+        "path=$" + String.raw`{output%%$'\n'*}`,
+        'dot_git=$(cat "$path/.git")',
+        'rm -rf -- "$path"',
+        'mkdir -- "$path"',
+        String.raw`printf "%s\n" "$dot_git" > "$path/.git"`,
+        String.raw`printf "%s\n" "$output"`,
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    const config: HarnessConfig = {
+      ...fixture.config,
+      paths: { ...fixture.config.paths, codexHooksDir: hooks },
+    };
+    const pi = createFakePi({ cwd: fixture.repo });
+    setupBitTask(pi, config, {
+      cwd: fixture.repo,
+      env: {
+        ...fixture.env,
+        REAL_CREATE_HOOK: join(CODEX_HOOKS, "worktree/create.sh"),
+      },
+    });
+
+    await expect(
+      executeTool(
+        getTool(pi.tools, "worktree_create"),
+        { name: "pi-worktree-race" },
+        pi.ctx,
+      ),
+    ).rejects.toThrow(/filesystem identity changed after hook publication/i);
+    const replacementStats = await fs.stat(
+      join(fixture.worktrees, "pi-worktree-race"),
+    );
+    expect(replacementStats.isDirectory()).toBe(true);
   });
 
   test("removes a clean worktree created through the tool", async () => {

--- a/tests/hooks/statusline-checks/run.test.ts
+++ b/tests/hooks/statusline-checks/run.test.ts
@@ -342,6 +342,170 @@ const runRunnerBounded = async (
   return { exitCode: await proc.exited };
 };
 
+const runRunnerIdentified = async (
+  projectDir: string,
+  boundary: string,
+  dev: string,
+  ino?: string,
+  env: Record<string, string> = {},
+): Promise<{ exitCode: number }> => {
+  const proc = Bun.spawn(
+    [
+      "bash",
+      RUNNER,
+      projectDir,
+      boundary,
+      dev,
+      ...(ino === undefined ? [] : [ino]),
+    ],
+    {
+      env: { ...process.env, ...env },
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+  await new Response(proc.stdout).text();
+  await new Response(proc.stderr).text();
+  return { exitCode: await proc.exited };
+};
+
+const seedRunnableProject = async (
+  root: string,
+  sentinel: string,
+): Promise<void> => {
+  await fs.mkdir(root, { recursive: true });
+  await fs.writeFile(
+    join(root, "package.json"),
+    JSON.stringify({ scripts: { lint: "bash check.sh" } }),
+  );
+  await fs.writeFile(join(root, "bun.lock"), "");
+  await fs.writeFile(join(root, ".git"), "gitdir: /nonexistent\n");
+  await fs.writeFile(
+    join(root, "check.sh"),
+    `#!/bin/bash\nprintf 'ran\\n' >> ${JSON.stringify(sentinel)}\n`,
+    { mode: 0o755 },
+  );
+};
+
+describe("runner: pinned worktree identity", () => {
+  const tmps: string[] = [];
+  afterEach(async () => {
+    await Promise.all(tmps.splice(0).map(cleanupTestDirectory));
+  });
+
+  test("partial identity arguments fail closed for an otherwise runnable project", async () => {
+    const tmp = await setupTestDirectory("run-identity-partial");
+    tmps.push(tmp);
+    const project = join(tmp, "project");
+    const sentinel = join(tmp, "ran");
+    const cacheDir = join(tmp, "cache");
+    await seedRunnableProject(project, sentinel);
+    const stats = await fs.lstat(project, { bigint: true });
+
+    const result = await runRunnerIdentified(
+      project,
+      project,
+      stats.dev.toString(10),
+      undefined,
+      { STATUSLINE_CACHE_DIR: cacheDir },
+    );
+    expect(result.exitCode).toBe(0);
+    expect(await readCache(cacheDir)).toBeNull();
+    expect(fs.access(sentinel)).rejects.toThrow();
+  });
+
+  test("rejects an otherwise runnable replacement before cwd pinning", async () => {
+    const tmp = await setupTestDirectory("run-identity-pre-pin");
+    tmps.push(tmp);
+    const project = join(tmp, "project");
+    const oldSentinel = join(tmp, "old-ran");
+    const replacementSentinel = join(tmp, "replacement-ran");
+    const cacheDir = join(tmp, "cache");
+    await seedRunnableProject(project, oldSentinel);
+    const stats = await fs.lstat(project, { bigint: true });
+    await fs.rm(project, { recursive: true, force: true });
+    await seedRunnableProject(project, replacementSentinel);
+
+    const result = await runRunnerIdentified(
+      project,
+      project,
+      stats.dev.toString(10),
+      stats.ino.toString(10),
+      { STATUSLINE_CACHE_DIR: cacheDir },
+    );
+    expect(result.exitCode).toBe(0);
+    expect(await readCache(cacheDir)).toBeNull();
+    expect(fs.access(oldSentinel)).rejects.toThrow();
+    expect(fs.access(replacementSentinel)).rejects.toThrow();
+  });
+
+  test("executes only from the pinned inode after pathname replacement", async () => {
+    const tmp = await setupTestDirectory("run-identity-post-pin");
+    tmps.push(tmp);
+    const project = join(tmp, "project");
+    const moved = join(tmp, "moved-original");
+    const replacement = join(tmp, "replacement-seed");
+    const oldSentinel = join(tmp, "old-ran");
+    const replacementSentinel = join(tmp, "replacement-ran");
+    const cacheDir = join(tmp, "cache");
+    const bin = join(tmp, "bin");
+    const swapped = join(tmp, "swapped");
+    await seedRunnableProject(project, oldSentinel);
+    await seedRunnableProject(replacement, replacementSentinel);
+    await fs.mkdir(bin);
+    const stats = await fs.lstat(project, { bigint: true });
+    const realStat = Bun.which("stat");
+    const realMv = Bun.which("mv");
+    const realCp = Bun.which("cp");
+    if (realStat === null || realMv === null || realCp === null) {
+      throw new Error("stat, mv, and cp are required for this test");
+    }
+    await fs.writeFile(
+      join(bin, "stat"),
+      [
+        "#!/usr/bin/env bash",
+        "set -uo pipefail",
+        'output=$("$REAL_STAT" "$@" 2>/dev/null)',
+        "status=$?",
+        '[ "$status" -eq 0 ] || exit "$status"',
+        String.raw`printf '%s\n' "$output"`,
+        "last=${!#}",
+        'if [ "$last" = "." ] && [ ! -e "$SWAPPED" ]; then',
+        '  : > "$SWAPPED"',
+        '  "$REAL_MV" -- "$PROJECT" "$MOVED"',
+        '  "$REAL_CP" -R -- "$REPLACEMENT" "$PROJECT"',
+        "fi",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const result = await runRunnerIdentified(
+      project,
+      project,
+      stats.dev.toString(10),
+      stats.ino.toString(10),
+      {
+        STATUSLINE_CACHE_DIR: cacheDir,
+        STATUSLINE_NOW_OVERRIDE: "70000",
+        PATH: `${bin}:${process.env.PATH ?? ""}`,
+        REAL_STAT: realStat,
+        REAL_MV: realMv,
+        REAL_CP: realCp,
+        PROJECT: project,
+        MOVED: moved,
+        REPLACEMENT: replacement,
+        SWAPPED: swapped,
+      },
+    );
+    expect(result.exitCode).toBe(0);
+    expect(await fs.readFile(oldSentinel, "utf8")).toContain("ran");
+    expect(fs.access(replacementSentinel)).rejects.toThrow();
+    const cache = await readCache(cacheDir);
+    const checks = cache?.checks as Record<string, { status: string }>;
+    expect(checks.lint.status).toBe("ok");
+  });
+});
+
 describe("runner: trust boundary", () => {
   const tmps: string[] = [];
   afterEach(async () => {

--- a/tests/pi-harness/bit-task.test.ts
+++ b/tests/pi-harness/bit-task.test.ts
@@ -80,6 +80,31 @@ const readTextResult = (result: unknown): string => {
   return text;
 };
 
+const mockWorktreePublication = async (path: string) => {
+  const gitDirPath = join(path, "..", ".mock-admin");
+  await fs.mkdir(gitDirPath);
+  const gitDir = await fs.realpath(gitDirPath);
+  await fs.writeFile(join(path, ".git"), `gitdir: ${gitDir}\n`);
+  const [rootStats, dotGitStats] = await Promise.all([
+    fs.lstat(path, { bigint: true }),
+    fs.lstat(join(path, ".git"), { bigint: true }),
+  ]);
+  const identity = {
+    version: 1 as const,
+    path,
+    root: {
+      dev: rootStats.dev.toString(10),
+      ino: rootStats.ino.toString(10),
+    },
+    dotGit: {
+      dev: dotGitStats.dev.toString(10),
+      ino: dotGitStats.ino.toString(10),
+    },
+    gitDir,
+  };
+  return { identity, stdout: `${path}\n${JSON.stringify(identity)}\n` };
+};
+
 describe("bit-task lifecycle", () => {
   test("builds a sequence-aware marker", () => {
     expect(buildTaskMarker("feature/harness", 3, "task-123")).toBe(
@@ -225,6 +250,7 @@ describe("bit-task tool registration", () => {
     const directory = await setupTestDirectory("pi-bit-task-env", ["created"]);
     try {
       const created = await fs.realpath(join(directory, "created"));
+      const publication = await mockWorktreePublication(created);
       const hookEnvs: (Record<string, string | undefined> | undefined)[] = [];
       const commandEnvs: (Record<string, string | undefined> | undefined)[] =
         [];
@@ -236,12 +262,19 @@ describe("bit-task tool registration", () => {
           return {
             exitCode: 0,
             timedOut: false,
-            stdout: `${created}\n`,
+            stdout: publication.stdout,
             stderr: "",
           };
         },
         runCommand: async (_command, args, options) => {
           commandEnvs.push(options.env);
+          if (args.includes("--absolute-git-dir")) {
+            return {
+              exitCode: 0,
+              stdout: `${publication.identity.gitDir}\n`,
+              stderr: "",
+            };
+          }
           if (args.includes("--git-common-dir")) {
             const commonDir = await fs.realpath(directory);
             return { exitCode: 0, stdout: `${commonDir}\n`, stderr: "" };
@@ -262,8 +295,8 @@ describe("bit-task tool registration", () => {
         ),
       ).resolves.toBeDefined();
       expect(hookEnvs).toHaveLength(1);
-      // worktree list + two common-dir identity resolutions (postcondition).
-      expect(commandEnvs).toHaveLength(3);
+      // Two admin-identity checks + worktree list + two common-dir checks.
+      expect(commandEnvs).toHaveLength(5);
       expect(hookEnvs[0]?.PI_HARNESS_CHILD).toBe("1");
       for (const env of commandEnvs) {
         expect(env?.PI_HARNESS_CHILD).toBe("1");
@@ -319,6 +352,174 @@ describe("bit-task tool registration", () => {
     }
   });
 
+  test("rejects a successful hook that omits its creation identity", async () => {
+    const directory = await setupTestDirectory("pi-bit-task-no-identity", [
+      "created",
+    ]);
+    try {
+      const created = await fs.realpath(join(directory, "created"));
+      let commandCalls = 0;
+      const pi = createFakePi({ cwd: directory });
+      setupBitTask(pi, makeConfig(), {
+        runHook: async () => ({
+          exitCode: 0,
+          timedOut: false,
+          stdout: `${created}\n`,
+          stderr: "",
+        }),
+        runCommand: async () => {
+          commandCalls += 1;
+          return { exitCode: 0, stdout: "", stderr: "" };
+        },
+      });
+
+      const error = await captureError(
+        executeTool(
+          getTool(pi.tools, "worktree_create"),
+          { name: "missing-identity" },
+          pi.ctx,
+        ),
+      );
+      expect(error.message).toContain("omitted its creation identity");
+      expect(error.message).toContain(created);
+      expect(commandCalls).toBe(0);
+    } finally {
+      await cleanupTestDirectory(directory);
+    }
+  });
+
+  test("reports the retained path before rejecting a malformed identity", async () => {
+    const directory = await setupTestDirectory("pi-bit-task-bad-identity", [
+      "created",
+    ]);
+    try {
+      const created = await fs.realpath(join(directory, "created"));
+      let commandCalls = 0;
+      const pi = createFakePi({ cwd: directory });
+      setupBitTask(pi, makeConfig(), {
+        runHook: async () => ({
+          exitCode: 0,
+          timedOut: false,
+          stdout: `${created}\nnot-json\n`,
+          stderr: "",
+        }),
+        runCommand: async () => {
+          commandCalls += 1;
+          return { exitCode: 0, stdout: "", stderr: "" };
+        },
+      });
+
+      const error = await captureError(
+        executeTool(
+          getTool(pi.tools, "worktree_create"),
+          { name: "malformed-identity" },
+          pi.ctx,
+        ),
+      );
+      expect(error.message).toContain("invalid identity record");
+      expect(error.message).toContain(created);
+      expect(error.message).toContain("worktree_remove");
+      expect(commandCalls).toBe(0);
+    } finally {
+      await cleanupTestDirectory(directory);
+    }
+  });
+
+  test("rejects replacement between hook publication and parent validation", async () => {
+    const directory = await setupTestDirectory("pi-bit-task-identity-race", [
+      "created",
+    ]);
+    try {
+      const created = await fs.realpath(join(directory, "created"));
+      const publication = await mockWorktreePublication(created);
+      let commandCalls = 0;
+      const pi = createFakePi({ cwd: directory });
+      setupBitTask(pi, makeConfig(), {
+        runHook: async () => {
+          await fs.rm(created, { recursive: true, force: true });
+          await fs.mkdir(created);
+          await fs.writeFile(
+            join(created, ".git"),
+            `gitdir: ${publication.identity.gitDir}\n`,
+          );
+          return {
+            exitCode: 0,
+            timedOut: false,
+            stdout: publication.stdout,
+            stderr: "",
+          };
+        },
+        runCommand: async () => {
+          commandCalls += 1;
+          return { exitCode: 0, stdout: "", stderr: "" };
+        },
+      });
+
+      const error = await captureError(
+        executeTool(
+          getTool(pi.tools, "worktree_create"),
+          { name: "replaced-before-validation" },
+          pi.ctx,
+        ),
+      );
+      expect(error.message).toContain("filesystem identity changed");
+      expect(error.message).toContain(created);
+      expect(commandCalls).toBe(0);
+    } finally {
+      await cleanupTestDirectory(directory);
+    }
+  });
+
+  test("rejects replacement during parent Git identity validation", async () => {
+    const directory = await setupTestDirectory("pi-bit-task-git-race", [
+      "created",
+    ]);
+    try {
+      const created = await fs.realpath(join(directory, "created"));
+      const publication = await mockWorktreePublication(created);
+      let commandCalls = 0;
+      const pi = createFakePi({ cwd: directory });
+      setupBitTask(pi, makeConfig(), {
+        runHook: async () => ({
+          exitCode: 0,
+          timedOut: false,
+          stdout: publication.stdout,
+          stderr: "",
+        }),
+        runCommand: async (_command, args) => {
+          commandCalls += 1;
+          if (args.includes("--absolute-git-dir")) {
+            await fs.rm(created, { recursive: true, force: true });
+            await fs.mkdir(created);
+            await fs.writeFile(
+              join(created, ".git"),
+              `gitdir: ${publication.identity.gitDir}\n`,
+            );
+            return {
+              exitCode: 0,
+              stdout: `${publication.identity.gitDir}\n`,
+              stderr: "",
+            };
+          }
+          throw new Error("registration must not run after identity swap");
+        },
+      });
+
+      const error = await captureError(
+        executeTool(
+          getTool(pi.tools, "worktree_create"),
+          { name: "replaced-during-git" },
+          pi.ctx,
+        ),
+      );
+      expect(error.message).toContain("changed during parent validation");
+      expect(error.message).toContain(created);
+      expect(commandCalls).toBe(1);
+    } finally {
+      await cleanupTestDirectory(directory);
+    }
+  });
+
   test("public worktree tool reports a retained path after hook timeout", async () => {
     const directory = await setupTestDirectory("pi-bit-task-tool-timeout", [
       "created",
@@ -359,17 +560,20 @@ describe("bit-task tool registration", () => {
     ]);
     try {
       const created = await fs.realpath(join(directory, "created"));
+      const publication = await mockWorktreePublication(created);
       const pi = createFakePi({ cwd: directory });
       setupBitTask(pi, makeConfig(), {
         runHook: async () => ({
           exitCode: 0,
           timedOut: false,
-          stdout: `${created}\n`,
+          stdout: publication.stdout,
           stderr: "",
         }),
-        runCommand: async () => ({
+        runCommand: async (_command, args) => ({
           exitCode: 0,
-          stdout: "",
+          stdout: args.includes("--absolute-git-dir")
+            ? `${publication.identity.gitDir}\n`
+            : "",
           stderr: "",
         }),
       });

--- a/tests/pi-harness/statusline.test.ts
+++ b/tests/pi-harness/statusline.test.ts
@@ -310,6 +310,81 @@ describe("Claude-compatible statusline rendering", () => {
 });
 
 describe("pi-harness statusline lifecycle", () => {
+  test("inherits trust only while a registered linked worktree stays intact", async () => {
+    const home = await tempDirectory("pi-statusline-worktree-trust");
+    const project = join(home, "repo");
+    const worktree = join(home, "topic-worktree");
+    const replacement = join(home, "replacement");
+    await fs.mkdir(project, { recursive: true });
+    await markAsProject(project);
+    await runGit(project, ["init", "-b", "main"]);
+    await runGit(project, ["config", "user.email", "test@example.com"]);
+    await runGit(project, ["config", "user.name", "Status Test"]);
+    await runGit(project, ["add", "."]);
+    await runGit(project, ["commit", "-m", "initial"]);
+    await runGit(project, ["worktree", "add", "-b", "topic", worktree]);
+    const canonicalProject = await fs.realpath(project);
+    const canonicalWorktree = await fs.realpath(worktree);
+    const runner = join(
+      resolvePaths(home).claudeHooksDir,
+      "lib/statusline_checks_run.sh",
+    );
+    await fs.mkdir(dirname(runner), { recursive: true });
+    await fs.writeFile(runner, "#!/bin/bash\nexit 0\n", { mode: 0o755 });
+
+    const gitReads: string[] = [];
+    const checkLaunches: string[][] = [];
+    const pi = createFakePi({ cwd: canonicalProject, gitBranch: "main" });
+    setupStatusline(pi, makeConfig(home, [canonicalProject]), {
+      cacheDir: join(home, "cache"),
+      getGitStatus: async (cwd) => {
+        gitReads.push(cwd);
+        return gitStatus({ repository: undefined });
+      },
+      getBranch: async (cwd) => (cwd === canonicalWorktree ? "topic" : "main"),
+      spawnDetached: (_command, args) => {
+        checkLaunches.push(args);
+      },
+    });
+
+    await pi.emitSessionStart({ type: "session_start", reason: "startup" });
+    await pi.emitToolResult({
+      type: "tool_result",
+      toolName: "worktree_create",
+      input: { name: "topic" },
+      content: [{ type: "text", text: canonicalWorktree }],
+      isError: false,
+    });
+    await pi.emitAgentSettled();
+    expect(gitReads).toEqual([
+      canonicalProject,
+      canonicalWorktree,
+      canonicalWorktree,
+    ]);
+    expect(checkLaunches).toEqual([
+      [runner, canonicalWorktree, canonicalWorktree],
+    ]);
+
+    // Git still has stale registration metadata, but neither a plain
+    // replacement nor a retargeted symlink may inherit trust.
+    await fs.rm(worktree, { recursive: true, force: true });
+    await fs.mkdir(worktree);
+    await pi.emitAgentSettled();
+    await fs.rm(worktree, { recursive: true, force: true });
+    await fs.mkdir(replacement);
+    await fs.symlink(replacement, worktree, "dir");
+    await pi.emitAgentSettled();
+
+    expect(gitReads).toEqual([
+      canonicalProject,
+      canonicalWorktree,
+      canonicalWorktree,
+    ]);
+    expect(checkLaunches).toEqual([
+      [runner, canonicalWorktree, canonicalWorktree],
+    ]);
+  });
+
   test("session_start installs a dynamic custom footer from cache", async () => {
     const home = await tempDirectory("pi-statusline-render");
     const project = join(home, "repo");
@@ -360,6 +435,84 @@ describe("pi-harness statusline lifecycle", () => {
 
     expect(pi.footerRenderRequests).toBeGreaterThan(requestsBeforeBranchChange);
     expect(pi.renderFooter(100)).toEqual(["plain | topic | Model B | 9%"]);
+  });
+
+  test("follows a created worktree until that active worktree is removed", async () => {
+    const home = await tempDirectory("pi-statusline-worktree");
+    const project = join(home, "repo");
+    const worktree = join(home, "topic-worktree");
+    await fs.mkdir(project, { recursive: true });
+    await fs.mkdir(worktree, { recursive: true });
+    await markAsProject(project);
+    await markAsProject(worktree);
+
+    const gitReads: string[] = [];
+    const checkLaunches: string[][] = [];
+    let worktreeBranch = "topic";
+    let worktreeValid = true;
+    const runner = join(
+      resolvePaths(home).claudeHooksDir,
+      "lib/statusline_checks_run.sh",
+    );
+    await fs.mkdir(dirname(runner), { recursive: true });
+    await fs.writeFile(runner, "#!/bin/bash\nexit 0\n", { mode: 0o755 });
+
+    const pi = createFakePi({ cwd: project, gitBranch: "main" });
+    setupStatusline(pi, makeConfig(home, [project]), {
+      cacheDir: join(home, "cache"),
+      getGitStatus: async (cwd) => {
+        gitReads.push(cwd);
+        return gitStatus({ repository: undefined });
+      },
+      getBranch: async (cwd) => (cwd === worktree ? worktreeBranch : "main"),
+      spawnDetached: (_command, args) => {
+        checkLaunches.push(args);
+      },
+      validateInheritedWorktree: async () => worktreeValid,
+    });
+
+    await pi.emitSessionStart({ type: "session_start", reason: "startup" });
+    await pi.emitToolResult({
+      type: "tool_result",
+      toolName: "worktree_create",
+      input: { name: "topic" },
+      content: [{ type: "text", text: worktree }],
+      isError: false,
+    });
+    expect(pi.renderFooter(100)).toEqual([
+      "topic-worktree | topic | TS L? T? X?",
+    ]);
+
+    // The built-in footer provider remains tied to the session checkout. Its
+    // stale update must not replace the active worktree branch.
+    pi.setGitBranch("stale-main");
+    worktreeBranch = "topic-next";
+    await pi.emitAgentSettled();
+    expect(pi.renderFooter(100)).toEqual([
+      "topic-worktree | topic-next | TS L? T? X?",
+    ]);
+    expect(checkLaunches).toEqual([[runner, worktree, worktree]]);
+
+    // A later identity failure revokes inherited trust before any Git read or
+    // repository-defined check can run, while retaining the last safe branch.
+    worktreeValid = false;
+    worktreeBranch = "replacement-branch";
+    await pi.emitAgentSettled();
+    expect(pi.renderFooter(100)).toEqual([
+      "topic-worktree | topic-next | TS L? T? X?",
+    ]);
+    expect(checkLaunches).toEqual([[runner, worktree, worktree]]);
+    expect(gitReads).toEqual([project, worktree, worktree]);
+
+    await pi.emitToolResult({
+      type: "tool_result",
+      toolName: "worktree_remove",
+      input: { path: worktree, confirmed: true },
+      content: [{ type: "text", text: `Removed worktree: ${worktree}` }],
+      isError: false,
+    });
+    expect(pi.renderFooter(100)).toEqual(["repo | stale-main | TS L? T? X?"]);
+    expect(gitReads).toEqual([project, worktree, worktree, project]);
   });
 
   test("default git collection renders origin and tracked diff totals", async () => {

--- a/tests/pi-harness/statusline.test.ts
+++ b/tests/pi-harness/statusline.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { visibleWidth as piVisibleWidth } from "@earendil-works/pi-tui";
 import { createHash } from "node:crypto";
 import { promises as fs } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join, relative } from "node:path";
 import type { HarnessConfig } from "../../pi/extensions/pi-harness/config";
 import setupStatusline, {
   parseNumstat,
@@ -133,6 +133,21 @@ const runGit = async (cwd: string, args: string[]): Promise<void> => {
     new Response(process.stderr).text(),
   ]);
   if (exitCode !== 0) throw new Error(`git ${args.join(" ")}: ${stderr}`);
+};
+
+const gitText = async (cwd: string, args: string[]): Promise<string> => {
+  const process = Bun.spawn(["git", ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    process.exited,
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+  ]);
+  if (exitCode !== 0) throw new Error(`git ${args.join(" ")}: ${stderr}`);
+  return stdout.trim();
 };
 
 describe("Claude-compatible statusline rendering", () => {
@@ -375,6 +390,173 @@ describe("pi-harness statusline lifecycle", () => {
     await fs.symlink(replacement, worktree, "dir");
     await pi.emitAgentSettled();
 
+    expect(gitReads).toEqual([
+      canonicalProject,
+      canonicalWorktree,
+      canonicalWorktree,
+    ]);
+    expect(checkLaunches).toEqual([
+      [runner, canonicalWorktree, canonicalWorktree],
+    ]);
+  });
+
+  test("rejects a copied foreign linked-worktree identity", async () => {
+    const home = await tempDirectory("pi-statusline-worktree-foreign");
+    const project = join(home, "repo");
+    const worktreeA = join(home, "worktree-a");
+    const worktreeB = join(home, "worktree-b");
+    await fs.mkdir(project, { recursive: true });
+    await markAsProject(project);
+    await runGit(project, ["init", "-b", "main"]);
+    await runGit(project, ["config", "user.email", "test@example.com"]);
+    await runGit(project, ["config", "user.name", "Status Test"]);
+    await runGit(project, ["add", "."]);
+    await runGit(project, ["commit", "-m", "initial"]);
+    await runGit(project, ["worktree", "add", "-b", "topic-a", worktreeA]);
+    await runGit(project, ["worktree", "add", "-b", "topic-b", worktreeB]);
+    const canonicalProject = await fs.realpath(project);
+    const canonicalWorktreeA = await fs.realpath(worktreeA);
+    const canonicalWorktreeB = await fs.realpath(worktreeB);
+    const runner = join(
+      resolvePaths(home).claudeHooksDir,
+      "lib/statusline_checks_run.sh",
+    );
+    await fs.mkdir(dirname(runner), { recursive: true });
+    await fs.writeFile(runner, "#!/bin/bash\nexit 0\n", { mode: 0o755 });
+
+    const gitReads: string[] = [];
+    const checkLaunches: string[][] = [];
+    const pi = createFakePi({ cwd: canonicalProject, gitBranch: "main" });
+    setupStatusline(pi, makeConfig(home, [canonicalProject]), {
+      cacheDir: join(home, "cache"),
+      getGitStatus: async (cwd) => {
+        gitReads.push(cwd);
+        return gitStatus({ repository: undefined });
+      },
+      getBranch: async (cwd) =>
+        cwd === canonicalWorktreeA ? "topic-a" : "main",
+      spawnDetached: (_command, args) => {
+        checkLaunches.push(args);
+      },
+    });
+
+    await pi.emitSessionStart({ type: "session_start", reason: "startup" });
+    await pi.emitToolResult({
+      type: "tool_result",
+      toolName: "worktree_create",
+      input: { name: "topic-a" },
+      content: [{ type: "text", text: canonicalWorktreeA }],
+      isError: false,
+    });
+    await pi.emitAgentSettled();
+    expect(checkLaunches).toHaveLength(1);
+
+    const foreignGitDir = await gitText(canonicalWorktreeB, [
+      "rev-parse",
+      "--absolute-git-dir",
+    ]);
+    await fs.rm(worktreeA, { recursive: true, force: true });
+    await fs.mkdir(worktreeA);
+    await fs.copyFile(
+      join(canonicalWorktreeB, ".git"),
+      join(canonicalWorktreeA, ".git"),
+    );
+
+    // Every pre-existing check still passes: the copied identity reports A as
+    // its top-level, uses the same common dir, points inside common/worktrees,
+    // and stale registration still lists A. Only B's backlink exposes the
+    // mismatch between the registered path and the detected admin identity.
+    const [sourceCommon, replacedCommon, replacedTop, replacedGitDir, list] =
+      await Promise.all([
+        gitText(canonicalProject, [
+          "rev-parse",
+          "--path-format=absolute",
+          "--git-common-dir",
+        ]),
+        gitText(canonicalWorktreeA, [
+          "rev-parse",
+          "--path-format=absolute",
+          "--git-common-dir",
+        ]),
+        gitText(canonicalWorktreeA, [
+          "rev-parse",
+          "--path-format=absolute",
+          "--show-toplevel",
+        ]),
+        gitText(canonicalWorktreeA, ["rev-parse", "--absolute-git-dir"]),
+        gitText(canonicalProject, ["worktree", "list", "--porcelain"]),
+      ]);
+    expect(await fs.realpath(replacedCommon)).toBe(
+      await fs.realpath(sourceCommon),
+    );
+    expect(await fs.realpath(replacedTop)).toBe(canonicalWorktreeA);
+    expect(await fs.realpath(replacedGitDir)).toBe(foreignGitDir);
+    expect(list).toContain(`worktree ${canonicalWorktreeA}`);
+    expect(list).toContain(`worktree ${canonicalWorktreeB}`);
+
+    await pi.emitAgentSettled();
+    expect(gitReads).toEqual([
+      canonicalProject,
+      canonicalWorktreeA,
+      canonicalWorktreeA,
+    ]);
+    expect(checkLaunches).toHaveLength(1);
+  });
+
+  test("accepts a valid relative admin gitdir backlink", async () => {
+    const home = await tempDirectory("pi-statusline-worktree-relative");
+    const project = join(home, "repo");
+    const worktree = join(home, "topic-worktree");
+    await fs.mkdir(project, { recursive: true });
+    await markAsProject(project);
+    await runGit(project, ["init", "-b", "main"]);
+    await runGit(project, ["config", "user.email", "test@example.com"]);
+    await runGit(project, ["config", "user.name", "Status Test"]);
+    await runGit(project, ["add", "."]);
+    await runGit(project, ["commit", "-m", "initial"]);
+    await runGit(project, ["worktree", "add", "-b", "topic", worktree]);
+    const canonicalProject = await fs.realpath(project);
+    const canonicalWorktree = await fs.realpath(worktree);
+    const gitDir = await gitText(canonicalWorktree, [
+      "rev-parse",
+      "--absolute-git-dir",
+    ]);
+    const backlinkFile = join(gitDir, "gitdir");
+    const relativeBacklink = relative(gitDir, join(canonicalWorktree, ".git"));
+    expect(isAbsolute(relativeBacklink)).toBe(false);
+    await fs.writeFile(backlinkFile, `${relativeBacklink}\n`);
+    const backlinkContents = await fs.readFile(backlinkFile, "utf8");
+    expect(backlinkContents.trim()).toBe(relativeBacklink);
+
+    const gitReads: string[] = [];
+    const checkLaunches: string[][] = [];
+    const runner = join(
+      resolvePaths(home).claudeHooksDir,
+      "lib/statusline_checks_run.sh",
+    );
+    await fs.mkdir(dirname(runner), { recursive: true });
+    await fs.writeFile(runner, "#!/bin/bash\nexit 0\n", { mode: 0o755 });
+    const pi = createFakePi({ cwd: canonicalProject, gitBranch: "main" });
+    setupStatusline(pi, makeConfig(home, [canonicalProject]), {
+      getGitStatus: async (cwd) => {
+        gitReads.push(cwd);
+        return gitStatus({ repository: undefined });
+      },
+      getBranch: async (cwd) => (cwd === canonicalWorktree ? "topic" : "main"),
+      spawnDetached: (_command, args) => {
+        checkLaunches.push(args);
+      },
+    });
+
+    await pi.emitSessionStart({ type: "session_start", reason: "startup" });
+    await pi.emitToolResult({
+      type: "tool_result",
+      toolName: "worktree_create",
+      input: { name: "topic" },
+      content: [{ type: "text", text: canonicalWorktree }],
+      isError: false,
+    });
+    await pi.emitAgentSettled();
     expect(gitReads).toEqual([
       canonicalProject,
       canonicalWorktree,

--- a/tests/pi-harness/statusline.test.ts
+++ b/tests/pi-harness/statusline.test.ts
@@ -21,6 +21,7 @@ import {
 import type { DetachedSpawnFunction } from "../../pi/extensions/pi-harness/lib/detached";
 import { resolvePaths } from "../../pi/extensions/pi-harness/lib/paths";
 import type { ThemeLike } from "../../pi/extensions/pi-harness/lib/pi-like";
+import { worktreeIdentityDetails } from "../../pi/extensions/pi-harness/lib/worktree-identity";
 import { cleanupTestDirectory, setupTestDirectory } from "../test-helpers";
 import { createFakePi } from "./fake-pi";
 
@@ -148,6 +149,27 @@ const gitText = async (cwd: string, args: string[]): Promise<string> => {
   ]);
   if (exitCode !== 0) throw new Error(`git ${args.join(" ")}: ${stderr}`);
   return stdout.trim();
+};
+
+const createdWorktreeDetails = async (path: string) => {
+  const [rootStats, dotGitStats, gitDir] = await Promise.all([
+    fs.lstat(path, { bigint: true }),
+    fs.lstat(join(path, ".git"), { bigint: true }),
+    gitText(path, ["rev-parse", "--absolute-git-dir"]),
+  ]);
+  return worktreeIdentityDetails({
+    version: 1,
+    path,
+    root: {
+      dev: rootStats.dev.toString(10),
+      ino: rootStats.ino.toString(10),
+    },
+    dotGit: {
+      dev: dotGitStats.dev.toString(10),
+      ino: dotGitStats.ino.toString(10),
+    },
+    gitDir: await fs.realpath(gitDir),
+  });
 };
 
 describe("Claude-compatible statusline rendering", () => {
@@ -363,11 +385,13 @@ describe("pi-harness statusline lifecycle", () => {
     });
 
     await pi.emitSessionStart({ type: "session_start", reason: "startup" });
+    const details = await createdWorktreeDetails(canonicalWorktree);
     await pi.emitToolResult({
       type: "tool_result",
       toolName: "worktree_create",
       input: { name: "topic" },
       content: [{ type: "text", text: canonicalWorktree }],
+      details,
       isError: false,
     });
     await pi.emitAgentSettled();
@@ -377,7 +401,13 @@ describe("pi-harness statusline lifecycle", () => {
       canonicalWorktree,
     ]);
     expect(checkLaunches).toEqual([
-      [runner, canonicalWorktree, canonicalWorktree],
+      [
+        runner,
+        canonicalWorktree,
+        canonicalWorktree,
+        details.worktreeIdentity.root.dev,
+        details.worktreeIdentity.root.ino,
+      ],
     ]);
 
     // Git still has stale registration metadata, but neither a plain
@@ -396,7 +426,13 @@ describe("pi-harness statusline lifecycle", () => {
       canonicalWorktree,
     ]);
     expect(checkLaunches).toEqual([
-      [runner, canonicalWorktree, canonicalWorktree],
+      [
+        runner,
+        canonicalWorktree,
+        canonicalWorktree,
+        details.worktreeIdentity.root.dev,
+        details.worktreeIdentity.root.ino,
+      ],
     ]);
   });
 
@@ -446,6 +482,7 @@ describe("pi-harness statusline lifecycle", () => {
       toolName: "worktree_create",
       input: { name: "topic-a" },
       content: [{ type: "text", text: canonicalWorktreeA }],
+      details: await createdWorktreeDetails(canonicalWorktreeA),
       isError: false,
     });
     await pi.emitAgentSettled();
@@ -503,6 +540,183 @@ describe("pi-harness statusline lifecycle", () => {
     expect(checkLaunches).toHaveLength(1);
   });
 
+  test("rejects recreation at the same path with the original .git contents", async () => {
+    const home = await tempDirectory("pi-statusline-worktree-recreated");
+    const project = join(home, "repo");
+    const worktree = join(home, "topic-worktree");
+    await fs.mkdir(project, { recursive: true });
+    await markAsProject(project);
+    await runGit(project, ["init", "-b", "main"]);
+    await runGit(project, ["config", "user.email", "test@example.com"]);
+    await runGit(project, ["config", "user.name", "Status Test"]);
+    await runGit(project, ["add", "."]);
+    await runGit(project, ["commit", "-m", "initial"]);
+    await runGit(project, ["worktree", "add", "-b", "topic", worktree]);
+    const canonicalProject = await fs.realpath(project);
+    const canonicalWorktree = await fs.realpath(worktree);
+    const originalDotGit = await fs.readFile(join(worktree, ".git"));
+    const originalGitDir = await gitText(canonicalWorktree, [
+      "rev-parse",
+      "--absolute-git-dir",
+    ]);
+    const runner = join(
+      resolvePaths(home).claudeHooksDir,
+      "lib/statusline_checks_run.sh",
+    );
+    await fs.mkdir(dirname(runner), { recursive: true });
+    await fs.writeFile(runner, "#!/bin/bash\nexit 0\n", { mode: 0o755 });
+
+    const gitReads: string[] = [];
+    const checkLaunches: string[][] = [];
+    const pi = createFakePi({ cwd: canonicalProject, gitBranch: "main" });
+    setupStatusline(pi, makeConfig(home, [canonicalProject]), {
+      cacheDir: join(home, "cache"),
+      getGitStatus: async (cwd) => {
+        gitReads.push(cwd);
+        return gitStatus({ repository: undefined });
+      },
+      getBranch: async (cwd) => (cwd === canonicalWorktree ? "topic" : "main"),
+      spawnDetached: (_command, args) => {
+        checkLaunches.push(args);
+      },
+    });
+
+    await pi.emitSessionStart({ type: "session_start", reason: "startup" });
+    await pi.emitToolResult({
+      type: "tool_result",
+      toolName: "worktree_create",
+      input: { name: "topic" },
+      content: [{ type: "text", text: canonicalWorktree }],
+      details: await createdWorktreeDetails(canonicalWorktree),
+      isError: false,
+    });
+    await pi.emitAgentSettled();
+    expect(checkLaunches).toHaveLength(1);
+
+    await fs.rm(worktree, { recursive: true, force: true });
+    await fs.mkdir(worktree);
+    await markAsProject(worktree);
+    await fs.writeFile(join(worktree, ".git"), originalDotGit);
+
+    // Restoring the original .git contents satisfies every live Git/backlink
+    // check. The creation-time root and .git inodes are what distinguish this
+    // attacker-controlled replacement from the worktree produced by the tool.
+    const [replacementTop, replacementGitDir, list, backlink] =
+      await Promise.all([
+        gitText(canonicalWorktree, [
+          "rev-parse",
+          "--path-format=absolute",
+          "--show-toplevel",
+        ]),
+        gitText(canonicalWorktree, ["rev-parse", "--absolute-git-dir"]),
+        gitText(canonicalProject, ["worktree", "list", "--porcelain"]),
+        fs.readFile(join(originalGitDir, "gitdir"), "utf8"),
+      ]);
+    expect(await fs.realpath(replacementTop)).toBe(canonicalWorktree);
+    expect(await fs.realpath(replacementGitDir)).toBe(originalGitDir);
+    expect(list).toContain(`worktree ${canonicalWorktree}`);
+    expect(await fs.realpath(backlink.trim())).toBe(
+      join(canonicalWorktree, ".git"),
+    );
+
+    await pi.emitAgentSettled();
+    expect(gitReads).toEqual([
+      canonicalProject,
+      canonicalWorktree,
+      canonicalWorktree,
+    ]);
+    expect(checkLaunches).toHaveLength(1);
+  });
+
+  test("rechecks identity after concurrent Git and backlink validation", async () => {
+    const home = await tempDirectory("pi-statusline-worktree-validation-race");
+    const project = join(home, "repo");
+    const worktree = join(home, "topic-worktree");
+    await fs.mkdir(project, { recursive: true });
+    await markAsProject(project);
+    await runGit(project, ["init", "-b", "main"]);
+    await runGit(project, ["config", "user.email", "test@example.com"]);
+    await runGit(project, ["config", "user.name", "Status Test"]);
+    await runGit(project, ["add", "."]);
+    await runGit(project, ["commit", "-m", "initial"]);
+    await runGit(project, ["worktree", "add", "-b", "topic", worktree]);
+    const canonicalProject = await fs.realpath(project);
+    const canonicalWorktree = await fs.realpath(worktree);
+    const originalDotGit = await fs.readFile(join(worktree, ".git"));
+    const details = await createdWorktreeDetails(canonicalWorktree);
+    const runner = join(
+      resolvePaths(home).claudeHooksDir,
+      "lib/statusline_checks_run.sh",
+    );
+    await fs.mkdir(dirname(runner), { recursive: true });
+    await fs.writeFile(runner, "#!/bin/bash\nexit 0\n", { mode: 0o755 });
+
+    let raceEnabled = false;
+    let arrivals = 0;
+    let releaseBarrier: (() => void) | undefined;
+    const barrier = new Promise<void>((resolve) => {
+      releaseBarrier = resolve;
+    });
+    const readGit = async (
+      cwd: string,
+      args: string[],
+    ): Promise<string | undefined> => {
+      if (raceEnabled) {
+        arrivals += 1;
+        if (arrivals === 5) {
+          await fs.rm(worktree, { recursive: true, force: true });
+          await fs.mkdir(worktree);
+          await markAsProject(worktree);
+          await fs.writeFile(join(worktree, ".git"), originalDotGit);
+          releaseBarrier?.();
+        }
+        await barrier;
+      }
+      try {
+        return await gitText(cwd, args);
+      } catch {
+        return undefined;
+      }
+    };
+
+    const gitReads: string[] = [];
+    const checkLaunches: string[][] = [];
+    const pi = createFakePi({ cwd: canonicalProject, gitBranch: "main" });
+    setupStatusline(pi, makeConfig(home, [canonicalProject]), {
+      gitOutput: readGit,
+      getGitStatus: async (cwd) => {
+        gitReads.push(cwd);
+        return gitStatus({ repository: undefined });
+      },
+      getBranch: async (cwd) => (cwd === canonicalWorktree ? "topic" : "main"),
+      spawnDetached: (_command, args) => {
+        checkLaunches.push(args);
+      },
+    });
+
+    await pi.emitSessionStart({ type: "session_start", reason: "startup" });
+    await pi.emitToolResult({
+      type: "tool_result",
+      toolName: "worktree_create",
+      input: { name: "topic" },
+      content: [{ type: "text", text: canonicalWorktree }],
+      details,
+      isError: false,
+    });
+    await pi.emitAgentSettled();
+    expect(checkLaunches).toHaveLength(1);
+
+    raceEnabled = true;
+    await pi.emitAgentSettled();
+    expect(arrivals).toBe(5);
+    expect(gitReads).toEqual([
+      canonicalProject,
+      canonicalWorktree,
+      canonicalWorktree,
+    ]);
+    expect(checkLaunches).toHaveLength(1);
+  });
+
   test("accepts a valid relative admin gitdir backlink", async () => {
     const home = await tempDirectory("pi-statusline-worktree-relative");
     const project = join(home, "repo");
@@ -549,11 +763,13 @@ describe("pi-harness statusline lifecycle", () => {
     });
 
     await pi.emitSessionStart({ type: "session_start", reason: "startup" });
+    const details = await createdWorktreeDetails(canonicalWorktree);
     await pi.emitToolResult({
       type: "tool_result",
       toolName: "worktree_create",
       input: { name: "topic" },
       content: [{ type: "text", text: canonicalWorktree }],
+      details,
       isError: false,
     });
     await pi.emitAgentSettled();
@@ -563,7 +779,13 @@ describe("pi-harness statusline lifecycle", () => {
       canonicalWorktree,
     ]);
     expect(checkLaunches).toEqual([
-      [runner, canonicalWorktree, canonicalWorktree],
+      [
+        runner,
+        canonicalWorktree,
+        canonicalWorktree,
+        details.worktreeIdentity.root.dev,
+        details.worktreeIdentity.root.ino,
+      ],
     ]);
   });
 
@@ -659,6 +881,13 @@ describe("pi-harness statusline lifecycle", () => {
       toolName: "worktree_create",
       input: { name: "topic" },
       content: [{ type: "text", text: worktree }],
+      details: worktreeIdentityDetails({
+        version: 1,
+        path: worktree,
+        root: { dev: "1", ino: "1" },
+        dotGit: { dev: "1", ino: "2" },
+        gitDir: join(worktree, ".git", "worktrees", "topic"),
+      }),
       isError: false,
     });
     expect(pi.renderFooter(100)).toEqual([
@@ -673,7 +902,7 @@ describe("pi-harness statusline lifecycle", () => {
     expect(pi.renderFooter(100)).toEqual([
       "topic-worktree | topic-next | TS L? T? X?",
     ]);
-    expect(checkLaunches).toEqual([[runner, worktree, worktree]]);
+    expect(checkLaunches).toEqual([[runner, worktree, worktree, "1", "1"]]);
 
     // A later identity failure revokes inherited trust before any Git read or
     // repository-defined check can run, while retaining the last safe branch.
@@ -683,7 +912,7 @@ describe("pi-harness statusline lifecycle", () => {
     expect(pi.renderFooter(100)).toEqual([
       "topic-worktree | topic-next | TS L? T? X?",
     ]);
-    expect(checkLaunches).toEqual([[runner, worktree, worktree]]);
+    expect(checkLaunches).toEqual([[runner, worktree, worktree, "1", "1"]]);
     expect(gitReads).toEqual([project, worktree, worktree]);
 
     await pi.emitToolResult({
@@ -695,6 +924,58 @@ describe("pi-harness statusline lifecycle", () => {
     });
     expect(pi.renderFooter(100)).toEqual(["repo | stale-main | TS L? T? X?"]);
     expect(gitReads).toEqual([project, worktree, worktree, project]);
+  });
+
+  test("missing creation details follow display state without inheriting trust", async () => {
+    const home = await tempDirectory("pi-statusline-worktree-capture-fail");
+    const project = join(home, "repo");
+    const worktree = join(home, "topic-worktree");
+    await fs.mkdir(project, { recursive: true });
+    await fs.mkdir(worktree, { recursive: true });
+    await markAsProject(project);
+    await markAsProject(worktree);
+    const runner = join(
+      resolvePaths(home).claudeHooksDir,
+      "lib/statusline_checks_run.sh",
+    );
+    await fs.mkdir(dirname(runner), { recursive: true });
+    await fs.writeFile(runner, "#!/bin/bash\nexit 0\n", { mode: 0o755 });
+
+    const gitReads: string[] = [];
+    const checkLaunches: string[][] = [];
+    let validatorCalls = 0;
+    const pi = createFakePi({ cwd: project, gitBranch: "main" });
+    setupStatusline(pi, makeConfig(home, [project]), {
+      getGitStatus: async (cwd) => {
+        gitReads.push(cwd);
+        return gitStatus({ repository: undefined });
+      },
+      getBranch: async () => "main",
+      spawnDetached: (_command, args) => {
+        checkLaunches.push(args);
+      },
+      validateInheritedWorktree: async () => {
+        validatorCalls += 1;
+        return true;
+      },
+    });
+
+    await pi.emitSessionStart({ type: "session_start", reason: "startup" });
+    await pi.emitToolResult({
+      type: "tool_result",
+      toolName: "worktree_create",
+      input: { name: "topic" },
+      content: [{ type: "text", text: worktree }],
+      isError: false,
+    });
+    await pi.emitAgentSettled();
+
+    expect(pi.renderFooter(100)).toEqual([
+      "topic-worktree | topic | TS L? T? X?",
+    ]);
+    expect(validatorCalls).toBe(0);
+    expect(gitReads).toEqual([project]);
+    expect(checkLaunches).toEqual([]);
   });
 
   test("default git collection renders origin and tracked diff totals", async () => {


### PR DESCRIPTION
## Summary

- follow a managed worktree immediately after creation and restore the session checkout after removal
- refresh branch, diff, and status-check state from the active linked worktree
- fail closed if the inherited worktree identity is deleted, replaced, or symlink-retargeted

## Testing

- `bun test` (1105 passed, 2 skipped)
- `bun run tsc`
- `bun run lint` (0 errors)
- Prettier check