### PR TITLE
fix(pi): make codex-reviewer invocations permission-safe

### DIFF
--- a/claude/.claude/agents/codex-reviewer.md
+++ b/claude/.claude/agents/codex-reviewer.md
@@ -29,62 +29,105 @@ between the `---` delimiters when present, otherwise use the prompt body.
 
 ### Phase 2: Codex Invocation
 
-**Content review** (plan, design, findings — the default): pass the review prompt
-with the artifact via stdin:
+**Content review** (plan, design, findings — the default): keep the large
+prompt out of the Bash command, then pass one short literal instruction through
+an explicitly allowed pipeline.
 
-```bash
-~/.claude/hooks/lib/codex-stage.sh prompt --dir "$PWD" --timeout 600 << 'PROMPT_EOF'
-You are a software architecture reviewer.
-Review the following implementation plan from an expert perspective.
+1. Allocate an exclusive private temporary directory with this explicitly
+   allowed command:
 
-## Review Perspectives
+   ```bash
+   bun -e 'const { mkdtemp } = await import("node:fs/promises"); console.log(await mkdtemp("/tmp/codex-reviewer-"));'
+   ```
 
-1. **Technical Accuracy**: Is the proposed approach technically correct?
-2. **Potential Risks**: Are there overlooked edge cases or risks?
-3. **Design Quality**: Are the architectural choices appropriate? Are there better alternatives?
-4. **Implementation Feasibility**: Are the plan steps feasible with correct dependencies?
-5. **Performance Considerations**: Are there design issues that affect performance?
-6. **Maintainability**: Is the proposed design maintainable long-term?
+   Copy the concrete absolute directory printed by the command (for example,
+   `/tmp/codex-reviewer-a1B2C3`) into every following tool argument and command.
+   Do not capture it with a shell variable or command substitution. The
+   generated directory is mode `0700`, so concurrent reviewers cannot collide
+   and other local accounts cannot read the staged artifact.
 
-## Output Format
+   Use the `write` tool to create `<printed-directory>/prompt.md`; never write
+   the prompt directly into shared `/tmp`. Write the complete prompt and
+   artifact to that file:
 
-Use the following format:
+   ```text
+   You are a software architecture reviewer.
+   Review the following implementation plan from an expert perspective.
 
-## Summary
-[1-2 sentence overall assessment]
+   ## Review Perspectives
 
-## Strengths
-- [Good points]
+   1. **Technical Accuracy**: Is the proposed approach technically correct?
+   2. **Potential Risks**: Are there overlooked edge cases or risks?
+   3. **Design Quality**: Are the architectural choices appropriate? Are there better alternatives?
+   4. **Implementation Feasibility**: Are the plan steps feasible with correct dependencies?
+   5. **Performance Considerations**: Are there design issues that affect performance?
+   6. **Maintainability**: Is the proposed design maintainable long-term?
 
-## Issues
+   ## Output Format
 
-### [Category]: [Specific issue]
-**Severity**: Critical / High / Medium / Low
-**Location**: [Section]
-**Problem**: [What is wrong]
-**Suggestion**: [How to fix]
+   Use the following format:
 
-## Recommendations
-[Prioritized list of improvement suggestions]
+   ## Summary
+   [1-2 sentence overall assessment]
 
----
+   ## Strengths
+   - [Good points]
 
-Artifact to review:
+   ## Issues
 
