### PR TITLE
feat(pi): add isolated BTW side questions

### DIFF
--- a/pi/README.md
+++ b/pi/README.md
@@ -153,6 +153,38 @@ Known gaps vs Claude Code: no Claude server-side auto mode (the local Ollama
 judge plus deterministic rules approximates it), no LSP plugins, provider-log
 is a request/status logger (not full logproxy).
 
+## BTW side questions
+
+`/btw <question>` answers a side question from a stable snapshot of the active
+parent-session leaf without adding the question or answer to the parent model's
+context. With no inline argument, TUI/RPC UI modes open a short input dialog.
+The command requires one of those UI-capable modes; RPC answers are also sent
+through the UI notification channel. Print/JSON mode reports an unsupported-mode
+error instead of producing an invisible answer.
+
+Each invocation creates an in-memory child, copies the parent's resolved
+(compaction-aware) messages, current model/thinking level, and system prompt,
+and disposes the child immediately after the answer. The child loads no
+extensions, skills, prompt templates, themes, or newly discovered context
+files or append-system prompts. It uses isolated in-memory settings, so
+configured packages cannot auto-install, and forces image blocks out of model
+context. Its exact tool allowlist is pi's built-in `read` and `ls`, with the
+same filesystem read scope as the parent session (this is a read-only boundary,
+not a filesystem sandbox). The `grep`/`find` wrappers are deliberately omitted
+because they can auto-install missing `rg`/`fd` binaries. `bash`, `edit`, and
+`write` are explicitly denied and the active set is checked before the model
+runs.
+
+Successful Q/A records are appended as custom entries in the parent session.
+They remain visible after resuming that parent (hidden records are replayed
+after parent compaction) but are never sent to its LLM, and no independently
+resumable child session or child file is created. Stored and rendered fields are
+terminal-control sanitized. Deleting the parent session therefore deletes BTW
+history with it. BTW is not registered inside `PI_HARNESS_CHILD=1` child
+profiles, and one parent session runs at most one BTW invocation at a time.
+Cancel a slow BTW request with `/btw-cancel` or `Ctrl+Alt+B`; parent session
+shutdown also aborts and disposes the child.
+
 ## AskUserQuestion compatibility
 
 The parent pi session registers an exact-name `AskUserQuestion` tool so shared

