### PR TITLE
feat(pi): enrich child-run TUI rendering

### DIFF
--- a/pi/extensions/pi-harness/features/child-runs/presentation.ts
+++ b/pi/extensions/pi-harness/features/child-runs/presentation.ts
@@ -1,8 +1,12 @@
+import type { ThemeColor } from "@earendil-works/pi-coding-agent";
 import {
-  stripTerminalControls,
-  truncateToWidth,
-  wrapPlainText,
-} from "../../lib/terminal-text";
+  Box,
+  Container,
+  Spacer,
+  Text,
+  type Component,
+} from "@earendil-works/pi-tui";
+import { stripTerminalControls } from "../../lib/terminal-text";
 import type {
   ChildRunRenderSummary,
   ChildRunStatus,
@@ -11,12 +15,7 @@ import type {
 } from "./model";
 import { decodePersistedChildRuns } from "./persistence";
 
-export interface ComponentLike {
-  render(width: number): string[];
-  invalidate(): void;
-  handleInput?(data: string): void;
-  dispose?(): void;
-}
+export type ComponentLike = Component;
 
 interface ToolResultLike {
   content?: unknown;
@@ -25,7 +24,20 @@ interface ToolResultLike {
 
 interface RenderOptionsLike {
   expanded?: boolean;
+  isPartial?: boolean;
 }
+
+interface RenderTheme {
+  fg(color: ThemeColor, text: string): string;
+  bold(text: string): string;
+}
+
+// pi always supplies a Theme. The identity fallback preserves direct renderer
+// use in tests and non-TUI compatibility shims that only exercise layout.
+const plainTheme: RenderTheme = {
+  fg: (_color, text) => text,
+  bold: (text) => text,
+};
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
@@ -41,22 +53,54 @@ const contentText = (content: unknown): string => {
     .join("\n");
 };
 
-export const statusIcon = (status: ChildRunStatus): string => {
-  switch (status) {
-    case "queued":
-      return "○";
-    case "running":
-      return "◌";
-    case "succeeded":
-      return "✓";
-    case "failed":
-      return "✗";
-    case "aborted":
-      return "■";
-    case "skipped":
-      return "–";
-  }
+const safeInline = (value: unknown, fallback: string): string => {
+  if (typeof value !== "string") return fallback;
+  const sanitized = stripTerminalControls(value, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return sanitized === "" ? fallback : sanitized;
 };
+
+const safeBlock = (value: string): string => stripTerminalControls(value);
+
+const childRunStatuses: readonly ChildRunStatus[] = [
+  "queued",
+  "running",
+  "succeeded",
+  "failed",
+  "aborted",
+  "skipped",
+];
+
+const safeStatus = (value: unknown): ChildRunStatus =>
+  typeof value === "string" &&
+  childRunStatuses.includes(value as ChildRunStatus)
+    ? (value as ChildRunStatus)
+    : "failed";
+
+const statusIcons: Record<ChildRunStatus, string> = {
+  queued: "○",
+  running: "◌",
+  succeeded: "✓",
+  failed: "✗",
+  aborted: "■",
+  skipped: "–",
+};
+
+export const statusIcon = (status: ChildRunStatus): string =>
+  statusIcons[status];
+
+const statusColors: Record<ChildRunStatus, ThemeColor> = {
+  queued: "dim",
+  running: "warning",
+  succeeded: "success",
+  failed: "error",
+  aborted: "warning",
+  skipped: "dim",
+};
+
+const statusColor = (status: ChildRunStatus): ThemeColor =>
+  statusColors[status];
 
 const summaryFromDetails = (
   details: unknown,
@@ -67,7 +111,7 @@ const summaryFromDetails = (
     }
   | undefined => {
   if (!isRecord(details) || !isRecord(details.childRuns)) return undefined;
-  const childRuns = details.childRuns;
+  const { childRuns } = details;
   if (childRuns.kind === "summary" && Array.isArray(childRuns.runs)) {
     const runs = childRuns.runs.filter((run): run is ChildRunRenderSummary =>
       isRecord(run),
@@ -99,54 +143,108 @@ export const persistedRows = (
   payload: PersistedChildRunsV1,
 ): PersistedChildRunV1[] => payload.runs;
 
-class PlainLinesComponent implements ComponentLike {
-  constructor(private readonly lines: string[]) {}
+const countStatuses = (
+  runs: ChildRunRenderSummary[],
+  status: ChildRunStatus,
+): number => runs.filter((run) => safeStatus(run.status) === status).length;
 
-  render(width: number): string[] {
-    if (width <= 0) return [""];
-    return this.lines.flatMap((line) =>
-      wrapPlainText(stripTerminalControls(line), width).map((wrapped) =>
-        truncateToWidth(wrapped, width, ""),
-      ),
-    );
-  }
+const renderHeader = (
+  label: string,
+  runs: ChildRunRenderSummary[],
+  theme: RenderTheme,
+): Text => {
+  const completed = runs.filter((run) => {
+    const status = safeStatus(run.status);
+    return status !== "queued" && status !== "running";
+  }).length;
+  const counters = childRunStatuses.flatMap((status) => {
+    const count = countStatuses(runs, status);
+    return count === 0
+      ? []
+      : [theme.fg(statusColor(status), `${statusIcon(status)}${count}`)];
+  });
+  const title = theme.fg(
+    "toolTitle",
+    theme.bold(safeInline(label, "child runs")),
+  );
+  const progress = theme.fg("muted", `${completed}/${runs.length} finished`);
+  const counts = counters.length === 0 ? "" : `  ${counters.join("  ")}`;
+  return new Text(`${title} ${progress}${counts}`, 0, 0);
+};
 
-  invalidate(): void {}
-}
+const renderRun = (run: ChildRunRenderSummary, theme: RenderTheme): Text => {
+  const status = safeStatus(run.status);
+  const taskIndex =
+    Number.isSafeInteger(run.taskIndex) && run.taskIndex >= 0
+      ? run.taskIndex + 1
+      : 1;
+  const stageIndex =
+    Number.isSafeInteger(run.stageIndex) && (run.stageIndex ?? -1) >= 0
+      ? (run.stageIndex as number) + 1
+      : undefined;
+  const position =
+    stageIndex === undefined ? `${taskIndex}` : `S${stageIndex}/T${taskIndex}`;
+  const icon = theme.fg(statusColor(status), statusIcon(status));
+  const badge = theme.fg("accent", theme.bold(`[${position}]`));
+  const agent = theme.fg("toolTitle", safeInline(run.agent, "unknown agent"));
+  const task = theme.fg(
+    "toolOutput",
+    safeInline(run.taskPreview, "(no task preview)"),
+  );
+  const reason =
+    status === "succeeded" || run.terminalReason === undefined
+      ? ""
+      : ` ${theme.fg(statusColor(status), `(${safeInline(run.terminalReason, "unknown")})`)}`;
+  return new Text(`${icon} ${badge} ${agent} — ${task}${reason}`, 0, 0);
+};
 
 export const renderChildRunsResult = (
   result: ToolResultLike,
   options: RenderOptionsLike = {},
+  theme: RenderTheme = plainTheme,
+  _context?: unknown,
 ): ComponentLike => {
   const summary = summaryFromDetails(result.details);
   if (summary === undefined) {
-    return new PlainLinesComponent([contentText(result.content)]);
+    return new Text(
+      theme.fg("toolOutput", safeBlock(contentText(result.content))),
+      0,
+      0,
+    );
   }
-  const completed = summary.runs.filter(
-    (run) => run.status !== "queued" && run.status !== "running",
-  ).length;
-  const lines = [
-    `${summary.label}: ${completed}/${summary.runs.length} finished`,
-  ];
+
+  const root = new Container();
+  root.addChild(renderHeader(summary.label, summary.runs, theme));
+
+  const rows = new Box(1, 0);
   const visibleRuns = options.expanded
     ? summary.runs
     : summary.runs.slice(0, 8);
-  for (const run of visibleRuns) {
-    const stage =
-      run.stageIndex === undefined
-        ? `${run.taskIndex + 1}`
-        : `S${run.stageIndex + 1}/T${run.taskIndex + 1}`;
-    lines.push(
-      `${statusIcon(run.status)} ${stage} ${run.agent} — ${run.taskPreview}`,
+  for (const run of visibleRuns) rows.addChild(renderRun(run, theme));
+  if (visibleRuns.length < summary.runs.length) {
+    rows.addChild(
+      new Text(
+        theme.fg("dim", `… ${summary.runs.length - visibleRuns.length} more`),
+        0,
+        0,
+      ),
     );
   }
-  if (visibleRuns.length < summary.runs.length) {
-    lines.push(`… ${summary.runs.length - visibleRuns.length} more`);
-  }
+  root.addChild(rows);
+
   if (options.expanded) {
-    const original = contentText(result.content);
-    if (original !== "") lines.push("", "Result:", original);
+    const original = safeBlock(contentText(result.content));
+    if (original !== "") {
+      root.addChild(new Spacer(1));
+      root.addChild(new Text(theme.fg("muted", theme.bold("Result")), 0, 0));
+      const output = new Box(1, 0);
+      output.addChild(new Text(theme.fg("toolOutput", original), 0, 0));
+      root.addChild(output);
+    }
   }
-  lines.push("/subagents to inspect transcripts");
-  return new PlainLinesComponent(lines);
+
+  root.addChild(
+    new Text(theme.fg("dim", "↳ /subagents to inspect transcripts"), 0, 0),
+  );
+  return root;
 };

--- a/pi/extensions/pi-harness/features/child-runs/ui.ts
+++ b/pi/extensions/pi-harness/features/child-runs/ui.ts
@@ -1,9 +1,15 @@
+import type { ThemeColor } from "@earendil-works/pi-coding-agent";
+import {
+  Box,
+  Container,
+  Text,
+  truncateToWidth as truncateStyledToWidth,
+} from "@earendil-works/pi-tui";
 import type { CtxLike } from "../../lib/pi-like";
 import {
   stripTerminalControls,
   truncateToWidth,
   visibleWidth,
-  wrapPlainText,
 } from "../../lib/terminal-text";
 import type {
   ChildInvocationSnapshot,
@@ -72,9 +78,6 @@ type FlatRun = {
   run: LiveChildRun;
 };
 
-const statusLabel = (status: ChildRunStatus): string =>
-  `${statusIcon(status)} ${status}`;
-
 const flattenRuns = (snapshots: ChildInvocationSnapshot[]): FlatRun[] =>
   snapshots.flatMap((invocation) =>
     invocation.runs.map((run) => ({ invocation, run })),
@@ -92,44 +95,81 @@ const line = (value: string, width: number): string =>
 const taskOneLine = (task: string): string =>
   stripTerminalControls(task, " ").replace(/\s+/g, " ").trim();
 
-const wrapDetailLine = (value: string, width: number): string[] =>
-  wrapPlainText(stripTerminalControls(value), Math.max(1, width));
+interface ChildRunTheme {
+  fg(color: ThemeColor, text: string): string;
+  bg(color: "selectedBg", text: string): string;
+  bold(text: string): string;
+}
 
-const wrapDetailText = (
-  prefix: string,
-  value: string,
-  width: number,
-): string[] => {
-  const safeWidth = Math.max(1, width);
-  const safePrefix = stripTerminalControls(prefix, " ");
-  const safeValue = stripTerminalControls(value);
-  const prefixWidth = visibleWidth(safePrefix);
-  if (prefixWidth >= safeWidth) {
-    return wrapDetailLine(`${safePrefix}${safeValue}`, safeWidth);
-  }
-  const continuation = " ".repeat(prefixWidth);
-  return wrapPlainText(safeValue, safeWidth - prefixWidth).map(
-    (part, index) => `${index === 0 ? safePrefix : continuation}${part}`,
-  );
+const plainTheme: ChildRunTheme = {
+  fg: (_color, text) => text,
+  bg: (_color, text) => text,
+  bold: (text) => text,
 };
 
-const transcriptLines = (item: TranscriptItem, width: number): string[] => {
+const resolveTheme = (value: unknown): ChildRunTheme => {
+  if (typeof value !== "object" || value === null) return plainTheme;
+  const candidate = value as Partial<ChildRunTheme>;
+  return typeof candidate.fg === "function" &&
+    typeof candidate.bg === "function" &&
+    typeof candidate.bold === "function"
+    ? (candidate as ChildRunTheme)
+    : plainTheme;
+};
+
+const safeBlock = (value: string): string => stripTerminalControls(value);
+
+const styledLine = (value: string, width: number): string => {
+  const safeWidth = Math.max(1, width);
+  return value.includes("\u001b")
+    ? truncateStyledToWidth(value, safeWidth, "")
+    : truncateToWidth(value, safeWidth, "");
+};
+
+const statusColors: Record<ChildRunStatus, ThemeColor> = {
+  queued: "dim",
+  running: "warning",
+  succeeded: "success",
+  failed: "error",
+  aborted: "warning",
+  skipped: "dim",
+};
+
+const statusColor = (status: ChildRunStatus): ThemeColor =>
+  statusColors[status];
+
+const transcriptComponent = (
+  item: TranscriptItem,
+  theme: ChildRunTheme,
+): ComponentLike => {
   if (item.type === "assistant") {
-    return ["assistant:", ...wrapDetailText("  ", item.text, width)];
+    const assistant = new Container();
+    assistant.addChild(
+      new Text(theme.fg("accent", theme.bold("assistant")), 0, 0),
+    );
+    const body = new Box(1, 0);
+    body.addChild(new Text(theme.fg("toolOutput", safeBlock(item.text)), 0, 0));
+    assistant.addChild(body);
+    return assistant;
   }
   if (item.type === "tool") {
     let runStatus: ChildRunStatus = "succeeded";
     if (item.status === "running") runStatus = "running";
     else if (item.status === "failed") runStatus = "failed";
     else if (item.status === "interrupted") runStatus = "aborted";
-    return wrapDetailLine(
-      `${statusIcon(runStatus)} tool-${item.localId} ${item.name} (${item.status})`,
-      width,
-    );
+    const icon = theme.fg(statusColor(runStatus), statusIcon(runStatus));
+    const tool = theme.fg("accent", theme.bold(`tool-${item.localId}`));
+    const name = theme.fg("toolOutput", taskOneLine(item.name));
+    const status = theme.fg(statusColor(runStatus), `(${item.status})`);
+    return new Text(`${icon} ${tool} ${name} ${status}`, 0, 0);
   }
-  return wrapDetailLine(
-    `… transcript truncated (${item.omittedItems} items, ${item.omittedBytes} bytes omitted)`,
-    width,
+  return new Text(
+    theme.fg(
+      "warning",
+      `… transcript truncated (${item.omittedItems} items, ${item.omittedBytes} bytes omitted)`,
+    ),
+    0,
+    0,
   );
 };
 
@@ -282,41 +322,99 @@ export class ChildRunsBrowserComponent implements ComponentLike {
   }
 }
 
-const detailContentLines = (selected: FlatRun, width: number): string[] => {
+const detailContentLines = (
+  selected: FlatRun,
+  width: number,
+  theme: ChildRunTheme,
+): string[] => {
   const { invocation, run } = selected;
-  const lines: string[] = [
-    ...wrapDetailLine(`${run.agent} · ${statusLabel(run.status)}`, width),
-    ...wrapDetailLine(
-      `${invocation.label}${run.stageName ? ` · ${run.stageName}` : ""}`,
-      width,
+  const root = new Container();
+  const metadata = new Box(1, 0, (text) => theme.bg("selectedBg", text));
+  const status = theme.fg(
+    statusColor(run.status),
+    `${statusIcon(run.status)} ${run.status}`,
+  );
+  const reason =
+    run.terminalReason === undefined
+      ? ""
+      : theme.fg(
+          statusColor(run.status),
+          ` (${taskOneLine(run.terminalReason)})`,
+        );
+  metadata.addChild(
+    new Text(
+      `${theme.fg("toolTitle", theme.bold(taskOneLine(run.agent)))}  ${status}${reason}`,
+      0,
+      0,
     ),
-    ...wrapDetailText("task: ", taskOneLine(run.task), width),
-    "",
-  ];
+  );
+
+  const taskPosition = `T${run.taskIndex + 1}`;
+  const position =
+    run.stageIndex === undefined
+      ? taskPosition
+      : `S${run.stageIndex + 1}/${taskPosition}`;
+  const invocationParts = [
+    taskOneLine(invocation.label),
+    run.stageName === undefined ? undefined : taskOneLine(run.stageName),
+    position,
+  ].filter((part): part is string => part !== undefined && part !== "");
+  metadata.addChild(
+    new Text(theme.fg("muted", invocationParts.join(" · ")), 0, 0),
+  );
+  metadata.addChild(
+    new Text(
+      theme.fg("muted", theme.bold("task  ")) +
+        theme.fg("toolOutput", taskOneLine(run.task)),
+      0,
+      0,
+    ),
+  );
+  root.addChild(metadata);
+  root.addChild(new Text(theme.fg("accent", theme.bold("Transcript")), 0, 0));
+
+  const transcript = new Box(1, 0);
   for (const item of run.transcript) {
-    lines.push(...transcriptLines(item, width));
+    transcript.addChild(transcriptComponent(item, theme));
   }
   if (run.liveDraft) {
-    lines.push("assistant [live]:");
-    lines.push(...wrapDetailText("  ", run.liveDraft, width));
+    transcript.addChild(
+      new Text(theme.fg("warning", theme.bold("assistant LIVE")), 0, 0),
+    );
+    const draft = new Box(1, 0);
+    draft.addChild(
+      new Text(theme.fg("toolOutput", safeBlock(run.liveDraft)), 0, 0),
+    );
+    transcript.addChild(draft);
   }
   if (run.transcript.length === 0 && !run.liveDraft) {
-    lines.push(
-      ...wrapDetailLine(
-        run.status === "queued" ? "(not launched)" : "(no assistant text yet)",
-        width,
+    transcript.addChild(
+      new Text(
+        theme.fg(
+          "dim",
+          run.status === "queued"
+            ? "(not launched)"
+            : "(no assistant text yet)",
+        ),
+        0,
+        0,
       ),
     );
   }
   if (run.protocolWarnings > 0) {
-    lines.push(
-      ...wrapDetailLine(
-        `(${run.protocolWarnings} child stream warning(s))`,
-        width,
+    transcript.addChild(
+      new Text(
+        theme.fg(
+          "warning",
+          `(${run.protocolWarnings} child stream warning(s))`,
+        ),
+        0,
+        0,
       ),
     );
   }
-  return lines;
+  root.addChild(transcript);
+  return root.render(Math.max(1, width));
 };
 
 /** Focused, near-full-screen transcript viewer for one fixed child run. */
@@ -326,6 +424,7 @@ export class ChildRunDetailComponent implements ComponentLike {
   private lastMaxOffset = 0;
   private lastViewport = 1;
   private readonly unsubscribe: () => void;
+  private readonly theme: ChildRunTheme;
 
   constructor(
     private readonly registry: ChildRunRegistry,
@@ -333,7 +432,9 @@ export class ChildRunDetailComponent implements ComponentLike {
     private readonly tui: TuiLike,
     private readonly keybindings: KeybindingsLike,
     private readonly onClose: () => void,
+    theme?: unknown,
   ) {
+    this.theme = resolveTheme(theme);
     const initialStatus = findRun(this.registry.getSnapshots(), this.runId)?.run
       .status;
     this.follow = initialStatus === "queued" || initialStatus === "running";
@@ -355,11 +456,15 @@ export class ChildRunDetailComponent implements ComponentLike {
     const selected = findRun(this.registry.getSnapshots(), this.runId);
     const allLines =
       selected === undefined
-        ? wrapDetailLine(
-            "Selected child run is no longer available.",
-            safeWidth,
-          )
-        : detailContentLines(selected, safeWidth);
+        ? new Text(
+            this.theme.fg(
+              "warning",
+              "Selected child run is no longer available.",
+            ),
+            0,
+            0,
+          ).render(safeWidth)
+        : detailContentLines(selected, safeWidth, this.theme);
 
     this.lastMaxOffset = Math.max(0, allLines.length - viewport);
     if (this.follow) this.offset = this.lastMaxOffset;
@@ -370,24 +475,29 @@ export class ChildRunDetailComponent implements ComponentLike {
 
     const running = selected?.run.status === "running";
     let state = "";
-    if (running && this.follow) state = " · LIVE";
-    else if (!this.follow) state = " · PAUSED";
-    const title = ` Child session${state} `;
+    if (running && this.follow) {
+      state = this.theme.fg("warning", " · LIVE");
+    } else if (!this.follow) {
+      state = this.theme.fg("warning", " · PAUSED");
+    }
+    const title = `${this.theme.fg("toolTitle", this.theme.bold(" Child session"))}${state} `;
     const borderWidth = Math.max(1, safeWidth - visibleWidth(title));
+    const border = this.theme.fg("borderMuted", "─".repeat(borderWidth));
     const first = allLines.length === 0 ? 0 : this.offset + 1;
     const last = Math.min(allLines.length, this.offset + viewport);
     const position = `${first}-${last}/${allLines.length}`;
     const output: string[] = [];
     if (showTitle) {
-      output.push(line(`${title}${"─".repeat(borderWidth)}`, safeWidth));
+      output.push(styledLine(`${title}${border}`, safeWidth));
     }
-    output.push(...visible.map((item) => line(item, safeWidth)));
+    output.push(...visible.map((item) => styledLine(item, safeWidth)));
     if (showHint) {
+      const hint = this.theme.fg(
+        "dim",
+        "↑↓ scroll  PgUp/PgDn page  Home/End  Esc/←/b close  ",
+      );
       output.push(
-        line(
-          `↑↓ scroll  PgUp/PgDn page  Home/End  Esc/←/b close  ${position}`,
-          safeWidth,
-        ),
+        styledLine(`${hint}${this.theme.fg("muted", position)}`, safeWidth),
       );
     }
     return output.slice(0, height);
@@ -729,7 +839,7 @@ export class ChildRunsPanelController {
     let detailPromise: Promise<void>;
     try {
       detailPromise = ui.custom<void>(
-        (tui, _theme, keybindings, done) => {
+        (tui, theme, keybindings, done) => {
           let closed = false;
           const close = () => {
             if (closed) return;
@@ -743,6 +853,7 @@ export class ChildRunsPanelController {
             tui,
             keybindings,
             close,
+            theme,
           );
         },
         {

--- a/tests/pi-harness/child-run-presentation.test.ts
+++ b/tests/pi-harness/child-run-presentation.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "bun:test";
+import type { Theme, ThemeColor } from "@earendil-works/pi-coding-agent";
+import { renderChildRunsResult } from "../../pi/extensions/pi-harness/features/child-runs/presentation";
+import {
+  stripTerminalControls,
+  visibleWidth,
+} from "../../pi/extensions/pi-harness/lib/terminal-text";
+
+interface ToolResultLike {
+  content?: unknown;
+  details?: unknown;
+}
+
+const colorCodes: Partial<Record<ThemeColor, number>> = {
+  accent: 36,
+  success: 32,
+  error: 31,
+  warning: 33,
+  muted: 90,
+  dim: 90,
+  text: 37,
+  toolTitle: 35,
+  toolOutput: 37,
+};
+
+const theme = {
+  fg(color: ThemeColor, text: string): string {
+    return `\u001b[${colorCodes[color] ?? 37}m${text}\u001b[39m`;
+  },
+  bold(text: string): string {
+    return `\u001b[1m${text}\u001b[22m`;
+  },
+} as Theme;
+
+const summaryResult = (): ToolResultLike => ({
+  content: [{ type: "text", text: "full workflow result" }],
+  details: {
+    childRuns: {
+      kind: "summary",
+      label: "workflow",
+      runs: [
+        ["queued", "queued task"],
+        ["running", "running task"],
+        ["succeeded", "successful task"],
+        ["failed", "failed task", "model-error"],
+        ["aborted", "aborted task", "parent-abort"],
+        ["skipped", "skipped task", "dependency-failed"],
+        ["succeeded", "another successful task"],
+        ["running", "another running task"],
+        ["queued", "another queued task"],
+        ["failed", "another failed task", "setup-error"],
+      ].map(([status, taskPreview, terminalReason], taskIndex) => ({
+        runId: `run-${taskIndex}`,
+        agent: `agent-${taskIndex}`,
+        taskPreview,
+        taskIndex,
+        stageIndex: 0,
+        stageName: "review",
+        status,
+        terminalReason,
+      })),
+    },
+  },
+});
+
+const render = (
+  result: ToolResultLike,
+  options: { expanded?: boolean; isPartial?: boolean } = {},
+  width = 120,
+): { raw: string[]; plain: string[] } => {
+  const raw = renderChildRunsResult(result, options, theme, {} as never).render(
+    width,
+  );
+  return {
+    raw,
+    plain: raw.map((line) => stripTerminalControls(line).trimEnd()),
+  };
+};
+
+describe("rich child-run tool result rendering", () => {
+  test("styles a compact status summary and limits its run rows", () => {
+    const { raw, plain } = render(summaryResult());
+
+    expect(raw.join("\n")).toContain("\u001b[35m");
+    expect(plain[0]).toBe("workflow 6/10 finished  ○2  ◌2  ✓2  ✗2  ■1  –1");
+    expect(plain.some((line) => line.includes("[S1/T1] agent-0"))).toBe(true);
+    expect(
+      plain.some((line) => line.includes("failed task (model-error)")),
+    ).toBe(true);
+    expect(plain.some((line) => line.includes("agent-7"))).toBe(true);
+    expect(plain.some((line) => line.includes("agent-8"))).toBe(false);
+    expect(plain).toContain(" … 2 more");
+    expect(plain.at(-1)).toBe("↳ /subagents to inspect transcripts");
+  });
+
+  test("shows every run and the original result when expanded", () => {
+    const { plain } = render(summaryResult(), { expanded: true });
+
+    expect(plain.some((line) => line.includes("[S1/T10] agent-9"))).toBe(true);
+    expect(plain).not.toContain(" … 2 more");
+    expect(plain).toContain("Result");
+    expect(plain).toContain(" full workflow result");
+  });
+
+  test("sanitizes tool-controlled text while retaining theme styling", () => {
+    const result: ToolResultLike = {
+      content: [{ type: "text", text: "unused" }],
+      details: {
+        childRuns: {
+          kind: "summary",
+          label: "work\u001b]0;owned\u0007flow",
+          runs: [
+            {
+              runId: "run-1",
+              agent: "reviewer\tname",
+              taskPreview: "inspect\u001b[31m red\u001b[0m\nnext",
+              taskIndex: 0,
+              status: "running",
+            },
+          ],
+        },
+      },
+    };
+
+    const { raw, plain } = render(result, {}, 40);
+
+    expect(raw.join("\n")).toContain("\u001b[35m");
+    expect(raw.join("\n")).not.toContain("]0;owned");
+    expect(plain[0]).toContain("workflow 0/1 finished");
+    expect(plain.join("\n")).toContain("[1] reviewer name — inspect red next");
+    expect(raw.every((line) => visibleWidth(line) <= 40)).toBe(true);
+  });
+
+  test("uses a themed, sanitized, width-safe fallback for unknown details", () => {
+    const { raw, plain } = render(
+      {
+        content: [
+          {
+            type: "text",
+            text: "safe\u001b]0;owned\u0007 output with a very long tail",
+          },
+        ],
+        details: {},
+      },
+      {},
+      16,
+    );
+
+    expect(raw.join("\n")).toContain("\u001b[37m");
+    expect(raw.join("\n")).not.toContain("]0;owned");
+    expect(plain.join(" ")).toContain("safe output");
+    expect(raw.every((line) => visibleWidth(line) <= 16)).toBe(true);
+  });
+});

--- a/tests/pi-harness/child-run-ui.test.ts
+++ b/tests/pi-harness/child-run-ui.test.ts
@@ -9,7 +9,10 @@ import {
   ChildRunDetailComponent,
   ChildRunsBrowserComponent,
 } from "../../pi/extensions/pi-harness/features/child-runs/ui";
-import { visibleWidth } from "../../pi/extensions/pi-harness/lib/terminal-text";
+import {
+  stripTerminalControls,
+  visibleWidth,
+} from "../../pi/extensions/pi-harness/lib/terminal-text";
 
 describe("child-session private focus capability", () => {
   const component = { render: () => ["x"], invalidate() {} };
@@ -230,6 +233,78 @@ describe("child-session browser component", () => {
 });
 
 describe("child-session detail component", () => {
+  test("renders a themed metadata card and transcript status rows", () => {
+    const { registry, tui, keybindings } = setup(24);
+    const { runIds } = registry.beginInvocation({
+      toolCallId: "parent-themed",
+      source: "workflow",
+      mode: "single",
+      label: "review workflow\u001b]2;spoof\u0007",
+      runs: [
+        {
+          agent: "codex-reviewer",
+          task: "review the renderer",
+          taskIndex: 0,
+          stageIndex: 0,
+          stageName: "verification",
+        },
+      ],
+    });
+    const runId = runAt(runIds, 0);
+    registry.observe(runId, { type: "process_started", at: 1 });
+    registry.observe(runId, {
+      type: "tool_started",
+      localId: 1,
+      name: "read",
+      at: 2,
+    });
+    registry.observe(runId, {
+      type: "tool_finished",
+      localId: 1,
+      name: "read",
+      failed: true,
+      at: 3,
+    });
+    registry.observe(runId, {
+      type: "assistant_final",
+      text: "Found one actionable issue.",
+      at: 4,
+    });
+
+    const theme = {
+      fg(_color: string, text: string) {
+        return `\u001b[36m${text}\u001b[39m`;
+      },
+      bg(_color: string, text: string) {
+        return `\u001b[48;5;236m${text}\u001b[49m`;
+      },
+      bold(text: string) {
+        return `\u001b[1m${text}\u001b[22m`;
+      },
+    };
+    const detail = new ChildRunDetailComponent(
+      registry,
+      runId,
+      tui,
+      keybindings,
+      () => {},
+      theme,
+    );
+
+    const lines = detail.render(64);
+    const plain = lines.map((item) => stripTerminalControls(item).trimEnd());
+    const rendered = plain.join("\n");
+    expect(lines.join("\n")).toContain("\u001b[48;5;236m");
+    expect(lines.join("\n")).not.toContain("]2;spoof");
+    expect(rendered).toContain("codex-reviewer");
+    expect(rendered).toContain("review workflow · verification · S1/T1");
+    expect(rendered).toContain("task  review the renderer");
+    expect(rendered).toContain("Transcript");
+    expect(rendered).toContain("✗ tool-1 read (failed)");
+    expect(rendered).toContain("Found one actionable issue.");
+    expect(lines.every((item) => visibleWidth(item) <= 64)).toBe(true);
+  });
+
   test("uses the near-full terminal height and starts completed output at the top", () => {
     const { registry, tui, keybindings } = setup(24);
     const [runId] = addRuns(registry, 1);


### PR DESCRIPTION
## Summary

- replace text-only child-run tool results with themed TUI components, status counters, and compact/expanded layouts
- add a themed detail overlay with metadata cards, transcript sections, status colors, and ANSI-aware viewport rendering
- preserve terminal-control sanitization, narrow-width wrapping, scrolling, live follow, and plain-renderer compatibility
- add focused coverage for themed output, sanitization, width bounds, and expanded details

## Testing

- `bun test tests/pi-harness/child-run-presentation.test.ts tests/pi-harness/child-run-ui.test.ts tests/pi-harness/child-run-integration.test.ts tests/pi-harness/child-run-layout.test.ts` (49 passed)
- `bun run tsc`
- `bun run check:pi-imports`
- `bun run check:pi-compat`
- `bun run lint` (0 errors)
- `bun test` (1283 passed; the existing pnpm statusline fixture still fails/times out and reproduces on `main`)