-<extracted artifact content here>
-PROMPT_EOF
-```
+   ### [Category]: [Specific issue]
+   **Severity**: Critical / High / Medium / Low
+   **Location**: [Section]
+   **Problem**: [What is wrong]
+   **Suggestion**: [How to fix]
+
+   ## Recommendations
+   [Prioritized list of improvement suggestions]
+
+   ---
+
+   Artifact to review:
+
+   <extracted artifact content here>
+   ```
+
+2. When the child process already has the desired working directory, rely on
+   the wrapper's `DIR=$PWD` default. This is the preferred command:
+
+   ```bash
+   printf '%s' 'Read /tmp/codex-reviewer-a1B2C3/prompt.md completely and follow it exactly.' |
+     ~/.claude/hooks/lib/codex-stage.sh prompt --timeout 600
+   ```
+
+   When a different directory is required, paste its concrete absolute path as
+   one properly shell-quoted literal argument after `--dir`:
+
+   ```bash
+   printf '%s' 'Read /tmp/codex-reviewer-a1B2C3/prompt.md completely and follow it exactly.' |
+     ~/.claude/hooks/lib/codex-stage.sh prompt --dir '/literal/absolute path' --timeout 600
+   ```
+
+   Never use a heredoc, here-string, input redirection, `--dir "$PWD"`, a shell
+   variable, or command substitution for these child invocations. Those forms
+   do not match the deterministic explicit-allow contract.
+
+3. After the wrapper returns (success or failure), remove the private directory
+   with its concrete literal path through the explicitly allowed `bun` command:
+
+   ```bash
+   bun -e 'const { rm } = await import("node:fs/promises"); await rm("/tmp/codex-reviewer-a1B2C3", { recursive: true, force: true });'
+   ```
 
 **Diff review** (uncommitted changes, a branch, or a single commit): use the
 first-class review mode instead of pasting the diff into a prompt:
 
 ```bash
 # uncommitted changes in a repo / worktree
-~/.claude/hooks/lib/codex-stage.sh review --uncommitted --dir <repo-or-worktree-abs-path>
+~/.claude/hooks/lib/codex-stage.sh review --uncommitted --dir '<repo-or-worktree-abs-path>'
 
 # a branch against its base, or a single commit
-~/.claude/hooks/lib/codex-stage.sh review --base main --dir <repo-abs-path>
-~/.claude/hooks/lib/codex-stage.sh review --commit <sha> --dir <repo-abs-path>
+~/.claude/hooks/lib/codex-stage.sh review --base main --dir '<repo-abs-path>'
+~/.claude/hooks/lib/codex-stage.sh review --commit '<sha>' --dir '<repo-abs-path>'
 ```
 
 Note: `codex exec review` accepts no `--sandbox`/`-C` flags — the wrapper enters
@@ -115,5 +158,5 @@ gap), 124 = timed out.
   disabled — that is a harness sandbox restriction, not a wrapper defect
 - Never pass `-m` — `~/.codex/config.toml` owns model selection
 - Privacy: the artifact and any repo files codex reads are sent to OpenAI
-- Fallback if the wrapper is missing: `codex exec --sandbox read-only --ephemeral -`
-  with the prompt heredoc piped to stdin
+- If the wrapper is missing, report that failure; never bypass it by invoking
+  `codex` directly

--- a/pi/skills/start-work/references/multi-model-workflows.md
+++ b/pi/skills/start-work/references/multi-model-workflows.md
@@ -103,6 +103,23 @@ validator:
 - All codex invocations go through `~/.claude/hooks/lib/codex-stage.sh`
   (auth preflight, portable timeout, `--ephemeral` for parallel safety, never
   `-m` — `~/.codex/config.toml` owns model selection).
+- Reviewer `prompt` commands in non-interactive children must match the
+  deterministic permission contract:
+  - For a short literal prompt, use
+    `printf '%s' '<instruction>' | ~/.claude/hooks/lib/codex-stage.sh prompt --timeout 600`
+    from the desired cwd, or add one properly shell-quoted literal
+    `--dir '/literal/absolute path'` argument.
+  - For a large prompt or artifact, first use the explicitly allowed
+    `bun -e`/`node:fs/promises` `mkdtemp` command from `codex-reviewer.md` to
+    allocate an exclusive mode-`0700` `/tmp/codex-reviewer-*` directory. Paste
+    the printed path literally (never through shell expansion), use the `write`
+    tool to create its `prompt.md`, and pipe only the short literal instruction
+    `Read /tmp/.../prompt.md completely and follow it exactly.` through the same
+    command. Clean up the private directory afterward with the documented
+    literal-path `bun -e` removal command.
+  - Never use a heredoc, here-string, input redirection, `--dir "$PWD"`, a
+    shell variable, or command substitution. Do not replace the wrapper with a
+    direct `codex` fallback.
 - For codex reviewer lens diversity use `prompt` mode (a focused prompt on
   stdin); `review` mode is a single holistic diff pass and takes no focus, so
   use it at most once per fan-out stage.