--- a/pi/extensions/pi-harness/features/btw/index.ts
+++ b/pi/extensions/pi-harness/features/btw/index.ts
@@ -1,0 +1,560 @@
+import { randomUUID } from "node:crypto";
+import type {
+  AgentMessage,
+  ThinkingLevel,
+} from "@earendil-works/pi-agent-core";
+import {
+  buildSessionContext,
+  createAgentSession,
+  DefaultResourceLoader,
+  getAgentDir,
+  type CreateAgentSessionOptions,
+  type ExtensionAPI,
+  type ExtensionCommandContext,
+  type ExtensionContext,
+  type ModelRegistry,
+  type ResourceLoader,
+  SessionManager,
+  SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+import type { PiLike } from "../../lib/pi-like";
+import { stripTerminalControls } from "../../lib/terminal-text";
+
+const HISTORY_TYPE = "pi-harness:btw";
+const STATUS_KEY = "pi-harness-btw";
+const QUESTION_MAX_BYTES = 16 * 1024;
+const ANSWER_MAX_BYTES = 64 * 1024;
+const TRUNCATION_MARKER = "\n\n[BTW answer truncated in parent history.]";
+
+// pi's grep/find wrappers auto-install missing rg/fd binaries. Keep the BTW
+// capability set to built-ins that never perform package or binary installs.
+const BTW_READ_ONLY_TOOLS = ["read", "ls"] as const;
+const BTW_DENIED_TOOLS = ["bash", "edit", "write"] as const;
+
+const BTW_SYSTEM_SUFFIX = `You are answering one side question in a temporary fork of another pi session.
+Treat the copied conversation as read-only background context. Answer only the side question; do not continue the parent task.
+You may inspect the current workspace only through the available read-only tools. Never attempt to mutate files, execute shell commands, or cause other side effects.`;
+
+class BtwCancellationSignal {
+  aborted = false;
+  private readonly listeners = new Set<() => void>();
+
+  onAbort(listener: () => void): () => void {
+    if (this.aborted) listener();
+    else this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  abort(): void {
+    if (this.aborted) return;
+    this.aborted = true;
+    for (const listener of this.listeners) listener();
+    this.listeners.clear();
+  }
+}
+
+class BtwCancellationController {
+  readonly signal = new BtwCancellationSignal();
+
+  abort(): void {
+    this.signal.abort();
+  }
+}
+
+interface BtwHistoryData {
+  version: 1;
+  id: string;
+  question: string;
+  answer: string;
+  answerTruncated: boolean;
+  model: string;
+  createdAt: number;
+}
+
+interface BtwSnapshot {
+  cwd: string;
+  parentSession?: string;
+  systemPrompt: string;
+  messages: AgentMessage[];
+  model: NonNullable<ExtensionCommandContext["model"]>;
+  modelRegistry: ModelRegistry;
+  thinkingLevel: ThinkingLevel;
+  signal?: BtwCancellationSignal;
+}
+
+interface ChildSessionEvent {
+  type: string;
+  message?: AgentMessage;
+}
+
+interface ChildSessionLike {
+  agent: {
+    state: {
+      messages: AgentMessage[];
+    };
+  };
+  prompt(
+    text: string,
+    options?: {
+      expandPromptTemplates?: boolean;
+      source?: "interactive" | "rpc" | "extension";
+    },
+  ): Promise<void>;
+  getActiveToolNames(): string[];
+  subscribe(listener: (event: ChildSessionEvent) => void): () => void;
+  abort(): Promise<void>;
+  dispose(): void;
+}
+
+interface BtwForkDependencies {
+  getAgentDir(): string;
+  createResourceLoader(
+    options: ConstructorParameters<typeof DefaultResourceLoader>[0],
+  ): ResourceLoader;
+  createSessionManager(
+    cwd: string,
+    options?: { parentSession?: string },
+  ): SessionManager;
+  createSettingsManager(): SettingsManager;
+  createSession(options: CreateAgentSessionOptions): Promise<ChildSessionLike>;
+}
+
+const defaultForkDependencies: BtwForkDependencies = {
+  getAgentDir,
+  createResourceLoader: (options) => new DefaultResourceLoader(options),
+  createSessionManager: (cwd, options) => SessionManager.inMemory(cwd, options),
+  createSettingsManager: () =>
+    SettingsManager.inMemory({ images: { blockImages: true } }),
+  createSession: async (options) => {
+    const result = await createAgentSession(options);
+    return result.session;
+  },
+};
+
+const byteLength = (value: string): number => Buffer.byteLength(value, "utf8");
+
+const truncateUtf8 = (
+  value: string,
+  maxBytes: number,
+): { text: string; truncated: boolean } => {
+  if (byteLength(value) <= maxBytes) {
+    return { text: value, truncated: false };
+  }
+
+  const contentLimit = Math.max(0, maxBytes - byteLength(TRUNCATION_MARKER));
+  let low = 0;
+  let high = value.length;
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    if (byteLength(value.slice(0, middle)) <= contentLimit) low = middle;
+    else high = middle - 1;
+  }
+
+  let end = low;
+  const last = value.charCodeAt(end - 1);
+  if (last >= 0xd800 && last <= 0xdbff) end -= 1;
+  return {
+    text: `${value.slice(0, Math.max(0, end))}${TRUNCATION_MARKER}`,
+    truncated: true,
+  };
+};
+
+const assertQuestion = (question: string): void => {
+  if (question === "") throw new Error("BTW question is empty");
+  if (byteLength(question) > QUESTION_MAX_BYTES) {
+    throw new Error(`BTW question exceeds ${QUESTION_MAX_BYTES} bytes`);
+  }
+};
+
+const seedSessionManager = (
+  sessionManager: SessionManager,
+  messages: AgentMessage[],
+): void => {
+  for (const source of messages) {
+    const message = structuredClone(source);
+    if (message.role === "compactionSummary") {
+      sessionManager.appendCustomMessageEntry(
+        "pi-harness:btw-compaction",
+        `Compaction summary from the parent session:\n\n${message.summary}`,
+        false,
+      );
+    } else if (message.role === "branchSummary") {
+      sessionManager.appendCustomMessageEntry(
+        "pi-harness:btw-branch-summary",
+        `Branch summary from the parent session:\n\n${message.summary}`,
+        false,
+      );
+    } else {
+      sessionManager.appendMessage(message);
+    }
+  }
+};
+
+const assertReadOnlyTools = (activeTools: string[]): void => {
+  const allowed = new Set<string>(BTW_READ_ONLY_TOOLS);
+  if (
+    activeTools.length !== allowed.size ||
+    activeTools.some((tool) => !allowed.has(tool))
+  ) {
+    throw new Error(
+      `BTW child tool isolation failed: active tools are ${activeTools.join(", ") || "(none)"}`,
+    );
+  }
+};
+
+const answerFromReadOnlyFork = async (
+  snapshot: BtwSnapshot,
+  question: string,
+  dependencies: BtwForkDependencies = defaultForkDependencies,
+): Promise<string> => {
+  assertQuestion(question);
+  const agentDir = dependencies.getAgentDir();
+  // One in-memory settings instance is shared by the loader and child. This
+  // leaves configured npm/git packages undiscovered (and therefore unable to
+  // auto-install) and forces copied/read images out of provider context.
+  const settingsManager = dependencies.createSettingsManager();
+  const resourceLoader = dependencies.createResourceLoader({
+    cwd: snapshot.cwd,
+    agentDir,
+    settingsManager,
+    noExtensions: true,
+    noSkills: true,
+    noPromptTemplates: true,
+    noThemes: true,
+    noContextFiles: true,
+    systemPrompt: `${snapshot.systemPrompt.trimEnd()}\n\n${BTW_SYSTEM_SUFFIX}`,
+    appendSystemPrompt: [],
+  });
+  await resourceLoader.reload();
+
+  const sessionManager = dependencies.createSessionManager(
+    snapshot.cwd,
+    snapshot.parentSession === undefined
+      ? undefined
+      : { parentSession: snapshot.parentSession },
+  );
+  seedSessionManager(sessionManager, snapshot.messages);
+  const session = await dependencies.createSession({
+    cwd: snapshot.cwd,
+    agentDir,
+    model: snapshot.model,
+    modelRegistry: snapshot.modelRegistry,
+    thinkingLevel: snapshot.thinkingLevel,
+    tools: [...BTW_READ_ONLY_TOOLS],
+    excludeTools: [...BTW_DENIED_TOOLS],
+    resourceLoader,
+    sessionManager,
+    settingsManager,
+  });
+
+  let latestAssistant: Extract<AgentMessage, { role: "assistant" }> | undefined;
+  const unsubscribeSession = session.subscribe((event) => {
+    if (event.type === "message_end" && event.message?.role === "assistant") {
+      latestAssistant = event.message;
+    }
+  });
+  let abortPromise: Promise<void> | undefined;
+  const abortChild = (): void => {
+    abortPromise ??= session.abort();
+  };
+  const unsubscribeAbort = snapshot.signal?.onAbort(abortChild);
+  const parentClosed = (): boolean => snapshot.signal?.aborted ?? false;
+
+  try {
+    if (parentClosed()) {
+      abortChild();
+      throw new Error("BTW cancelled because the parent session closed");
+    }
+    assertReadOnlyTools(session.getActiveToolNames());
+    await session.prompt(question, {
+      expandPromptTemplates: false,
+      source: "extension",
+    });
+    if (parentClosed()) {
+      throw new Error("BTW cancelled because the parent session closed");
+    }
+    if (latestAssistant?.stopReason !== "stop") {
+      throw new Error(
+        `BTW child did not complete successfully (${latestAssistant?.stopReason ?? "no response"})`,
+      );
+    }
+    const answer = latestAssistant.content
+      .filter(
+        (block): block is { type: "text"; text: string } =>
+          block.type === "text",
+      )
+      .map((block) => block.text)
+      .join("\n")
+      .trim();
+    if (answer === "") throw new Error("BTW child returned no text answer");
+    return answer;
+  } finally {
+    unsubscribeSession();
+    unsubscribeAbort?.();
+    try {
+      await abortPromise;
+    } finally {
+      session.dispose();
+    }
+  }
+};
+
+const isHistoryData = (value: unknown): value is BtwHistoryData => {
+  if (value === null || typeof value !== "object") return false;
+  const data = value as Partial<BtwHistoryData>;
+  return (
+    data.version === 1 &&
+    typeof data.id === "string" &&
+    typeof data.question === "string" &&
+    typeof data.answer === "string" &&
+    typeof data.answerTruncated === "boolean" &&
+    typeof data.model === "string" &&
+    typeof data.createdAt === "number" &&
+    Number.isFinite(data.createdAt)
+  );
+};
+
+const errorText = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+interface BtwFeatureDependencies {
+  answerQuestion?: typeof answerFromReadOnlyFork;
+  now?: () => number;
+  createId?: () => string;
+}
+
+interface NativeAbortControllerLike {
+  readonly signal: AbortSignal;
+  abort(): void;
+}
+
+const createNativeAbortController = (): NativeAbortControllerLike =>
+  new AbortController() as unknown as NativeAbortControllerLike;
+
+const readQuestion = async (
+  args: string,
+  ctx: ExtensionCommandContext,
+  cancellation: BtwCancellationSignal,
+): Promise<string | undefined> => {
+  const inline = args.trim();
+  if (inline !== "") return inline;
+  if (!ctx.hasUI) {
+    throw new Error("Usage: /btw <question> (interactive input unavailable)");
+  }
+  const controller = createNativeAbortController();
+  const unsubscribe = cancellation.onAbort(() => controller.abort());
+  try {
+    const question = await ctx.ui.input(
+      "BTW question",
+      "Ask without changing parent context",
+      { signal: controller.signal },
+    );
+    return question?.trim();
+  } finally {
+    unsubscribe();
+  }
+};
+
+const setupBtw = (
+  pi: PiLike,
+  dependencies: BtwFeatureDependencies = {},
+): void => {
+  const answerQuestion = dependencies.answerQuestion ?? answerFromReadOnlyFork;
+  const now = dependencies.now ?? Date.now;
+  const createId = dependencies.createId ?? randomUUID;
+  const runtime = pi as unknown as ExtensionAPI;
+  let running = false;
+  let activeAbort: BtwCancellationController | undefined;
+  let sessionGeneration = 0;
+
+  pi.on("session_start", () => {
+    sessionGeneration += 1;
+  });
+  pi.on("session_shutdown", () => {
+    sessionGeneration += 1;
+    activeAbort?.abort();
+  });
+  runtime.on("session_compact", (_event, ctx) => {
+    const visibleIds = new Set<string>();
+    for (const entry of ctx.sessionManager.buildContextEntries()) {
+      if (
+        entry.type === "custom" &&
+        entry.customType === HISTORY_TYPE &&
+        isHistoryData(entry.data)
+      ) {
+        visibleIds.add(entry.data.id);
+      }
+    }
+
+    const histories = new Map<string, BtwHistoryData>();
+    for (const entry of ctx.sessionManager.getBranch()) {
+      if (
+        entry.type === "custom" &&
+        entry.customType === HISTORY_TYPE &&
+        isHistoryData(entry.data)
+      ) {
+        histories.set(entry.data.id, entry.data);
+      }
+    }
+    for (const [id, data] of histories) {
+      if (!visibleIds.has(id)) {
+        pi.appendEntry<BtwHistoryData>(HISTORY_TYPE, data);
+      }
+    }
+  });
+
+  const cancelActive = (ctx: ExtensionContext): void => {
+    if (activeAbort === undefined) {
+      if (ctx.hasUI) ctx.ui.notify("No BTW question is running", "warning");
+      return;
+    }
+    activeAbort.abort();
+    if (ctx.hasUI) ctx.ui.notify("BTW cancellation requested", "info");
+  };
+  pi.registerCommand("btw-cancel", {
+    description: "Cancel the active BTW side question",
+    handler: async (_args, ctx) => cancelActive(ctx),
+  });
+  pi.registerShortcut("ctrl+alt+b", {
+    description: "Cancel the active BTW side question",
+    handler: cancelActive,
+  });
+
+  pi.registerEntryRenderer<BtwHistoryData>(
+    HISTORY_TYPE,
+    (entry, { expanded }, theme) => {
+      if (!isHistoryData(entry.data)) {
+        return new Text(
+          theme.fg("warning", "BTW history entry is malformed"),
+          1,
+          0,
+        );
+      }
+      const { data } = entry;
+      const question = stripTerminalControls(data.question);
+      const answer = stripTerminalControls(data.answer);
+      const model = stripTerminalControls(data.model);
+      let text = `${theme.fg("accent", theme.bold("BTW"))}\n`;
+      text += `${theme.fg("muted", "Q:")} ${question}\n\n${answer}`;
+      if (expanded) {
+        text += `\n\n${theme.fg(
+          "dim",
+          `${model} · ${new Date(data.createdAt).toLocaleString()}${
+            data.answerTruncated ? " · retained answer truncated" : ""
+          }`,
+        )}`;
+      }
+      return new Text(text, 1, 0);
+    },
+  );
+
+  pi.registerCommand("btw", {
+    description:
+      "Ask a read-only side question without changing parent context",
+    handler: async (args, ctx) => {
+      const hasUI = ctx.hasUI;
+      const ui = ctx.ui;
+      const mode = ctx.mode;
+      if (running) {
+        if (hasUI) ui.notify("A BTW question is already running", "warning");
+        return;
+      }
+
+      running = true;
+      let statusSet = false;
+      const invocationGeneration = sessionGeneration;
+      const contextIsStale = (): boolean =>
+        invocationGeneration !== sessionGeneration;
+      const invocationAbort = new BtwCancellationController();
+      activeAbort = invocationAbort;
+      try {
+        if (!hasUI) throw new Error("BTW requires TUI or RPC UI mode");
+        const input = await readQuestion(args, ctx, invocationAbort.signal);
+        if (input === undefined) return;
+        const question = stripTerminalControls(input).trim();
+        assertQuestion(question);
+
+        if (!ctx.model) throw new Error("No model selected for BTW");
+        if (!ctx.isIdle() && hasUI) {
+          ui.notify("Waiting for the parent session to settle...", "info");
+        }
+        do {
+          await ctx.waitForIdle();
+          if (invocationAbort.signal.aborted) return;
+        } while (!ctx.isIdle());
+        if (!ctx.model) throw new Error("No model selected for BTW");
+
+        ui.setStatus(STATUS_KEY, "btw: answering");
+        statusSet = true;
+        const resolved = buildSessionContext(
+          ctx.sessionManager.getEntries(),
+          ctx.sessionManager.getLeafId(),
+        );
+        const snapshot: BtwSnapshot = {
+          cwd: ctx.cwd,
+          parentSession: ctx.sessionManager.getSessionFile(),
+          systemPrompt: ctx.getSystemPrompt(),
+          messages: structuredClone(resolved.messages),
+          model: ctx.model,
+          modelRegistry: ctx.modelRegistry,
+          thinkingLevel: pi.getThinkingLevel(),
+          signal: invocationAbort.signal,
+        };
+        const rawAnswer = await answerQuestion(snapshot, question);
+        if (invocationAbort.signal.aborted || contextIsStale()) return;
+        const answer = stripTerminalControls(rawAnswer.trim()).trim();
+        if (answer === "") {
+          throw new Error("BTW child returned no displayable text answer");
+        }
+        const retained = truncateUtf8(answer, ANSWER_MAX_BYTES);
+        const record: BtwHistoryData = {
+          version: 1,
+          id: createId(),
+          question: stripTerminalControls(question),
+          answer: retained.text,
+          answerTruncated: retained.truncated,
+          model: stripTerminalControls(
+            `${snapshot.model.provider}/${snapshot.model.id}`,
+          ),
+          createdAt: now(),
+        };
+        pi.appendEntry<BtwHistoryData>(HISTORY_TYPE, record);
+        if (mode === "rpc") {
+          ui.notify(`BTW\nQ: ${record.question}\n\n${record.answer}`, "info");
+        }
+      } catch (error) {
+        if (!contextIsStale() && !invocationAbort.signal.aborted) {
+          if (!hasUI) throw error;
+          ui.notify(`BTW failed: ${errorText(error)}`, "error");
+        }
+      } finally {
+        if (statusSet && !contextIsStale()) {
+          try {
+            ui.setStatus(STATUS_KEY, undefined);
+          } catch {
+            // Pi can invalidate a command UI context during session replacement.
+          }
+        }
+        if (activeAbort === invocationAbort) activeAbort = undefined;
+        running = false;
+      }
+    },
+  });
+};
+
+export {
+  ANSWER_MAX_BYTES,
+  answerFromReadOnlyFork,
+  BTW_DENIED_TOOLS,
+  BtwCancellationController,
+  type BtwFeatureDependencies,
+  type BtwForkDependencies,
+  type BtwHistoryData,
+  type BtwSnapshot,
+  BTW_READ_ONLY_TOOLS,
+  HISTORY_TYPE,
+  QUESTION_MAX_BYTES,
+  setupBtw as default,
+  truncateUtf8,
+};

--- a/pi/extensions/pi-harness/features/btw/index.ts
+++ b/pi/extensions/pi-harness/features/btw/index.ts
@@ -4,6 +4,7 @@ import type {
   ThinkingLevel,
 } from "@earendil-works/pi-agent-core";
 import {
+  AuthStorage,
   buildSessionContext,
   createAgentSession,
   DefaultResourceLoader,
@@ -25,7 +26,9 @@ const HISTORY_TYPE = "pi-harness:btw";
 const STATUS_KEY = "pi-harness-btw";
 const QUESTION_MAX_BYTES = 16 * 1024;
 const ANSWER_MAX_BYTES = 64 * 1024;
+const ERROR_MAX_BYTES = 4 * 1024;
 const TRUNCATION_MARKER = "\n\n[BTW answer truncated in parent history.]";
+const ERROR_TRUNCATION_MARKER = "…";
 
 // pi's grep/find wrappers auto-install missing rg/fd binaries. Keep the BTW
 // capability set to built-ins that never perform package or binary installs.
@@ -137,12 +140,14 @@ const byteLength = (value: string): number => Buffer.byteLength(value, "utf8");
 const truncateUtf8 = (
   value: string,
   maxBytes: number,
+  marker = TRUNCATION_MARKER,
 ): { text: string; truncated: boolean } => {
   if (byteLength(value) <= maxBytes) {
     return { text: value, truncated: false };
   }
 
-  const contentLimit = Math.max(0, maxBytes - byteLength(TRUNCATION_MARKER));
+  const retainedMarker = byteLength(marker) <= maxBytes ? marker : "";
+  const contentLimit = Math.max(0, maxBytes - byteLength(retainedMarker));
   let low = 0;
   let high = value.length;
   while (low < high) {
@@ -155,7 +160,7 @@ const truncateUtf8 = (
   const last = value.charCodeAt(end - 1);
   if (last >= 0xd800 && last <= 0xdbff) end -= 1;
   return {
-    text: `${value.slice(0, Math.max(0, end))}${TRUNCATION_MARKER}`,
+    text: `${value.slice(0, Math.max(0, end))}${retainedMarker}`,
     truncated: true,
   };
 };
@@ -240,6 +245,7 @@ const answerFromReadOnlyFork = async (
     agentDir,
     model: snapshot.model,
     modelRegistry: snapshot.modelRegistry,
+    authStorage: AuthStorage.inMemory(),
     thinkingLevel: snapshot.thinkingLevel,
     tools: [...BTW_READ_ONLY_TOOLS],
     excludeTools: [...BTW_DENIED_TOOLS],
@@ -315,8 +321,14 @@ const isHistoryData = (value: unknown): value is BtwHistoryData => {
   );
 };
 
-const errorText = (error: unknown): string =>
-  error instanceof Error ? error.message : String(error);
+const errorText = (error: unknown): string => {
+  const raw = error instanceof Error ? error.message : String(error);
+  return truncateUtf8(
+    stripTerminalControls(raw),
+    ERROR_MAX_BYTES,
+    ERROR_TRUNCATION_MARKER,
+  ).text;
+};
 
 interface BtwFeatureDependencies {
   answerQuestion?: typeof answerFromReadOnlyFork;
@@ -331,6 +343,25 @@ interface NativeAbortControllerLike {
 
 const createNativeAbortController = (): NativeAbortControllerLike =>
   new AbortController() as unknown as NativeAbortControllerLike;
+
+const waitForIdleOrAbort = async (
+  ctx: ExtensionCommandContext,
+  cancellation: BtwCancellationSignal,
+): Promise<boolean> => {
+  if (cancellation.aborted) return true;
+  let unsubscribe = (): void => {};
+  const aborted = new Promise<true>((resolve) => {
+    unsubscribe = cancellation.onAbort(() => resolve(true));
+  });
+  const idle = Promise.resolve()
+    .then(() => ctx.waitForIdle())
+    .then(() => false as const);
+  try {
+    return await Promise.race([idle, aborted]);
+  } finally {
+    unsubscribe();
+  }
+};
 
 const readQuestion = async (
   args: string,
@@ -366,6 +397,7 @@ const setupBtw = (
   const runtime = pi as unknown as ExtensionAPI;
   let running = false;
   let activeAbort: BtwCancellationController | undefined;
+  let activeOperation: Promise<void> | undefined;
   let sessionGeneration = 0;
   let branchGeneration = 0;
 
@@ -379,9 +411,11 @@ const setupBtw = (
     branchGeneration += 1;
     activeAbort?.abort();
   });
-  pi.on("session_shutdown", () => {
+  pi.on("session_shutdown", async () => {
     sessionGeneration += 1;
     activeAbort?.abort();
+    const operation = activeOperation;
+    await operation;
   });
   runtime.on("session_compact", (_event, ctx) => {
     const visibleIds = new Set<string>();
@@ -507,15 +541,18 @@ const setupBtw = (
       // Return control to Pi after input validation so `/btw-cancel` can be
       // dispatched while the side question is running. The generation and
       // cancellation guards below own the detached operation's whole lifetime.
-      void (async () => {
+      const operation = Promise.resolve().then(async () => {
         let statusSet = false;
         try {
           if (!ctx.isIdle()) {
             ui.notify("Waiting for the parent session to settle...", "info");
           }
           while (!ctx.isIdle()) {
-            await ctx.waitForIdle();
-            if (invocationAbort.signal.aborted || invocationIsStale()) return;
+            const aborted = await waitForIdleOrAbort(
+              ctx,
+              invocationAbort.signal,
+            );
+            if (aborted || invocationIsStale()) return;
           }
           if (invocationAbort.signal.aborted || invocationIsStale()) return;
           if (!ctx.model) throw new Error("No model selected for BTW");
@@ -583,8 +620,11 @@ const setupBtw = (
             }
           }
           releaseInvocation();
+          if (activeOperation === operation) activeOperation = undefined;
         }
-      })();
+      });
+      activeOperation = operation;
+      void operation;
     },
   });
 };
@@ -599,6 +639,7 @@ export {
   type BtwHistoryData,
   type BtwSnapshot,
   BTW_READ_ONLY_TOOLS,
+  ERROR_MAX_BYTES,
   HISTORY_TYPE,
   QUESTION_MAX_BYTES,
   setupBtw as default,

--- a/pi/extensions/pi-harness/features/btw/index.ts
+++ b/pi/extensions/pi-harness/features/btw/index.ts
@@ -367,9 +367,17 @@ const setupBtw = (
   let running = false;
   let activeAbort: BtwCancellationController | undefined;
   let sessionGeneration = 0;
+  let branchGeneration = 0;
 
   pi.on("session_start", () => {
     sessionGeneration += 1;
+  });
+  pi.on("session_before_tree", () => {
+    // Invalidate before navigation changes the active leaf. Cancelling even if
+    // a later handler vetoes navigation is the conservative outcome: a BTW
+    // answer must never move from its snapshotted branch to another branch.
+    branchGeneration += 1;
+    activeAbort?.abort();
   });
   pi.on("session_shutdown", () => {
     sessionGeneration += 1;
@@ -462,83 +470,121 @@ const setupBtw = (
       }
 
       running = true;
-      let statusSet = false;
-      const invocationGeneration = sessionGeneration;
-      const contextIsStale = (): boolean =>
-        invocationGeneration !== sessionGeneration;
+      const invocationSessionGeneration = sessionGeneration;
+      const invocationBranchGeneration = branchGeneration;
+      const sessionContextIsStale = (): boolean =>
+        invocationSessionGeneration !== sessionGeneration;
+      const invocationIsStale = (): boolean =>
+        sessionContextIsStale() ||
+        invocationBranchGeneration !== branchGeneration;
       const invocationAbort = new BtwCancellationController();
       activeAbort = invocationAbort;
+      const releaseInvocation = (): void => {
+        if (activeAbort === invocationAbort) activeAbort = undefined;
+        running = false;
+      };
+
+      let question: string;
       try {
         if (!hasUI) throw new Error("BTW requires TUI or RPC UI mode");
         const input = await readQuestion(args, ctx, invocationAbort.signal);
-        if (input === undefined) return;
-        const question = stripTerminalControls(input).trim();
+        if (input === undefined) {
+          releaseInvocation();
+          return;
+        }
+        question = stripTerminalControls(input).trim();
         assertQuestion(question);
-
         if (!ctx.model) throw new Error("No model selected for BTW");
-        if (!ctx.isIdle() && hasUI) {
-          ui.notify("Waiting for the parent session to settle...", "info");
-        }
-        do {
-          await ctx.waitForIdle();
-          if (invocationAbort.signal.aborted) return;
-        } while (!ctx.isIdle());
-        if (!ctx.model) throw new Error("No model selected for BTW");
-
-        ui.setStatus(STATUS_KEY, "btw: answering");
-        statusSet = true;
-        const resolved = buildSessionContext(
-          ctx.sessionManager.getEntries(),
-          ctx.sessionManager.getLeafId(),
-        );
-        const snapshot: BtwSnapshot = {
-          cwd: ctx.cwd,
-          parentSession: ctx.sessionManager.getSessionFile(),
-          systemPrompt: ctx.getSystemPrompt(),
-          messages: structuredClone(resolved.messages),
-          model: ctx.model,
-          modelRegistry: ctx.modelRegistry,
-          thinkingLevel: pi.getThinkingLevel(),
-          signal: invocationAbort.signal,
-        };
-        const rawAnswer = await answerQuestion(snapshot, question);
-        if (invocationAbort.signal.aborted || contextIsStale()) return;
-        const answer = stripTerminalControls(rawAnswer.trim()).trim();
-        if (answer === "") {
-          throw new Error("BTW child returned no displayable text answer");
-        }
-        const retained = truncateUtf8(answer, ANSWER_MAX_BYTES);
-        const record: BtwHistoryData = {
-          version: 1,
-          id: createId(),
-          question: stripTerminalControls(question),
-          answer: retained.text,
-          answerTruncated: retained.truncated,
-          model: stripTerminalControls(
-            `${snapshot.model.provider}/${snapshot.model.id}`,
-          ),
-          createdAt: now(),
-        };
-        pi.appendEntry<BtwHistoryData>(HISTORY_TYPE, record);
-        if (mode === "rpc") {
-          ui.notify(`BTW\nQ: ${record.question}\n\n${record.answer}`, "info");
-        }
       } catch (error) {
-        if (!contextIsStale() && !invocationAbort.signal.aborted) {
-          if (!hasUI) throw error;
+        releaseInvocation();
+        if (!hasUI) throw error;
+        if (!invocationIsStale() && !invocationAbort.signal.aborted) {
           ui.notify(`BTW failed: ${errorText(error)}`, "error");
         }
-      } finally {
-        if (statusSet && !contextIsStale()) {
-          try {
-            ui.setStatus(STATUS_KEY, undefined);
-          } catch {
-            // Pi can invalidate a command UI context during session replacement.
-          }
-        }
-        if (activeAbort === invocationAbort) activeAbort = undefined;
-        running = false;
+        return;
       }
+
+      // Return control to Pi after input validation so `/btw-cancel` can be
+      // dispatched while the side question is running. The generation and
+      // cancellation guards below own the detached operation's whole lifetime.
+      void (async () => {
+        let statusSet = false;
+        try {
+          if (!ctx.isIdle()) {
+            ui.notify("Waiting for the parent session to settle...", "info");
+          }
+          while (!ctx.isIdle()) {
+            await ctx.waitForIdle();
+            if (invocationAbort.signal.aborted || invocationIsStale()) return;
+          }
+          if (invocationAbort.signal.aborted || invocationIsStale()) return;
+          if (!ctx.model) throw new Error("No model selected for BTW");
+
+          const parentSession = ctx.sessionManager.getSessionFile();
+          const parentEntries = ctx.sessionManager.getEntries();
+          const hasAssistant = parentEntries.some(
+            (entry) =>
+              entry.type === "message" && entry.message.role === "assistant",
+          );
+          if (parentSession !== undefined && !hasAssistant) {
+            throw new Error(
+              "BTW history is not durable until the parent completes its first assistant response",
+            );
+          }
+
+          ui.setStatus(STATUS_KEY, "btw: answering");
+          statusSet = true;
+          const resolved = buildSessionContext(
+            parentEntries,
+            ctx.sessionManager.getLeafId(),
+          );
+          const snapshot: BtwSnapshot = {
+            cwd: ctx.cwd,
+            parentSession,
+            systemPrompt: ctx.getSystemPrompt(),
+            messages: structuredClone(resolved.messages),
+            model: ctx.model,
+            modelRegistry: ctx.modelRegistry,
+            thinkingLevel: pi.getThinkingLevel(),
+            signal: invocationAbort.signal,
+          };
+          const rawAnswer = await answerQuestion(snapshot, question);
+          if (invocationAbort.signal.aborted || invocationIsStale()) return;
+          const answer = stripTerminalControls(rawAnswer.trim()).trim();
+          if (answer === "") {
+            throw new Error("BTW child returned no displayable text answer");
+          }
+          const retained = truncateUtf8(answer, ANSWER_MAX_BYTES);
+          const record: BtwHistoryData = {
+            version: 1,
+            id: createId(),
+            question: stripTerminalControls(question),
+            answer: retained.text,
+            answerTruncated: retained.truncated,
+            model: stripTerminalControls(
+              `${snapshot.model.provider}/${snapshot.model.id}`,
+            ),
+            createdAt: now(),
+          };
+          pi.appendEntry<BtwHistoryData>(HISTORY_TYPE, record);
+          if (mode === "rpc") {
+            ui.notify(`BTW\nQ: ${record.question}\n\n${record.answer}`, "info");
+          }
+        } catch (error) {
+          if (!invocationIsStale() && !invocationAbort.signal.aborted) {
+            ui.notify(`BTW failed: ${errorText(error)}`, "error");
+          }
+        } finally {
+          if (statusSet && !sessionContextIsStale()) {
+            try {
+              ui.setStatus(STATUS_KEY, undefined);
+            } catch {
+              // Pi can invalidate a command UI context during session replacement.
+            }
+          }
+          releaseInvocation();
+        }
+      })();
     },
   });
 };

--- a/pi/extensions/pi-harness/features/permission-policy/judge.ts
+++ b/pi/extensions/pi-harness/features/permission-policy/judge.ts
@@ -53,7 +53,7 @@ interface CacheEntry {
   expiresAt: number;
 }
 
-interface ActiveAbortSignal extends AbortSignal {
+type ActiveAbortSignal = {
   readonly aborted: boolean;
   addEventListener(
     type: "abort",
@@ -61,7 +61,7 @@ interface ActiveAbortSignal extends AbortSignal {
     options?: { once?: boolean },
   ): void;
   removeEventListener(type: "abort", listener: () => void): void;
-}
+};
 
 interface AbortControllerLike {
   readonly signal: ActiveAbortSignal;

--- a/pi/extensions/pi-harness/index.ts
+++ b/pi/extensions/pi-harness/index.ts
@@ -21,6 +21,7 @@ import setupStatusline from "./features/statusline/index";
 import setupProviderLog from "./features/provider-log/index";
 import setupAsukuNotify from "./features/asuku-notify/index";
 import setupAskUserQuestion from "./features/ask-user-question/index";
+import setupBtw from "./features/btw/index";
 import setupChildRuns from "./features/child-runs/index";
 
 // The parameter is typed against the narrowed PiLike seam instead of pi's
@@ -43,6 +44,7 @@ const setupHarness = (pi: PiLike, config: HarnessConfig): void => {
   if (config.features["provider-log"]) setupProviderLog(pi, config);
   if (config.features["asuku-notify"]) setupAsukuNotify(pi, config);
   if (config.features["ask-user-question"]) setupAskUserQuestion(pi);
+  if (!config.isChild) setupBtw(pi);
 };
 
 const piHarness: ExtensionFactory = (pi): void => {

--- a/pi/extensions/pi-harness/lib/pi-like.ts
+++ b/pi/extensions/pi-harness/lib/pi-like.ts
@@ -61,6 +61,7 @@ export interface PiEventMap {
   tool_call: ToolCallEvent;
   tool_result: ToolResultEvent;
   agent_settled: GenericEvent;
+  session_compact: GenericEvent;
   session_shutdown: GenericEvent;
   // Provider hooks (V10): request payload before send, and status + headers
   // before the stream is consumed. pi-harness only observes these (void
@@ -98,6 +99,7 @@ export interface PiEventResultMap {
   tool_call: ToolCallBlockResult | undefined | void;
   tool_result: ToolResultPatch | undefined | void;
   agent_settled: void;
+  session_compact: void;
   session_shutdown: void;
   before_provider_request: void;
   after_provider_response: void;
@@ -209,6 +211,11 @@ export interface ToolDefLike {
 export interface PiLike {
   on<K extends PiEventName>(event: K, handler: PiEventHandler<K>): void;
   registerTool(tool: ToolDefLike): void;
+  registerCommand: ExtensionAPI["registerCommand"];
+  registerShortcut: ExtensionAPI["registerShortcut"];
+  registerEntryRenderer: ExtensionAPI["registerEntryRenderer"];
+  appendEntry: ExtensionAPI["appendEntry"];
+  getThinkingLevel: ExtensionAPI["getThinkingLevel"];
 }
 
 // Compile-only contracts against pi's documented public API. Keeping these

--- a/pi/extensions/pi-harness/lib/pi-like.ts
+++ b/pi/extensions/pi-harness/lib/pi-like.ts
@@ -41,6 +41,14 @@ export interface ContextEvent {
   messages: unknown[];
 }
 
+export interface SessionBeforeTreeEvent {
+  type: "session_before_tree";
+  preparation: {
+    targetId: string;
+    oldLeafId: string | null;
+  };
+}
+
 export interface ToolCallEvent {
   type: "tool_call";
   toolName: string;
@@ -76,6 +84,7 @@ export interface PiEventMap {
   tool_call: ToolCallEvent;
   tool_result: ToolResultEvent;
   agent_settled: GenericEvent;
+  session_before_tree: SessionBeforeTreeEvent;
   session_compact: GenericEvent;
   session_shutdown: GenericEvent;
   // Provider hooks (V10): request payload before send, and status + headers
@@ -116,6 +125,7 @@ export interface PiEventResultMap {
   tool_call: ToolCallBlockResult | undefined | void;
   tool_result: ToolResultPatch | undefined | void;
   agent_settled: void;
+  session_before_tree: void;
   session_compact: void;
   session_shutdown: void;
   before_provider_request: void;

--- a/scripts/check-pi-imports.ts
+++ b/scripts/check-pi-imports.ts
@@ -33,7 +33,10 @@ export const EXTENSION_ROOTS = [
 // with the running pi process. Keep this allowlist exact: subpaths, lookalikes,
 // other pi packages, and codex-web runtime imports remain denied.
 const RUNTIME_IMPORTS_BY_ROOT = new Map<string, ReadonlySet<string>>([
-  [EXTENSION_ROOT, new Set(["@earendil-works/pi-tui"])],
+  [
+    EXTENSION_ROOT,
+    new Set(["@earendil-works/pi-coding-agent", "@earendil-works/pi-tui"]),
+  ],
 ]);
 
 const transpiler = new Bun.Transpiler({ loader: "ts" });

--- a/tests/pi-harness/btw.test.ts
+++ b/tests/pi-harness/btw.test.ts
@@ -1,0 +1,880 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { UserMessage } from "@earendil-works/pi-ai/compat";
+import {
+  buildSessionContext,
+  type CreateAgentSessionOptions,
+  type EntryRenderer,
+  type ExtensionCommandContext,
+  type ExtensionContext,
+  type ModelRegistry,
+  type RegisteredCommand,
+  type ResourceLoader,
+  SessionManager,
+  SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+import setupBtw, {
+  ANSWER_MAX_BYTES,
+  answerFromReadOnlyFork,
+  BTW_DENIED_TOOLS,
+  BtwCancellationController,
+  type BtwForkDependencies,
+  type BtwHistoryData,
+  type BtwSnapshot,
+  BTW_READ_ONLY_TOOLS,
+  HISTORY_TYPE,
+  QUESTION_MAX_BYTES,
+  truncateUtf8,
+} from "../../pi/extensions/pi-harness/features/btw/index";
+import { loadConfig } from "../../pi/extensions/pi-harness/config";
+import { setupHarness } from "../../pi/extensions/pi-harness/index";
+import type { PiLike } from "../../pi/extensions/pi-harness/lib/pi-like";
+import { resolvePaths } from "../../pi/extensions/pi-harness/lib/paths";
+import { createFakePi } from "./fake-pi";
+
+const parentModel = {
+  provider: "test-provider",
+  id: "test-model",
+  name: "Test model",
+} as NonNullable<ExtensionCommandContext["model"]>;
+
+const userMessage = (text: string): UserMessage => ({
+  role: "user",
+  content: [{ type: "text", text }],
+  timestamp: 1,
+});
+
+const assistantMessage = (
+  text: string,
+  stopReason: Extract<
+    AgentMessage,
+    { role: "assistant" }
+  >["stopReason"] = "stop",
+): Extract<AgentMessage, { role: "assistant" }> => ({
+  role: "assistant",
+  content: [{ type: "text", text }],
+  api: "openai-responses",
+  provider: "test-provider",
+  model: "test-model",
+  usage: {
+    input: 1,
+    output: 1,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 2,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  },
+  stopReason,
+  timestamp: 2,
+});
+
+interface ChildHarness {
+  dependencies: BtwForkDependencies;
+  child: {
+    agent: { state: { messages: AgentMessage[] } };
+    promptText?: string;
+    promptOptions?: {
+      expandPromptTemplates?: boolean;
+      source?: "interactive" | "rpc" | "extension";
+    };
+    disposed: boolean;
+    aborted: boolean;
+    activeTools: string[];
+    answer?: string;
+    stopReason: Extract<AgentMessage, { role: "assistant" }>["stopReason"];
+    emitAssistant: boolean;
+    promptError?: Error;
+  };
+  loaderOptions: Record<string, unknown>[];
+  createOptions: CreateAgentSessionOptions[];
+  reloads: number;
+}
+
+const childHarness = (): ChildHarness => {
+  const loaderOptions: Record<string, unknown>[] = [];
+  const createOptions: CreateAgentSessionOptions[] = [];
+  let reloads = 0;
+  const child = {
+    agent: { state: { messages: [] as AgentMessage[] } },
+    promptText: undefined as string | undefined,
+    promptOptions: undefined as
+      | {
+          expandPromptTemplates?: boolean;
+          source?: "interactive" | "rpc" | "extension";
+        }
+      | undefined,
+    disposed: false,
+    aborted: false,
+    activeTools: [...BTW_READ_ONLY_TOOLS],
+    answer: "side answer" as string | undefined,
+    stopReason: "stop" as const,
+    emitAssistant: true,
+    promptError: undefined as Error | undefined,
+  };
+
+  const dependencies: BtwForkDependencies = {
+    getAgentDir: () => "/agent",
+    createResourceLoader: (options) => {
+      loaderOptions.push(options as unknown as Record<string, unknown>);
+      return {
+        reload: async () => {
+          reloads += 1;
+        },
+      } as ResourceLoader;
+    },
+    createSessionManager: (cwd, options) =>
+      SessionManager.inMemory(cwd, options),
+    createSettingsManager: () =>
+      SettingsManager.inMemory({ images: { blockImages: true } }),
+    createSession: async (options) => {
+      createOptions.push(options);
+      child.agent.state.messages =
+        options.sessionManager?.buildSessionContext().messages ?? [];
+      let listener:
+        | ((event: { type: string; message?: AgentMessage }) => void)
+        | undefined;
+      return {
+        agent: child.agent,
+        getActiveToolNames: () => [...child.activeTools],
+        subscribe: (value) => {
+          listener = value;
+          return () => {
+            listener = undefined;
+          };
+        },
+        prompt: async (text, promptOptions) => {
+          child.promptText = text;
+          child.promptOptions = promptOptions;
+          if (child.promptError) throw child.promptError;
+          if (child.emitAssistant) {
+            const message = assistantMessage(
+              child.answer ?? "",
+              child.stopReason,
+            );
+            child.agent.state.messages.push(message);
+            listener?.({ type: "message_end", message });
+          }
+        },
+        abort: async () => {
+          child.aborted = true;
+        },
+        dispose: () => {
+          child.disposed = true;
+        },
+      };
+    },
+  };
+
+  return {
+    dependencies,
+    child,
+    loaderOptions,
+    createOptions,
+    get reloads() {
+      return reloads;
+    },
+  };
+};
+
+const snapshot = (): BtwSnapshot => ({
+  cwd: "/repo",
+  parentSession: "/sessions/parent.jsonl",
+  systemPrompt: "parent system prompt",
+  messages: [userMessage("parent context")],
+  model: parentModel,
+  modelRegistry: {} as ModelRegistry,
+  thinkingLevel: "low",
+});
+
+describe("BTW read-only fork runner", () => {
+  test("creates an extension-free in-memory child with an exact read-only tool set", async () => {
+    const harness = childHarness();
+    const parent = snapshot();
+
+    await expect(
+      answerFromReadOnlyFork(
+        parent,
+        "What does this do?",
+        harness.dependencies,
+      ),
+    ).resolves.toBe("side answer");
+
+    expect(harness.reloads).toBe(1);
+    expect(harness.loaderOptions[0]).toMatchObject({
+      cwd: "/repo",
+      agentDir: "/agent",
+      noExtensions: true,
+      noSkills: true,
+      noPromptTemplates: true,
+      noThemes: true,
+      noContextFiles: true,
+      appendSystemPrompt: [],
+    });
+    expect(String(harness.loaderOptions[0].systemPrompt)).toContain(
+      "parent system prompt",
+    );
+    expect(String(harness.loaderOptions[0].systemPrompt)).toContain(
+      "Never attempt to mutate files",
+    );
+    expect(harness.createOptions[0].tools).toEqual([...BTW_READ_ONLY_TOOLS]);
+    expect(harness.createOptions[0].excludeTools).toEqual([
+      ...BTW_DENIED_TOOLS,
+    ]);
+    expect(harness.createOptions[0].model).toBe(parentModel);
+    expect(harness.createOptions[0].thinkingLevel).toBe("low");
+    expect(harness.loaderOptions[0].settingsManager).toBe(
+      harness.createOptions[0].settingsManager,
+    );
+    expect(harness.createOptions[0].settingsManager?.getBlockImages()).toBe(
+      true,
+    );
+    expect(harness.child.promptText).toBe("What does this do?");
+    expect(harness.child.promptOptions).toEqual({
+      expandPromptTemplates: false,
+      source: "extension",
+    });
+    expect(harness.child.agent.state.messages.slice(0, -1)).toEqual(
+      parent.messages,
+    );
+    expect(
+      harness.createOptions[0].sessionManager?.buildSessionContext().messages,
+    ).toEqual(parent.messages);
+    expect(harness.child.disposed).toBe(true);
+  });
+
+  test("seeds compaction summaries into the recoverable child session", async () => {
+    const harness = childHarness();
+    const parent = snapshot();
+    parent.messages = [
+      {
+        role: "compactionSummary",
+        summary: "important compacted context",
+        tokensBefore: 10_000,
+        timestamp: 1,
+      },
+      userMessage("recent context"),
+    ];
+
+    await answerFromReadOnlyFork(parent, "question", harness.dependencies);
+    const seeded =
+      harness.createOptions[0].sessionManager?.buildSessionContext().messages;
+    expect(seeded?.[0]?.role).toBe("custom");
+    expect(JSON.stringify(seeded?.[0])).toContain(
+      "important compacted context",
+    );
+    expect(seeded?.[1]).toEqual(userMessage("recent context"));
+  });
+
+  test("fails closed on an unexpected active tool and still disposes", async () => {
+    const harness = childHarness();
+    harness.child.activeTools.push("bash");
+
+    await expect(
+      answerFromReadOnlyFork(snapshot(), "question", harness.dependencies),
+    ).rejects.toThrow("tool isolation failed");
+    expect(harness.child.promptText).toBeUndefined();
+    expect(harness.child.disposed).toBe(true);
+  });
+
+  test("aborts and disposes when the parent signal is already closed", async () => {
+    const harness = childHarness();
+    const parent = snapshot();
+    const controller = new BtwCancellationController();
+    controller.abort();
+    parent.signal = controller.signal;
+
+    await expect(
+      answerFromReadOnlyFork(parent, "question", harness.dependencies),
+    ).rejects.toThrow("parent session closed");
+    expect(harness.child.aborted).toBe(true);
+    expect(harness.child.promptText).toBeUndefined();
+    expect(harness.child.disposed).toBe(true);
+  });
+
+  test("rejects incomplete or missing fresh assistant responses", async () => {
+    const limited = childHarness();
+    limited.child.stopReason = "length";
+    await expect(
+      answerFromReadOnlyFork(snapshot(), "question", limited.dependencies),
+    ).rejects.toThrow("did not complete successfully (length)");
+    expect(limited.child.disposed).toBe(true);
+
+    const stale = childHarness();
+    const parent = snapshot();
+    parent.messages.push(assistantMessage("unrelated parent answer"));
+    stale.child.emitAssistant = false;
+    await expect(
+      answerFromReadOnlyFork(parent, "question", stale.dependencies),
+    ).rejects.toThrow("no response");
+    expect(stale.child.disposed).toBe(true);
+  });
+
+  test("disposes when prompting fails or returns no text", async () => {
+    const failed = childHarness();
+    failed.child.promptError = new Error("provider failed");
+    await expect(
+      answerFromReadOnlyFork(snapshot(), "question", failed.dependencies),
+    ).rejects.toThrow("provider failed");
+    expect(failed.child.disposed).toBe(true);
+
+    const empty = childHarness();
+    empty.child.answer = "  ";
+    await expect(
+      answerFromReadOnlyFork(snapshot(), "question", empty.dependencies),
+    ).rejects.toThrow("no text answer");
+    expect(empty.child.disposed).toBe(true);
+  });
+});
+
+interface CommandHarness {
+  pi: PiLike;
+  command: (name?: string) => RegisteredCommand;
+  shortcut: (name: string) => (ctx: ExtensionContext) => Promise<void> | void;
+  renderer: () => EntryRenderer<BtwHistoryData>;
+  entries: { customType: string; data: unknown }[];
+  emitSessionCompact(ctx: ExtensionCommandContext): Promise<void>;
+  emitSessionStart(): Promise<void>;
+  emitSessionShutdown(): Promise<void>;
+}
+
+const commandHarness = (): CommandHarness => {
+  const commands = new Map<string, RegisteredCommand>();
+  const shortcuts = new Map<
+    string,
+    (ctx: ExtensionContext) => Promise<void> | void
+  >();
+  let renderer: EntryRenderer<BtwHistoryData> | undefined;
+  let compactHandler:
+    | ((
+        event: { type: string },
+        ctx: ExtensionCommandContext,
+      ) => Promise<void> | void)
+    | undefined;
+  let startHandler: (() => Promise<void> | void) | undefined;
+  let shutdownHandler: (() => Promise<void> | void) | undefined;
+  const entries: { customType: string; data: unknown }[] = [];
+  const pi = {
+    on(event: string, handler: () => Promise<void> | void) {
+      if (event === "session_compact") {
+        compactHandler = handler as unknown as typeof compactHandler;
+      }
+      if (event === "session_start") startHandler = handler;
+      if (event === "session_shutdown") shutdownHandler = handler;
+    },
+    registerTool() {},
+    registerCommand(
+      name: string,
+      options: Omit<RegisteredCommand, "name" | "sourceInfo">,
+    ) {
+      commands.set(name, {
+        ...options,
+        name,
+        sourceInfo: {} as RegisteredCommand["sourceInfo"],
+      });
+    },
+    registerShortcut(
+      name: string,
+      options: {
+        handler: (ctx: ExtensionContext) => Promise<void> | void;
+      },
+    ) {
+      shortcuts.set(name, options.handler);
+    },
+    registerEntryRenderer(
+      customType: string,
+      value: EntryRenderer<BtwHistoryData>,
+    ) {
+      if (customType === HISTORY_TYPE) renderer = value;
+    },
+    appendEntry(customType: string, data: unknown) {
+      entries.push({ customType, data });
+    },
+    getThinkingLevel: () => "high" as const,
+  } as unknown as PiLike;
+  return {
+    pi,
+    command: (name = "btw") => {
+      const command = commands.get(name);
+      if (!command) throw new Error(`${name} command was not registered`);
+      return command;
+    },
+    shortcut: (name) => {
+      const shortcut = shortcuts.get(name);
+      if (!shortcut) throw new Error(`${name} shortcut was not registered`);
+      return shortcut;
+    },
+    renderer: () => {
+      if (!renderer) throw new Error("renderer was not registered");
+      return renderer;
+    },
+    entries,
+    emitSessionCompact: async (ctx) => {
+      await compactHandler?.({ type: "session_compact" }, ctx);
+    },
+    emitSessionStart: async () => {
+      await startHandler?.();
+    },
+    emitSessionShutdown: async () => {
+      await shutdownHandler?.();
+    },
+  };
+};
+
+interface ContextHarness {
+  ctx: ExtensionCommandContext;
+  order: string[];
+  notifications: { message: string; level?: string }[];
+  statuses: { key: string; value: string | undefined }[];
+  sessionManager: SessionManager;
+}
+
+const commandContext = (
+  options: {
+    hasUI?: boolean;
+    idle?: boolean;
+    mode?: "tui" | "rpc";
+  } = {},
+): ContextHarness => {
+  const sessionManager = SessionManager.inMemory("/repo");
+  sessionManager.appendMessage(userMessage("main question"));
+  const order: string[] = [];
+  const notifications: { message: string; level?: string }[] = [];
+  const statuses: { key: string; value: string | undefined }[] = [];
+  let idle = options.idle ?? false;
+  const ctx = {
+    cwd: "/repo",
+    hasUI: options.hasUI ?? true,
+    mode: options.mode ?? "tui",
+    model: parentModel,
+    modelRegistry: {} as ModelRegistry,
+    sessionManager,
+    signal: undefined,
+    ui: {
+      input: async () => undefined,
+      notify: (message: string, level?: string) => {
+        notifications.push({ message, level });
+      },
+      setStatus: (key: string, value: string | undefined) => {
+        statuses.push({ key, value });
+      },
+    },
+    isIdle: () => idle,
+    waitForIdle: async () => {
+      order.push("wait");
+      idle = true;
+    },
+    getSystemPrompt: () => "current system",
+  } as unknown as ExtensionCommandContext;
+  return { ctx, order, notifications, statuses, sessionManager };
+};
+
+describe("BTW parent command", () => {
+  test("waits for a stable snapshot and retains Q/A only as a parent custom entry", async () => {
+    const harness = commandHarness();
+    const context = commandContext();
+    let received: BtwSnapshot | undefined;
+    setupBtw(harness.pi, {
+      now: () => 1234,
+      createId: () => "btw-1",
+      answerQuestion: async (value) => {
+        context.order.push("answer");
+        received = value;
+        return "answer text";
+      },
+    });
+
+    await harness.command().handler("  side question  ", context.ctx);
+
+    expect(context.order).toEqual(["wait", "answer"]);
+    expect(received?.messages).toEqual([userMessage("main question")]);
+    expect(received?.systemPrompt).toBe("current system");
+    expect(received?.thinkingLevel).toBe("high");
+    expect(harness.entries).toEqual([
+      {
+        customType: HISTORY_TYPE,
+        data: {
+          version: 1,
+          id: "btw-1",
+          question: "side question",
+          answer: "answer text",
+          answerTruncated: false,
+          model: "test-provider/test-model",
+          createdAt: 1234,
+        },
+      },
+    ]);
+
+    // Custom entries are durable/renderable session state, not LLM messages.
+    context.sessionManager.appendCustomEntry(
+      HISTORY_TYPE,
+      harness.entries[0].data,
+    );
+    expect(
+      buildSessionContext(context.sessionManager.getEntries()).messages,
+    ).toEqual([userMessage("main question")]);
+  });
+
+  test("replays hidden history after parent compaction", async () => {
+    const harness = commandHarness();
+    const context = commandContext({ idle: true });
+    setupBtw(harness.pi, {
+      createId: () => "btw-compacted",
+      answerQuestion: async () => "kept answer",
+    });
+    await harness.command().handler("kept question", context.ctx);
+    const [{ data }] = harness.entries;
+
+    context.sessionManager.appendCustomEntry(HISTORY_TYPE, data);
+    const firstKeptId = context.sessionManager.appendMessage(
+      userMessage("newer parent context"),
+    );
+    context.sessionManager.appendCompaction(
+      "parent summary",
+      firstKeptId,
+      10_000,
+    );
+    harness.entries.length = 0;
+
+    await harness.emitSessionCompact(context.ctx);
+    expect(harness.entries).toEqual([{ customType: HISTORY_TYPE, data }]);
+  });
+
+  test("uses UI input when args are empty and reports missing model without running", async () => {
+    const harness = commandHarness();
+    const context = commandContext();
+    context.ctx.ui.input = async () => "from dialog";
+    let questions: string[] = [];
+    setupBtw(harness.pi, {
+      answerQuestion: async (_snapshot, question) => {
+        questions.push(question);
+        return "ok";
+      },
+    });
+    await harness.command().handler("", context.ctx);
+    expect(questions).toEqual(["from dialog"]);
+
+    const noModelHarness = commandHarness();
+    const noModel = commandContext();
+    noModel.ctx.model = undefined;
+    questions = [];
+    setupBtw(noModelHarness.pi, {
+      answerQuestion: async (_snapshot, question) => {
+        questions.push(question);
+        return "never";
+      },
+    });
+    await noModelHarness.command().handler("question", noModel.ctx);
+    expect(questions).toEqual([]);
+    expect(noModel.notifications[0]?.message).toContain("No model selected");
+
+    const noUiHarness = commandHarness();
+    const noUi = commandContext({ hasUI: false });
+    setupBtw(noUiHarness.pi, {
+      answerQuestion: async () => "never",
+    });
+    await expect(
+      noUiHarness.command().handler("question", noUi.ctx),
+    ).rejects.toThrow("requires TUI or RPC");
+    expect(noUiHarness.entries).toHaveLength(0);
+  });
+
+  test("rechecks idleness before taking the synchronous snapshot", async () => {
+    const harness = commandHarness();
+    const context = commandContext({ idle: false });
+    let waits = 0;
+    context.ctx.waitForIdle = async () => {
+      waits += 1;
+      context.order.push("wait");
+    };
+    context.ctx.isIdle = () => waits >= 2;
+    setupBtw(harness.pi, {
+      answerQuestion: async () => {
+        context.order.push("answer");
+        return "ok";
+      },
+    });
+
+    await harness.command().handler("question", context.ctx);
+    expect(context.order).toEqual(["wait", "wait", "answer"]);
+  });
+
+  test("rejects overlapping invocations and releases the guard after completion", async () => {
+    const harness = commandHarness();
+    const firstContext = commandContext({ idle: true });
+    const secondContext = commandContext({ idle: true });
+    let release!: (value: string) => void;
+    let started!: () => void;
+    const hasStarted = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    setupBtw(harness.pi, {
+      answerQuestion: async () => {
+        started();
+        return new Promise<string>((resolve) => {
+          release = resolve;
+        });
+      },
+    });
+
+    const first = harness.command().handler("first", firstContext.ctx);
+    await hasStarted;
+    await harness.command().handler("second", secondContext.ctx);
+    expect(secondContext.notifications[0]?.message).toContain(
+      "already running",
+    );
+    expect(harness.entries).toHaveLength(0);
+
+    release("done");
+    await first;
+    expect(harness.entries).toHaveLength(1);
+  });
+
+  test("cancels an in-flight child through the command and shortcut", async () => {
+    for (const cancel of ["command", "shortcut"] as const) {
+      const harness = commandHarness();
+      const context = commandContext({ idle: true });
+      let started!: () => void;
+      const hasStarted = new Promise<void>((resolve) => {
+        started = resolve;
+      });
+      setupBtw(harness.pi, {
+        answerQuestion: async (value) => {
+          started();
+          return new Promise<string>((_resolve, reject) => {
+            value.signal?.onAbort(() => reject(new Error("cancelled")));
+          });
+        },
+      });
+
+      const invocation = harness.command().handler("question", context.ctx);
+      await hasStarted;
+      if (cancel === "command") {
+        await harness.command("btw-cancel").handler("", context.ctx);
+      } else {
+        await harness.shortcut("ctrl+alt+b")(context.ctx);
+      }
+      await invocation;
+
+      expect(harness.entries).toHaveLength(0);
+      expect(context.statuses.at(-1)).toEqual({
+        key: "pi-harness-btw",
+        value: undefined,
+      });
+      expect(
+        context.notifications.some(({ message }) =>
+          message.includes("cancellation requested"),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test("aborts an argument-less dialog when the parent shuts down", async () => {
+    const harness = commandHarness();
+    const context = commandContext({ idle: true });
+    let started!: () => void;
+    const hasStarted = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    context.ctx.ui.input = async (_title, _placeholder, options) => {
+      started();
+      return new Promise<string | undefined>((resolve) => {
+        const signal = options?.signal as unknown as {
+          aborted: boolean;
+          addEventListener(
+            type: "abort",
+            listener: () => void,
+            options?: { once?: boolean },
+          ): void;
+        };
+        if (signal.aborted) resolve(undefined);
+        else {
+          signal.addEventListener("abort", () => resolve(undefined), {
+            once: true,
+          });
+        }
+      });
+    };
+    setupBtw(harness.pi, { answerQuestion: async () => "never" });
+
+    const invocation = harness.command().handler("", context.ctx);
+    await hasStarted;
+    await harness.emitSessionShutdown();
+    await invocation;
+    expect(harness.entries).toHaveLength(0);
+  });
+
+  test("drops a late old-session answer without stale context access", async () => {
+    const harness = commandHarness();
+    const oldContext = commandContext({ idle: true, mode: "rpc" });
+    let stale = false;
+    for (const property of ["hasUI", "ui", "mode"] as const) {
+      const value = oldContext.ctx[property];
+      Object.defineProperty(oldContext.ctx, property, {
+        get: () => {
+          if (stale) throw new Error("stale command context");
+          return value;
+        },
+      });
+    }
+    let started!: () => void;
+    const hasStarted = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    let release!: (answer: string) => void;
+    let calls = 0;
+    setupBtw(harness.pi, {
+      answerQuestion: async (value) => {
+        calls += 1;
+        if (calls > 1) return "fresh answer";
+        started();
+        value.signal?.onAbort(() => {
+          stale = true;
+        });
+        return new Promise<string>((resolve) => {
+          release = resolve;
+        });
+      },
+    });
+
+    const invocation = harness
+      .command()
+      .handler("old question", oldContext.ctx);
+    await hasStarted;
+    await harness.emitSessionShutdown();
+    await harness.emitSessionStart();
+    release("late answer");
+    await invocation;
+
+    expect(harness.entries).toHaveLength(0);
+    expect(oldContext.notifications).toHaveLength(0);
+
+    const newContext = commandContext({ idle: true, mode: "rpc" });
+    await harness.command().handler("new question", newContext.ctx);
+    expect(calls).toBe(2);
+    expect(harness.entries).toHaveLength(1);
+    expect(harness.entries[0].data).toMatchObject({ answer: "fresh answer" });
+    expect(newContext.notifications.at(-1)?.message).toContain("fresh answer");
+  });
+
+  test("bounds questions and retained answers without splitting UTF-8", async () => {
+    const harness = commandHarness();
+    const context = commandContext({ idle: true });
+    let calls = 0;
+    setupBtw(harness.pi, {
+      answerQuestion: async () => {
+        calls += 1;
+        return "😀".repeat(ANSWER_MAX_BYTES);
+      },
+    });
+
+    await harness
+      .command()
+      .handler("x".repeat(QUESTION_MAX_BYTES + 1), context.ctx);
+    expect(calls).toBe(0);
+    expect(context.notifications[0]?.message).toContain("exceeds");
+
+    await harness.command().handler("bounded", context.ctx);
+    const data = harness.entries[0].data as BtwHistoryData;
+    expect(data.answerTruncated).toBe(true);
+    expect(Buffer.byteLength(data.answer, "utf8")).toBeLessThanOrEqual(
+      ANSWER_MAX_BYTES,
+    );
+    expect(data.answer).not.toContain("�");
+
+    expect(truncateUtf8("short", ANSWER_MAX_BYTES)).toEqual({
+      text: "short",
+      truncated: false,
+    });
+  });
+
+  test("returns the answer through RPC UI as well as parent history", async () => {
+    const harness = commandHarness();
+    const context = commandContext({ idle: true, mode: "rpc" });
+    setupBtw(harness.pi, {
+      answerQuestion: async () => "rpc answer",
+    });
+
+    await harness.command().handler("rpc question", context.ctx);
+    expect(harness.entries).toHaveLength(1);
+    expect(
+      context.notifications.some(({ message }) =>
+        message.includes("rpc answer"),
+      ),
+    ).toBe(true);
+  });
+
+  test("sanitizes terminal controls before persistence and rendering", async () => {
+    const harness = commandHarness();
+    const context = commandContext({ idle: true });
+    setupBtw(harness.pi, {
+      createId: () => "safe-id",
+      answerQuestion: async () => "answer\u001b]2;owned\u0007safe",
+    });
+    await harness.command().handler("question\u001b[31mred", context.ctx);
+    const data = harness.entries[0].data as BtwHistoryData;
+    expect(JSON.stringify(data)).not.toContain("\u001b");
+
+    const component = harness.renderer()(
+      {
+        data: {
+          ...data,
+          answer: "raw\u001b[31mcontrol",
+          model: "model\u001b]2;owned\u0007",
+        },
+      } as never,
+      { expanded: true },
+      {
+        fg: (_color: string, text: string) => text,
+        bold: (text: string) => text,
+      } as never,
+    );
+    expect(component?.render(80).join("\n")).not.toContain("\u001b");
+
+    const emptyHarness = commandHarness();
+    const emptyContext = commandContext({ idle: true });
+    let calls = 0;
+    setupBtw(emptyHarness.pi, {
+      answerQuestion: async () => {
+        calls += 1;
+        return "\u001b[31m";
+      },
+    });
+    await emptyHarness.command().handler("\u001b[31m", emptyContext.ctx);
+    expect(calls).toBe(0);
+    await emptyHarness.command().handler("visible", emptyContext.ctx);
+    expect(calls).toBe(1);
+    expect(emptyHarness.entries).toHaveLength(0);
+  });
+
+  test("renders malformed resumed history defensively", () => {
+    const harness = commandHarness();
+    setupBtw(harness.pi);
+    const renderer = harness.renderer();
+    const component = renderer({ data: null } as never, { expanded: false }, {
+      fg: (_color: string, text: string) => text,
+      bold: (text: string) => text,
+    } as never);
+    expect(component?.render(80).join("\n")).toContain("malformed");
+  });
+});
+
+describe("BTW umbrella lifecycle", () => {
+  test("registers only in parent harness profiles", () => {
+    const paths = resolvePaths("/tmp/pi-btw-config");
+    const parent = createFakePi();
+    const parentConfig = loadConfig({}, paths);
+    parentConfig.features.subagent = false;
+    parentConfig.features.workflow = false;
+    setupHarness(parent, parentConfig);
+    expect(parent.commands.has("btw")).toBe(true);
+    expect(parent.commands.has("btw-cancel")).toBe(true);
+    expect(parent.shortcuts.has("ctrl+alt+b")).toBe(true);
+
+    const child = createFakePi();
+    const childConfig = loadConfig({ PI_HARNESS_CHILD: "1" }, paths);
+    childConfig.features.subagent = false;
+    childConfig.features.workflow = false;
+    setupHarness(child, childConfig);
+    expect(child.commands.has("btw")).toBe(false);
+  });
+});

--- a/tests/pi-harness/btw.test.ts
+++ b/tests/pi-harness/btw.test.ts
@@ -25,6 +25,7 @@ import setupBtw, {
   type BtwHistoryData,
   type BtwSnapshot,
   BTW_READ_ONLY_TOOLS,
+  ERROR_MAX_BYTES,
   HISTORY_TYPE,
   QUESTION_MAX_BYTES,
   truncateUtf8,
@@ -235,6 +236,8 @@ describe("BTW read-only fork runner", () => {
       ...BTW_DENIED_TOOLS,
     ]);
     expect(harness.createOptions[0].model).toBe(parentModel);
+    expect(harness.createOptions[0].authStorage).toBeDefined();
+    expect(harness.createOptions[0].authStorage?.list()).toEqual([]);
     expect(harness.createOptions[0].thinkingLevel).toBe("low");
     expect(harness.loaderOptions[0].settingsManager).toBe(
       harness.createOptions[0].settingsManager,
@@ -546,6 +549,7 @@ describe("BTW parent command", () => {
       answerQuestion: async () => "kept answer",
     });
     await harness.command().handler("kept question", context.ctx);
+    await waitFor(() => harness.entries.length === 1);
     const [{ data }] = harness.entries;
 
     context.sessionManager.appendCustomEntry(HISTORY_TYPE, data);
@@ -575,6 +579,7 @@ describe("BTW parent command", () => {
       },
     });
     await harness.command().handler("", context.ctx);
+    await waitFor(() => questions.length === 1);
     expect(questions).toEqual(["from dialog"]);
 
     const noModelHarness = commandHarness();
@@ -621,6 +626,47 @@ describe("BTW parent command", () => {
     await harness.command().handler("question", context.ctx);
     await waitFor(() => context.order.includes("answer"));
     expect(context.order).toEqual(["wait", "wait", "answer"]);
+  });
+
+  test("cancellation releases a permanently pending idle wait", async () => {
+    for (const trigger of ["command", "shutdown"] as const) {
+      const harness = commandHarness();
+      const context = commandContext({ idle: false });
+      let waiting!: () => void;
+      const waitStarted = new Promise<void>((resolve) => {
+        waiting = resolve;
+      });
+      context.ctx.waitForIdle = () => {
+        waiting();
+        return new Promise<void>(() => {});
+      };
+      let answerCalls = 0;
+      setupBtw(harness.pi, {
+        answerQuestion: async () => {
+          answerCalls += 1;
+          return "never";
+        },
+      });
+
+      await harness.command().handler("question", context.ctx);
+      await waitStarted;
+      const completion =
+        trigger === "command"
+          ? (async () => {
+              await harness.command("btw-cancel").handler("", context.ctx);
+              await harness.emitSessionShutdown();
+            })()
+          : harness.emitSessionShutdown();
+      await Promise.race([
+        completion,
+        new Promise<never>((_resolve, reject) => {
+          setTimeout(() => reject(new Error("BTW cancellation hung")), 250);
+        }),
+      ]);
+
+      expect(answerCalls).toBe(0);
+      expect(harness.entries).toHaveLength(0);
+    }
   });
 
   test("rejects overlapping invocations and releases the guard after completion", async () => {
@@ -695,6 +741,48 @@ describe("BTW parent command", () => {
         ),
       ).toBe(true);
     }
+  });
+
+  test("waits for detached cleanup during parent shutdown", async () => {
+    const harness = commandHarness();
+    const context = commandContext({ idle: true });
+    let started!: () => void;
+    const hasStarted = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    let releaseCleanup!: () => void;
+    const cleanupGate = new Promise<void>((resolve) => {
+      releaseCleanup = resolve;
+    });
+    let cleanupFinished = false;
+    setupBtw(harness.pi, {
+      answerQuestion: async (value) => {
+        started();
+        return new Promise<string>((_resolve, reject) => {
+          value.signal?.onAbort(() => {
+            void cleanupGate.then(() => {
+              cleanupFinished = true;
+              reject(new Error("cancelled after cleanup"));
+            });
+          });
+        });
+      },
+    });
+
+    const invocation = harness.command().handler("question", context.ctx);
+    await hasStarted;
+    await invocation;
+    let shutdownSettled = false;
+    const shutdown = harness.emitSessionShutdown().then(() => {
+      shutdownSettled = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(shutdownSettled).toBe(false);
+
+    releaseCleanup();
+    await shutdown;
+    expect(cleanupFinished).toBe(true);
+    expect(harness.entries).toHaveLength(0);
   });
 
   test("drops an answer when parent tree navigation changes the active branch", async () => {
@@ -835,9 +923,10 @@ describe("BTW parent command", () => {
       .command()
       .handler("old question", oldContext.ctx);
     await hasStarted;
-    await harness.emitSessionShutdown();
-    await harness.emitSessionStart();
+    const shutdown = harness.emitSessionShutdown();
     release("late answer");
+    await shutdown;
+    await harness.emitSessionStart();
     await invocation;
     await new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -871,6 +960,7 @@ describe("BTW parent command", () => {
     expect(context.notifications[0]?.message).toContain("exceeds");
 
     await harness.command().handler("bounded", context.ctx);
+    await waitFor(() => harness.entries.length === 1);
     const data = harness.entries[0].data as BtwHistoryData;
     expect(data.answerTruncated).toBe(true);
     expect(Buffer.byteLength(data.answer, "utf8")).toBeLessThanOrEqual(
@@ -892,6 +982,7 @@ describe("BTW parent command", () => {
     });
 
     await harness.command().handler("rpc question", context.ctx);
+    await waitFor(() => harness.entries.length === 1);
     expect(harness.entries).toHaveLength(1);
     expect(
       context.notifications.some(({ message }) =>
@@ -908,6 +999,7 @@ describe("BTW parent command", () => {
       answerQuestion: async () => "answer\u001b]2;owned\u0007safe",
     });
     await harness.command().handler("question\u001b[31mred", context.ctx);
+    await waitFor(() => harness.entries.length === 1);
     const data = harness.entries[0].data as BtwHistoryData;
     expect(JSON.stringify(data)).not.toContain("\u001b");
 
@@ -938,9 +1030,45 @@ describe("BTW parent command", () => {
     });
     await emptyHarness.command().handler("\u001b[31m", emptyContext.ctx);
     expect(calls).toBe(0);
+    const notificationCount = emptyContext.notifications.length;
     await emptyHarness.command().handler("visible", emptyContext.ctx);
+    await waitFor(() => emptyContext.notifications.length > notificationCount);
+    expect(emptyContext.notifications.at(-1)?.message).toContain(
+      "no displayable text answer",
+    );
     expect(calls).toBe(1);
     expect(emptyHarness.entries).toHaveLength(0);
+  });
+
+  test("sanitizes and bounds failures from input and child execution", async () => {
+    const rawError = `bad\u001b]2;owned\u0007${"x".repeat(
+      ERROR_MAX_BYTES * 2,
+    )}`;
+    for (const source of ["input", "child"] as const) {
+      const harness = commandHarness();
+      const context = commandContext({ idle: true });
+      if (source === "input") {
+        context.ctx.ui.input = async () => {
+          throw new Error(rawError);
+        };
+      }
+      setupBtw(harness.pi, {
+        answerQuestion: async () => {
+          throw new Error(rawError);
+        },
+      });
+
+      await harness
+        .command()
+        .handler(source === "input" ? "" : "question", context.ctx);
+      await waitFor(() => context.notifications.length > 0);
+      const message = context.notifications.at(-1)?.message ?? "";
+      expect(message).not.toContain("\u001b");
+      expect(Buffer.byteLength(message, "utf8")).toBeLessThanOrEqual(
+        ERROR_MAX_BYTES + Buffer.byteLength("BTW failed: ", "utf8"),
+      );
+      expect(message).toEndWith("…");
+    }
   });
 
   test("renders malformed resumed history defensively", () => {

--- a/tests/pi-harness/btw.test.ts
+++ b/tests/pi-harness/btw.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { UserMessage } from "@earendil-works/pi-ai/compat";
 import {
@@ -43,6 +46,17 @@ const userMessage = (text: string): UserMessage => ({
   content: [{ type: "text", text }],
   timestamp: 1,
 });
+
+const waitFor = async (
+  predicate: () => boolean,
+  timeoutMs = 1_000,
+): Promise<void> => {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("timed out waiting for BTW");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+};
 
 const assistantMessage = (
   text: string,
@@ -332,12 +346,15 @@ interface CommandHarness {
   shortcut: (name: string) => (ctx: ExtensionContext) => Promise<void> | void;
   renderer: () => EntryRenderer<BtwHistoryData>;
   entries: { customType: string; data: unknown }[];
+  emitSessionBeforeTree(): Promise<void>;
   emitSessionCompact(ctx: ExtensionCommandContext): Promise<void>;
   emitSessionStart(): Promise<void>;
   emitSessionShutdown(): Promise<void>;
 }
 
-const commandHarness = (): CommandHarness => {
+const commandHarness = (
+  onAppend?: (customType: string, data: unknown) => void,
+): CommandHarness => {
   const commands = new Map<string, RegisteredCommand>();
   const shortcuts = new Map<
     string,
@@ -350,6 +367,7 @@ const commandHarness = (): CommandHarness => {
         ctx: ExtensionCommandContext,
       ) => Promise<void> | void)
     | undefined;
+  let beforeTreeHandler: (() => Promise<void> | void) | undefined;
   let startHandler: (() => Promise<void> | void) | undefined;
   let shutdownHandler: (() => Promise<void> | void) | undefined;
   const entries: { customType: string; data: unknown }[] = [];
@@ -358,6 +376,7 @@ const commandHarness = (): CommandHarness => {
       if (event === "session_compact") {
         compactHandler = handler as unknown as typeof compactHandler;
       }
+      if (event === "session_before_tree") beforeTreeHandler = handler;
       if (event === "session_start") startHandler = handler;
       if (event === "session_shutdown") shutdownHandler = handler;
     },
@@ -388,6 +407,7 @@ const commandHarness = (): CommandHarness => {
     },
     appendEntry(customType: string, data: unknown) {
       entries.push({ customType, data });
+      onAppend?.(customType, data);
     },
     getThinkingLevel: () => "high" as const,
   } as unknown as PiLike;
@@ -408,6 +428,9 @@ const commandHarness = (): CommandHarness => {
       return renderer;
     },
     entries,
+    emitSessionBeforeTree: async () => {
+      await beforeTreeHandler?.();
+    },
     emitSessionCompact: async (ctx) => {
       await compactHandler?.({ type: "session_compact" }, ctx);
     },
@@ -484,6 +507,7 @@ describe("BTW parent command", () => {
     });
 
     await harness.command().handler("  side question  ", context.ctx);
+    await waitFor(() => harness.entries.length === 1);
 
     expect(context.order).toEqual(["wait", "answer"]);
     expect(received?.messages).toEqual([userMessage("main question")]);
@@ -595,6 +619,7 @@ describe("BTW parent command", () => {
     });
 
     await harness.command().handler("question", context.ctx);
+    await waitFor(() => context.order.includes("answer"));
     expect(context.order).toEqual(["wait", "wait", "answer"]);
   });
 
@@ -626,6 +651,7 @@ describe("BTW parent command", () => {
 
     release("done");
     await first;
+    await waitFor(() => harness.entries.length === 1);
     expect(harness.entries).toHaveLength(1);
   });
 
@@ -648,12 +674,15 @@ describe("BTW parent command", () => {
 
       const invocation = harness.command().handler("question", context.ctx);
       await hasStarted;
+      // The main command must return while its child is still running so the
+      // TUI can dispatch the cancellation slash command.
+      await invocation;
       if (cancel === "command") {
         await harness.command("btw-cancel").handler("", context.ctx);
       } else {
         await harness.shortcut("ctrl+alt+b")(context.ctx);
       }
-      await invocation;
+      await waitFor(() => context.statuses.at(-1)?.value === undefined);
 
       expect(harness.entries).toHaveLength(0);
       expect(context.statuses.at(-1)).toEqual({
@@ -665,6 +694,72 @@ describe("BTW parent command", () => {
           message.includes("cancellation requested"),
         ),
       ).toBe(true);
+    }
+  });
+
+  test("drops an answer when parent tree navigation changes the active branch", async () => {
+    const harness = commandHarness();
+    const context = commandContext({ idle: true });
+    let started!: () => void;
+    const hasStarted = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    let release!: (answer: string) => void;
+    setupBtw(harness.pi, {
+      answerQuestion: async () => {
+        started();
+        return new Promise<string>((resolve) => {
+          release = resolve;
+        });
+      },
+    });
+
+    const invocation = harness.command().handler("branch A", context.ctx);
+    await hasStarted;
+    await invocation;
+    await harness.emitSessionBeforeTree();
+    release("late branch A answer");
+    await waitFor(() => context.statuses.at(-1)?.value === undefined);
+
+    expect(harness.entries).toHaveLength(0);
+  });
+
+  test("requires a durable parent before retaining resumable history", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "pi-btw-session-"));
+    try {
+      const sessionManager = SessionManager.create("/repo", directory);
+      sessionManager.appendMessage(userMessage("first parent prompt"));
+      const context = commandContext({ idle: true });
+      Object.assign(context.ctx, { sessionManager });
+      const harness = commandHarness((customType, data) => {
+        sessionManager.appendCustomEntry(customType, data);
+      });
+      let calls = 0;
+      setupBtw(harness.pi, {
+        answerQuestion: async () => {
+          calls += 1;
+          return "durable answer";
+        },
+      });
+
+      await harness.command().handler("too early", context.ctx);
+      await waitFor(() => context.notifications.length > 0);
+      expect(calls).toBe(0);
+      expect(context.notifications.at(-1)?.message).toContain(
+        "not durable until the parent completes",
+      );
+      expect(harness.entries).toHaveLength(0);
+
+      sessionManager.appendMessage(assistantMessage("parent answer"));
+      await harness.command().handler("now durable", context.ctx);
+      await waitFor(() => harness.entries.length === 1);
+
+      const sessionFile = sessionManager.getSessionFile();
+      if (sessionFile === undefined) throw new Error("missing session file");
+      const persisted = await readFile(sessionFile, "utf8");
+      expect(persisted).toContain(`"customType":"${HISTORY_TYPE}"`);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
     }
   });
 
@@ -744,12 +839,14 @@ describe("BTW parent command", () => {
     await harness.emitSessionStart();
     release("late answer");
     await invocation;
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(harness.entries).toHaveLength(0);
     expect(oldContext.notifications).toHaveLength(0);
 
     const newContext = commandContext({ idle: true, mode: "rpc" });
     await harness.command().handler("new question", newContext.ctx);
+    await waitFor(() => harness.entries.length === 1);
     expect(calls).toBe(2);
     expect(harness.entries).toHaveLength(1);
     expect(harness.entries[0].data).toMatchObject({ answer: "fresh answer" });

--- a/tests/pi-harness/check-pi-imports.test.ts
+++ b/tests/pi-harness/check-pi-imports.test.ts
@@ -39,13 +39,20 @@ describe("check-pi-imports self-containment analysis", () => {
     );
   });
 
-  test("allows only pi-tui's documented root runtime import in pi-harness", () => {
-    expect(
-      check('import { visibleWidth } from "@earendil-works/pi-tui";'),
-    ).toEqual([]);
+  test("allows only documented root runtime imports in pi-harness", () => {
+    for (const specifier of [
+      "@earendil-works/pi-coding-agent",
+      "@earendil-works/pi-tui",
+    ]) {
+      expect(check(`import { x } from ${JSON.stringify(specifier)};`)).toEqual(
+        [],
+      );
+    }
 
     for (const specifier of [
       "@earendil-works/pi-ai",
+      "@earendil-works/pi-coding-agent/dist/index.js",
+      "@earendil-works/pi-coding-agent-evil",
       "@earendil-works/pi-tui/dist/index.js",
       "@earendil-works/pi-tui-evil",
     ]) {
@@ -56,14 +63,18 @@ describe("check-pi-imports self-containment analysis", () => {
   });
 
   test("does not grant the pi-harness runtime allowlist to codex-web", () => {
-    const source = 'import { visibleWidth } from "@earendil-works/pi-tui";';
-    const violations = collectViolations(
-      "index.ts",
-      join(CODEX_WEB_EXTENSION_ROOT, "index.ts"),
-      source,
-      CODEX_WEB_EXTENSION_ROOT,
-    );
-    expect(violations[0]).toContain("runtime import of @earendil-works/pi-tui");
+    for (const specifier of [
+      "@earendil-works/pi-coding-agent",
+      "@earendil-works/pi-tui",
+    ]) {
+      const violations = collectViolations(
+        "index.ts",
+        join(CODEX_WEB_EXTENSION_ROOT, "index.ts"),
+        `import { x } from ${JSON.stringify(specifier)};`,
+        CODEX_WEB_EXTENSION_ROOT,
+      );
+      expect(violations[0]).toContain(`runtime import of ${specifier}`);
+    }
   });
 
   test("flags a relative import that escapes the extension root", () => {

--- a/tests/pi-harness/fake-pi.ts
+++ b/tests/pi-harness/fake-pi.ts
@@ -69,6 +69,7 @@ interface HandlerStore {
   tool_call: PiEventHandler<"tool_call">[];
   tool_result: PiEventHandler<"tool_result">[];
   agent_settled: PiEventHandler<"agent_settled">[];
+  session_compact: PiEventHandler<"session_compact">[];
   session_shutdown: PiEventHandler<"session_shutdown">[];
   before_provider_request: PiEventHandler<"before_provider_request">[];
   after_provider_response: PiEventHandler<"after_provider_response">[];
@@ -86,11 +87,23 @@ export interface FakePi extends PiLike {
     payload: ToolResultEvent,
   ): Promise<ToolResultPatch | undefined>;
   emitAgentSettled(payload?: GenericEvent): Promise<void>;
+  emitSessionCompact(payload?: GenericEvent): Promise<void>;
   emitSessionShutdown(payload?: GenericEvent): Promise<void>;
   emitBeforeProviderRequest(payload: GenericEvent): Promise<void>;
   emitAfterProviderResponse(payload: GenericEvent): Promise<void>;
   /** Tools registered via registerTool, in order. */
   readonly tools: ToolDefLike[];
+  /** Extension command names registered through the public API. */
+  readonly commands: ReadonlySet<string>;
+  /** Extension shortcuts registered through the public API. */
+  readonly shortcuts: ReadonlySet<string>;
+  /** Custom-entry renderer names registered through the public API. */
+  readonly entryRenderers: ReadonlySet<string>;
+  /** Entries appended through the public extension API. */
+  readonly appendedEntries: readonly {
+    customType: string;
+    data: unknown;
+  }[];
   /** Notifications captured from ctx.ui.notify. */
   readonly notifications: Notification[];
   /** Widget lines captured from ctx.ui.setWidget, keyed by widget id. */
@@ -133,11 +146,16 @@ export function createFakePi(
     tool_call: [],
     tool_result: [],
     agent_settled: [],
+    session_compact: [],
     session_shutdown: [],
     before_provider_request: [],
     after_provider_response: [],
   };
   const tools: ToolDefLike[] = [];
+  const commands = new Set<string>();
+  const shortcuts = new Set<string>();
+  const entryRenderers = new Set<string>();
+  const appendedEntries: { customType: string; data: unknown }[] = [];
   const notifications: Notification[] = [];
   const widgets = new Map<string, string[] | undefined>();
   const confirmQueue: boolean[] = [];
@@ -214,6 +232,7 @@ export function createFakePi(
     tool_call: (handler) => store.tool_call.push(handler),
     tool_result: (handler) => store.tool_result.push(handler),
     agent_settled: (handler) => store.agent_settled.push(handler),
+    session_compact: (handler) => store.session_compact.push(handler),
     session_shutdown: (handler) => store.session_shutdown.push(handler),
     before_provider_request: (handler) =>
       store.before_provider_request.push(handler),
@@ -227,6 +246,21 @@ export function createFakePi(
     },
     registerTool(tool) {
       tools.push(tool);
+    },
+    registerCommand(name, _options) {
+      commands.add(name);
+    },
+    registerShortcut(shortcut, _options) {
+      shortcuts.add(shortcut);
+    },
+    registerEntryRenderer(customType, _renderer) {
+      entryRenderers.add(customType);
+    },
+    appendEntry(customType, data) {
+      appendedEntries.push({ customType, data });
+    },
+    getThinkingLevel() {
+      return "off";
     },
     async emitSessionStart(payload) {
       for (const handler of store.session_start) await handler(payload, ctx);
@@ -261,6 +295,9 @@ export function createFakePi(
     async emitAgentSettled(payload = { type: "agent_settled" }) {
       for (const handler of store.agent_settled) await handler(payload, ctx);
     },
+    async emitSessionCompact(payload = { type: "session_compact" }) {
+      for (const handler of store.session_compact) await handler(payload, ctx);
+    },
     async emitSessionShutdown(payload = { type: "session_shutdown" }) {
       for (const handler of store.session_shutdown) await handler(payload, ctx);
     },
@@ -275,6 +312,10 @@ export function createFakePi(
       }
     },
     tools,
+    commands,
+    shortcuts,
+    entryRenderers,
+    appendedEntries,
     notifications,
     widgets,
     renderFooter(width) {

--- a/tests/pi-harness/fake-pi.ts
+++ b/tests/pi-harness/fake-pi.ts
@@ -33,6 +33,7 @@ import type {
   TuiLike,
   PiEventName,
   PiLike,
+  SessionBeforeTreeEvent,
   SessionStartEvent,
   ToolCallBlockResult,
   ToolCallEvent,
@@ -72,6 +73,7 @@ interface HandlerStore {
   tool_call: PiEventHandler<"tool_call">[];
   tool_result: PiEventHandler<"tool_result">[];
   agent_settled: PiEventHandler<"agent_settled">[];
+  session_before_tree: PiEventHandler<"session_before_tree">[];
   session_compact: PiEventHandler<"session_compact">[];
   session_shutdown: PiEventHandler<"session_shutdown">[];
   before_provider_request: PiEventHandler<"before_provider_request">[];
@@ -92,6 +94,7 @@ export interface FakePi extends PiLike {
     payload: ToolResultEvent,
   ): Promise<ToolResultPatch | undefined>;
   emitAgentSettled(payload?: GenericEvent): Promise<void>;
+  emitSessionBeforeTree(payload: SessionBeforeTreeEvent): Promise<void>;
   emitSessionCompact(payload?: GenericEvent): Promise<void>;
   emitSessionShutdown(payload?: GenericEvent): Promise<void>;
   emitBeforeProviderRequest(payload: GenericEvent): Promise<void>;
@@ -153,6 +156,7 @@ export function createFakePi(
     tool_call: [],
     tool_result: [],
     agent_settled: [],
+    session_before_tree: [],
     session_compact: [],
     session_shutdown: [],
     before_provider_request: [],
@@ -241,6 +245,7 @@ export function createFakePi(
     tool_call: (handler) => store.tool_call.push(handler),
     tool_result: (handler) => store.tool_result.push(handler),
     agent_settled: (handler) => store.agent_settled.push(handler),
+    session_before_tree: (handler) => store.session_before_tree.push(handler),
     session_compact: (handler) => store.session_compact.push(handler),
     session_shutdown: (handler) => store.session_shutdown.push(handler),
     before_provider_request: (handler) =>
@@ -311,6 +316,11 @@ export function createFakePi(
     },
     async emitAgentSettled(payload = { type: "agent_settled" }) {
       for (const handler of store.agent_settled) await handler(payload, ctx);
+    },
+    async emitSessionBeforeTree(payload) {
+      for (const handler of store.session_before_tree) {
+        await handler(payload, ctx);
+      }
     },
     async emitSessionCompact(payload = { type: "session_compact" }) {
       for (const handler of store.session_compact) await handler(payload, ctx);


### PR DESCRIPTION
## Summary

- add `/btw` to answer side questions from a stable snapshot in an extension-free, in-memory read-only child
- retain sanitized Q/A only as parent custom entries, including replay after compaction, without adding it to parent model context
- add cancellation, RPC visibility, stale-session protection, import-gate compatibility, and focused lifecycle tests

## Behavior

- child tools are limited to built-in `read` and `ls`; shell and file mutations are unavailable
- no independently resumable child session is written, so deleting the parent also removes BTW history
- `/btw-cancel`, `Ctrl+Alt+B`, and parent shutdown abort active requests

## Verification

- `bun run run-all`
- `bun run check:pi-compat`
- `bun test tests/pi-harness/btw.test.ts`