@@ -141,7 +158,10 @@ validator:
 
 Every reviewer is codex; you synthesize after the automatic background-
 completion message arrives, not after the immediate acceptance result. Replace
-`<REPO>` with the absolute path to the repo or worktree under review.
+`<REPO>` with the concrete absolute path to the repo or worktree under review
+before submitting the plan. Replace the entire `'<REPO>'` token with that path
+properly shell-quoted as one literal `--dir` argument; the child must not
+substitute `$PWD`, a shell variable, or `$(...)`.
 
 ```json
 {
@@ -152,15 +172,15 @@ completion message arrives, not after the immediate acceptance result. Replace
       "tasks": [
         {
           "agentType": "codex-reviewer",
-          "task": "Holistically review the uncommitted changes in <REPO>. Run: ~/.claude/hooks/lib/codex-stage.sh review --uncommitted --dir <REPO> (Bash timeout 600000 ms). Report codex's findings faithfully, each with severity (Critical|High|Medium|Low), file:line, problem, and suggestion. Label the report reviewer=codex:holistic."
+          "task": "Holistically review the uncommitted changes in <REPO>. Run: ~/.claude/hooks/lib/codex-stage.sh review --uncommitted --dir '<REPO>' (Bash timeout 600000 ms). Report codex's findings faithfully, each with severity (Critical|High|Medium|Low), file:line, problem, and suggestion. Label the report reviewer=codex:holistic."
         },
         {
           "agentType": "codex-reviewer",
-          "task": "Review the uncommitted changes in <REPO> for CORRECTNESS BUGS only. Run codex in prompt mode: printf '%s' 'Read the uncommitted diff (git diff) in this repository and report ONLY correctness bugs — logic errors, missing cases, broken invariants, off-by-one — each with file:line.' | ~/.claude/hooks/lib/codex-stage.sh prompt --dir <REPO> --timeout 600 (Bash timeout 600000 ms). Label the report reviewer=codex:correctness."
+          "task": "Review the uncommitted changes in <REPO> for CORRECTNESS BUGS only. Run codex in prompt mode: printf '%s' 'Read the uncommitted diff (git diff) in this repository and report ONLY correctness bugs — logic errors, missing cases, broken invariants, off-by-one — each with file:line.' | ~/.claude/hooks/lib/codex-stage.sh prompt --dir '<REPO>' --timeout 600 (Bash timeout 600000 ms). Label the report reviewer=codex:correctness."
         },
         {
           "agentType": "codex-reviewer",
-          "task": "Review the uncommitted changes in <REPO> for CONVENTION VIOLATIONS and risky patterns only. Run codex in prompt mode: printf '%s' 'Read the uncommitted diff (git diff) in this repository and report ONLY convention violations and risky patterns, each with file:line.' | ~/.claude/hooks/lib/codex-stage.sh prompt --dir <REPO> --timeout 600 (Bash timeout 600000 ms). Label the report reviewer=codex:conventions."
+          "task": "Review the uncommitted changes in <REPO> for CONVENTION VIOLATIONS and risky patterns only. Run codex in prompt mode: printf '%s' 'Read the uncommitted diff (git diff) in this repository and report ONLY convention violations and risky patterns, each with file:line.' | ~/.claude/hooks/lib/codex-stage.sh prompt --dir '<REPO>' --timeout 600 (Bash timeout 600000 ms). Label the report reviewer=codex:conventions."
         }
       ]
     }
@@ -220,11 +240,11 @@ verification).
       "tasks": [
         {
           "agentType": "codex-reviewer",
-          "task": "The implement stage's PoC reports (with each builder's worktree absolute path) follow:\n{previous}\nReview the PoC labeled builder=codex:direct: find its worktree absolute path in the reports above, then run: ~/.claude/hooks/lib/codex-stage.sh review --uncommitted --dir <that worktree> (Bash timeout 600000 ms). Report findings with severity and file:line; note builder=codex:direct."
+          "task": "The implement stage's PoC reports (with each builder's worktree absolute path) follow:\n{previous}\nReview the PoC labeled builder=codex:direct: find its worktree absolute path in the reports above, then run: ~/.claude/hooks/lib/codex-stage.sh review --uncommitted --dir '<that worktree>' (Bash timeout 600000 ms). Report findings with severity and file:line; note builder=codex:direct."
         },
         {
           "agentType": "codex-reviewer",
-          "task": "The implement stage's PoC reports (with each builder's worktree absolute path) follow:\n{previous}\nReview the PoC labeled builder=codex:robust: find its worktree absolute path in the reports above, then run: ~/.claude/hooks/lib/codex-stage.sh review --uncommitted --dir <that worktree> (Bash timeout 600000 ms). Report findings with severity and file:line; note builder=codex:robust."
+          "task": "The implement stage's PoC reports (with each builder's worktree absolute path) follow:\n{previous}\nReview the PoC labeled builder=codex:robust: find its worktree absolute path in the reports above, then run: ~/.claude/hooks/lib/codex-stage.sh review --uncommitted --dir '<that worktree>' (Bash timeout 600000 ms). Report findings with severity and file:line; note builder=codex:robust."
         }
       ]
     }
@@ -242,8 +262,10 @@ delegate it to a plan stage.
 The PoC worktree paths are engine-assigned and unknown when you write the plan,
 so the review tasks reference them through `{previous}` — the engine splices the
 implement stage's reports (including each worktree absolute path) into the
-review prompts at run time. This keeps the implement→review flow in a single
-`workflow` call.
+review prompts at run time. The reviewer must copy the selected concrete path
+as one properly shell-quoted literal `--dir '/absolute path'` argument, never
+through a shell variable or substitution. This keeps the implement→review flow
+in a single `workflow` call.
 
 An optional Claude PoC is +α: append to the implement roster a Claude-family
 task with `"isolation": "worktree"` — the codex PoCs remain the mandatory
@@ -270,13 +292,13 @@ into.
           "agentType": "codex-runner",
           "cwd": "<REPO>/packages/a",
           "writeScope": ["packages/a"],
-          "task": "Delegate this write task to codex, scoped to <REPO>/packages/a (--dir). Touch ONLY files under packages/a; do not write outside it. Spec: <what to create/modify under packages/a, and how to verify>. Run: ~/.claude/hooks/lib/codex-stage.sh run --dir <REPO>/packages/a --timeout 600 (task on stdin; Bash timeout 600000 ms). Report codex's summary, git diff --stat, and status (complete or incomplete)."
+          "task": "Delegate this write task to codex, scoped to <REPO>/packages/a (--dir). Touch ONLY files under packages/a; do not write outside it. Spec: <what to create/modify under packages/a, and how to verify>. Run: ~/.claude/hooks/lib/codex-stage.sh run --dir '<REPO>/packages/a' --timeout 600 (task on stdin; Bash timeout 600000 ms). Report codex's summary, git diff --stat, and status (complete or incomplete)."
         },
         {
           "agentType": "codex-runner",
           "cwd": "<REPO>/packages/b",
           "writeScope": ["packages/b"],
-          "task": "Delegate this write task to codex, scoped to <REPO>/packages/b (--dir). Touch ONLY files under packages/b; do not write outside it. Spec: <what to create/modify under packages/b, and how to verify>. Run: ~/.claude/hooks/lib/codex-stage.sh run --dir <REPO>/packages/b --timeout 600 (task on stdin; Bash timeout 600000 ms). Report codex's summary, git diff --stat, and status (complete or incomplete)."
+          "task": "Delegate this write task to codex, scoped to <REPO>/packages/b (--dir). Touch ONLY files under packages/b; do not write outside it. Spec: <what to create/modify under packages/b, and how to verify>. Run: ~/.claude/hooks/lib/codex-stage.sh run --dir '<REPO>/packages/b' --timeout 600 (task on stdin; Bash timeout 600000 ms). Report codex's summary, git diff --stat, and status (complete or incomplete)."
         }
       ]
     },
@@ -286,7 +308,7 @@ into.
       "tasks": [
         {
           "agentType": "codex-reviewer",
-          "task": "Review the aggregate uncommitted changes in <REPO>. Run: ~/.claude/hooks/lib/codex-stage.sh review --uncommitted --dir <REPO> (Bash timeout 600000 ms). This aggregate review is the authoritative view of the parallel writes (per-runner diffstats overlap). Report findings with severity and file:line."
+          "task": "Review the aggregate uncommitted changes in <REPO>. Run: ~/.claude/hooks/lib/codex-stage.sh review --uncommitted --dir '<REPO>' (Bash timeout 600000 ms). This aggregate review is the authoritative view of the parallel writes (per-runner diffstats overlap). Report findings with severity and file:line."
         }
       ]
     }
@@ -301,6 +323,24 @@ codex-sandbox-enforced (writable root = the `--dir` target). Nothing is
 committed — you decide what to keep from the aggregate diff.
 
 ## Wrapper quick reference
+
+Permission-safe reviewer prompt input:
+
+```bash
+# Desired cwd is already active: omit --dir so both pipeline segments are explicit allows.
+printf '%s' 'Review the uncommitted diff for correctness bugs only.' |
+  ~/.claude/hooks/lib/codex-stage.sh prompt --timeout 600
+
+# A different cwd: replace the example with one shell-quoted literal absolute path.
+printf '%s' 'Review the uncommitted diff for correctness bugs only.' |
+  ~/.claude/hooks/lib/codex-stage.sh prompt --dir '/literal/absolute path' --timeout 600
+```
+
+For a large artifact, first allocate the private directory with the documented
+`mkdtemp` command, write its `prompt.md`, and change the literal instruction to
+`Read /tmp/codex-reviewer-a1B2C3/prompt.md completely and follow it exactly.`
+The `codex-reviewer` agent definition contains the matching literal-path cleanup
+command.
 
 ```bash
 ~/.claude/hooks/lib/codex-stage.sh review [--uncommitted | --base <branch> | --commit <sha>] --dir <abs> [--timeout <sec>]

--- a/tests/pi-harness/agent-loader.test.ts
+++ b/tests/pi-harness/agent-loader.test.ts
@@ -2,7 +2,11 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { spawn } from "node:child_process";
 import { existsSync, promises as fs, readFileSync } from "node:fs";
 import { join } from "node:path";
-import type { HarnessConfig } from "../../pi/extensions/pi-harness/config";
+import {
+  DEFAULT_PERMISSION_JUDGE_CONFIG,
+  type HarnessConfig,
+} from "../../pi/extensions/pi-harness/config";
+import setupPermissionPolicy from "../../pi/extensions/pi-harness/features/permission-policy";
 import setupSubagent from "../../pi/extensions/pi-harness/features/subagent/index";
 import {
   CHILD_PERMISSION_SIGNAL_ENV,
@@ -576,6 +580,148 @@ describe("pi-harness subagent", () => {
       pi.ctx,
     );
     await expect(execution).rejects.toThrow(/stopReason length/);
+  });
+
+  test("runs the documented codex-reviewer pipeline in a non-interactive child", async () => {
+    const home = await makeTempDirectory("pi-subagent-codex-reviewer");
+    const agentsDirectory = resolvePaths(home).claudeAgentsDir;
+    const wrapperDirectory = join(home, ".claude", "hooks", "lib");
+    const wrapperPath = join(wrapperDirectory, "codex-stage.sh");
+    const privatePromptDirectory = join(home, "codex-reviewer-a1B2C3");
+    const promptArtifact = join(privatePromptDirectory, "prompt.md");
+    const receivedPrompt = join(home, "mock-codex-stdin.txt");
+    await fs.mkdir(agentsDirectory, { recursive: true });
+    await fs.mkdir(wrapperDirectory, { recursive: true });
+    await fs.mkdir(privatePromptDirectory, { mode: 0o700 });
+    await fs.copyFile(
+      join(import.meta.dir, "../../claude/.claude/agents/codex-reviewer.md"),
+      join(agentsDirectory, "codex-reviewer.md"),
+    );
+    await fs.writeFile(promptArtifact, "Review this integration artifact.");
+    await fs.writeFile(
+      wrapperPath,
+      [
+        "#!/bin/bash",
+        "set -euo pipefail",
+        'cat > "$MOCK_CODEX_STDIN"',
+        "printf '%s\\n' 'mock codex reached'",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    let policyDecision: Awaited<
+      ReturnType<ReturnType<typeof createFakePi>["emitToolCall"]>
+    > = undefined;
+    const spawnFn: SpawnFunction = (_command, args, launchOptions) => {
+      const promptFlag = args.indexOf("--append-system-prompt");
+      const instructions = readFileSync(args[promptFlag + 1] ?? "", "utf8");
+      const wrapperExamples = [
+        ...instructions.matchAll(/```bash\n([\s\S]*?)```/g),
+      ]
+        .map((match) => match[1] ?? "")
+        .filter((example) => example.includes("codex-stage.sh"))
+        .join("\n");
+      expect(wrapperExamples).not.toContain("<<");
+      expect(wrapperExamples).not.toContain('--dir "$PWD"');
+      const commandMatch =
+        /```bash\n[ \t]*(printf '%s' 'Read \/tmp\/codex-reviewer-a1B2C3\/prompt\.md completely and follow it exactly\.' \|\n[ \t]+~\/\.claude\/hooks\/lib\/codex-stage\.sh prompt --timeout 600)\n[ \t]*```/.exec(
+          instructions,
+        );
+      if (commandMatch?.[1] === undefined) {
+        throw new Error("documented default-cwd reviewer pipeline not found");
+      }
+      const documentedCommand = commandMatch[1].replaceAll(
+        "/tmp/codex-reviewer-a1B2C3/prompt.md",
+        promptArtifact,
+      );
+      const controller = createFakeProcess();
+      queueMicrotask(() => {
+        void (async () => {
+          try {
+            const childPi = createFakePi({
+              hasUI: false,
+              cwd: home,
+            });
+            setupPermissionPolicy(
+              childPi,
+              {
+                ...makeConfig(home),
+                isChild: true,
+                permissionJudge: {
+                  ...DEFAULT_PERMISSION_JUDGE_CONFIG,
+                  configurationError:
+                    "integration fallback judge must not be reached",
+                },
+              },
+              {
+                permissionSignalToken:
+                  launchOptions.env[CHILD_PERMISSION_SIGNAL_ENV],
+                writePermissionSignal: (text) => controller.emitStderr(text),
+              },
+            );
+            policyDecision = await childPi.emitToolCall({
+              type: "tool_call",
+              toolName: "bash",
+              toolCallId: "codex-reviewer-pipeline",
+              input: { command: documentedCommand },
+            });
+            if (policyDecision !== undefined) {
+              controller.emitStdout(
+                assistantEvent(`blocked: ${policyDecision.reason}`),
+              );
+              controller.close(0);
+              return;
+            }
+
+            const executed = Bun.spawnSync(["bash", "-c", documentedCommand], {
+              cwd: home,
+              env: {
+                ...launchOptions.env,
+                HOME: home,
+                MOCK_CODEX_STDIN: receivedPrompt,
+              },
+              stdout: "pipe",
+              stderr: "pipe",
+            });
+            const stderr = Buffer.from(executed.stderr).toString("utf8");
+            if (stderr !== "") controller.emitStderr(stderr);
+            controller.emitStdout(
+              assistantEvent(Buffer.from(executed.stdout).toString("utf8")),
+            );
+            controller.close(executed.exitCode);
+          } catch (error) {
+            controller.emitStderr(String(error));
+            controller.close(1);
+          }
+        })();
+      });
+      return controller.process;
+    };
+    const pi = createFakePi({ cwd: home });
+    setupSubagent(pi, makeConfig(home), { spawnFn });
+
+    const value = await executeTool(
+      pi.tools[0],
+      { agent: "codex-reviewer", task: "Review the test artifact" },
+      pi.ctx,
+    );
+    if (
+      !isRecord(value) ||
+      !isRecord(value.details) ||
+      !Array.isArray(value.details.results) ||
+      !isRecord(value.details.results[0])
+    ) {
+      throw new Error("Expected a spawned codex-reviewer result");
+    }
+    const [result] = value.details.results;
+
+    expect(policyDecision).toBeUndefined();
+    expect(result.permissionBlocked).toBeUndefined();
+    expect(result.failed).toBe(false);
+    expect(result.output).toContain("mock codex reached");
+    expect(await fs.readFile(receivedPrompt, "utf8")).toBe(
+      `Read ${promptArtifact} completely and follow it exactly.`,
+    );
   });
 
   test("treats a child permission block as failure even when pi exits zero", async () => {

--- a/tests/pi-harness/permission-rules.test.ts
+++ b/tests/pi-harness/permission-rules.test.ts
@@ -258,30 +258,56 @@ describe("explicit allow matching", () => {
     ),
   );
 
-  test("allows the documented printf-to-codex-stage prompt pipeline", () => {
+  test("allows the documented codex-reviewer staging, prompt, and cleanup commands", () => {
+    const instruction =
+      "printf '%s' 'Read /tmp/codex-reviewer-a1B2C3/prompt.md completely and follow it exactly.'";
+    for (const wrapper of [
+      "~/.claude/hooks/lib/codex-stage.sh prompt --timeout 600",
+      "~/.claude/hooks/lib/codex-stage.sh prompt --dir '/tmp/My Repo' --timeout 600",
+    ]) {
+      expect(
+        evaluateCommand(`${instruction} |\n  ${wrapper}`, productionRules)
+          .verdict,
+      ).toBe("allow");
+    }
+
+    const staging =
+      'bun -e \'const { mkdtemp } = await import("node:fs/promises"); console.log(await mkdtemp("/tmp/codex-reviewer-"));\'';
+    const cleanup =
+      'bun -e \'const { rm } = await import("node:fs/promises"); await rm("/tmp/codex-reviewer-a1B2C3", { recursive: true, force: true });\'';
+    expect(evaluateCommand(staging, productionRules).verdict).toBe("allow");
+    expect(evaluateCommand(cleanup, productionRules).verdict).toBe("allow");
+  });
+
+  test("does not widen the codex-stage allow to unsafe prompt forms", () => {
     const wrapper = "~/.claude/hooks/lib/codex-stage.sh prompt --dir /tmp";
-    expect(
-      evaluateCommand(`printf '%s' 'review this' | ${wrapper}`, productionRules)
-        .verdict,
-    ).toBe("allow");
     expect(
       evaluateCommand(
         `printf '%s' "$(bit relay sync)" | ${wrapper}`,
         productionRules,
       ).verdict,
     ).toBe("deny");
+    for (const command of [
+      `printf '%s' "$(cat ~/.ssh/id_ed25519)" | ${wrapper}`,
+      "printf '%s' 'review this' | /tmp/codex-stage.sh prompt",
+      `printf '%s' 'review this' | ~/.claude/hooks/lib/codex-stage.sh prompt --dir "$PWD"`,
+      "~/.claude/hooks/lib/codex-stage.sh prompt <<< 'review this'",
+      "~/.claude/hooks/lib/codex-stage.sh prompt < /tmp/review-prompt.md",
+    ]) {
+      expect(evaluateCommand(command, productionRules).verdict).toBe(
+        "default-continue",
+      );
+    }
     expect(
       evaluateCommand(
-        `printf '%s' "$(cat ~/.ssh/id_ed25519)" | ${wrapper}`,
+        [
+          "~/.claude/hooks/lib/codex-stage.sh prompt << 'PROMPT_EOF'",
+          "review this",
+          "PROMPT_EOF",
+        ].join("\n"),
         productionRules,
       ).verdict,
-    ).toBe("default-continue");
-    expect(
-      evaluateCommand(
-        "printf '%s' 'review this' | /tmp/codex-stage.sh prompt",
-        productionRules,
-      ).verdict,
-    ).toBe("default-continue");
+    ).toBe("deny");
   });
 
   test.each([


### PR DESCRIPTION
## Summary

- replace the heredoc-based `codex-reviewer` prompt flow with deterministic explicit-allow pipelines
- stage large review prompts in exclusive private temporary directories and clean them up through allowed commands
- quote literal target directories, align workflow templates, and add policy plus non-interactive subagent regression coverage

## Testing

- `bun test` — 1152 passed, 2 gated skips
- focused permission-policy, subagent, workflow, and workflow-plan tests
- `bun run tsc`
- `bun run lint` — 0 errors
- `bun run check:pi-rules`
- `bun run check:pi-imports`
- `bun run check:codex-rules`
- `bun run check:codex-agents`
- Prettier check for all changed files

Closes #53
