### PR TITLE
feat(pi): prefer gh for GitHub repository inspection

### DIFF
--- a/pi/extensions/pi-harness/features/github-cli-reminder/README.md
+++ b/pi/extensions/pi-harness/features/github-cli-reminder/README.md
@@ -1,0 +1,20 @@
+# GitHub CLI reminder
+
+This feature injects a hidden custom message on the first parent-session
+`before_agent_start` event. The persisted message tells the model to inspect
+GitHub repositories, issues, and pull requests with `gh repo`, `gh issue`,
+`gh pr`, or `gh api`, while leaving `web_fetch` available for non-GitHub public
+pages.
+
+Later turns reuse that message from session context instead of persisting a new
+copy. The handler checks pi's active branch entries, so resume/reload does not
+add a duplicate, while compaction or tree navigation to a branch without the
+entry causes the next user-prompt run to refresh it.
+
+The reminder is a soft policy only. It does not block tool calls.
+
+The umbrella extension registers the feature only when `config.isChild` is
+false. Child pi processes therefore keep their existing safety hooks without
+receiving duplicate parent guidance. Real pi collects custom messages from all
+`before_agent_start` handlers, so hook-bridge context and this reminder are both
+preserved.

--- a/pi/extensions/pi-harness/features/github-cli-reminder/index.ts
+++ b/pi/extensions/pi-harness/features/github-cli-reminder/index.ts
@@ -1,0 +1,74 @@
+import type { PiLike } from "../../lib/pi-like";
+
+const GITHUB_CLI_REMINDER_TYPE = "pi-harness-github-cli-reminder" as const;
+
+const GITHUB_CLI_REMINDER = `<system-reminder>
+When inspecting GitHub repositories, issues, or pull requests, use the gh CLI through the bash tool:
+- GitHub repositories: \`gh repo view\`
+- GitHub issues: \`gh issue view\` / \`gh issue list\`
+- GitHub pull requests: \`gh pr view\` / \`gh pr list\`
+- Advanced GitHub API access: \`gh api\`
+
+Do not use web_fetch for GitHub repository metadata, issues, or pull requests.
+Use web_fetch only for non-GitHub public web pages.
+Use the git CLI as needed to inspect local repository state.
+</system-reminder>`;
+
+interface SessionContextLike {
+  sessionManager?: {
+    buildContextEntries(): unknown;
+  };
+}
+
+const reminderInActiveContext = (ctx: unknown): boolean | undefined => {
+  const { sessionManager } = ctx as SessionContextLike;
+  if (sessionManager === undefined) return undefined;
+
+  try {
+    const entries = sessionManager.buildContextEntries();
+    if (!Array.isArray(entries)) return undefined;
+    return entries.some(
+      (entry) =>
+        typeof entry === "object" &&
+        entry !== null &&
+        "type" in entry &&
+        entry.type === "custom_message" &&
+        "customType" in entry &&
+        entry.customType === GITHUB_CLI_REMINDER_TYPE,
+    );
+  } catch {
+    return undefined;
+  }
+};
+
+/** Keep GitHub inspection guidance in parent context without per-turn copies. */
+const setupGitHubCliReminder = (pi: PiLike): void => {
+  // Only test/legacy adapters lack SessionManager. Real pi derives presence
+  // from the active branch so resume, reload, compaction, and tree navigation
+  // neither duplicate a persisted reminder nor lose one on an older branch.
+  let injectedWithoutSessionState = false;
+
+  pi.on("before_agent_start", (_event, ctx) => {
+    const persisted = reminderInActiveContext(ctx);
+    if (persisted ?? injectedWithoutSessionState) return undefined;
+    injectedWithoutSessionState = true;
+    return {
+      message: {
+        customType: GITHUB_CLI_REMINDER_TYPE,
+        content: GITHUB_CLI_REMINDER,
+        display: false,
+      },
+    };
+  });
+
+  // Let adapters without SessionManager model a context boundary in tests.
+  pi.on("session_compact", () => {
+    injectedWithoutSessionState = false;
+  });
+};
+
+export {
+  GITHUB_CLI_REMINDER,
+  GITHUB_CLI_REMINDER_TYPE,
+  setupGitHubCliReminder as default,
+};

--- a/pi/extensions/pi-harness/index.ts
+++ b/pi/extensions/pi-harness/index.ts
@@ -20,6 +20,7 @@ import {
   type PermissionBlockerOptions,
 } from "./features/permission-policy/block";
 import setupHookBridge from "./features/hook-bridge/index";
+import setupGitHubCliReminder from "./features/github-cli-reminder/index";
 import {
   buildRegistry,
   partitionBridgeRegistry,
@@ -69,6 +70,10 @@ const setupHarness = (
     config.features.subagent || config.features.workflow
       ? setupChildRuns(pi)
       : undefined;
+
+  // Parent turns receive one hidden soft-policy reminder. Child processes omit
+  // it to avoid duplicating guidance already supplied by their orchestrator.
+  if (!config.isChild) setupGitHubCliReminder(pi);
 
   // Reject package runners with an equivalent project script before the local
   // judge can ask. A hook pass, timeout, or error still falls through to the

--- a/tests/pi-harness/github-cli-reminder.test.ts
+++ b/tests/pi-harness/github-cli-reminder.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import type { HarnessConfig } from "../../pi/extensions/pi-harness/config";
+import setupGitHubCliReminder, {
+  GITHUB_CLI_REMINDER,
+  GITHUB_CLI_REMINDER_TYPE,
+} from "../../pi/extensions/pi-harness/features/github-cli-reminder/index";
+import setupHookBridge from "../../pi/extensions/pi-harness/features/hook-bridge/index";
+import type { BridgeHookSpec } from "../../pi/extensions/pi-harness/features/hook-bridge/registry";
+import { setupHarness } from "../../pi/extensions/pi-harness/index";
+import type {
+  PiEventHandler,
+  PiEventName,
+  PiLike,
+} from "../../pi/extensions/pi-harness/lib/pi-like";
+import { resolvePaths } from "../../pi/extensions/pi-harness/lib/paths";
+import { cleanupTestDirectory, setupTestDirectory } from "../test-helpers";
+import { createFakePi } from "./fake-pi";
+
+const tempDirectories: string[] = [];
+
+const makeConfig = (home: string, isChild = false): HarnessConfig => ({
+  isChild,
+  features: {
+    "hook-bridge": false,
+    subagent: false,
+    workflow: false,
+    "bit-task": false,
+    statusline: false,
+    "provider-log": false,
+    "asuku-notify": false,
+    "ask-user-question": false,
+  },
+  trust: { trustedRoots: [] },
+  paths: resolvePaths(home),
+});
+
+const captureBeforeAgentStartHandlers = (
+  pi: ReturnType<typeof createFakePi>,
+) => {
+  const handlers: PiEventHandler<"before_agent_start">[] = [];
+  const capturingPi: PiLike = {
+    ...pi,
+    on: <K extends PiEventName>(event: K, handler: PiEventHandler<K>): void => {
+      if (event === "before_agent_start") {
+        handlers.push(
+          handler as unknown as PiEventHandler<"before_agent_start">,
+        );
+      }
+      pi.on(event, handler);
+    },
+  };
+  return { handlers, pi: capturingPi };
+};
+
+afterEach(async () => {
+  await Promise.all(tempDirectories.splice(0).map(cleanupTestDirectory));
+});
+
+describe("pi-harness GitHub CLI reminder", () => {
+  test("keeps concrete hidden gh guidance without per-turn copies", async () => {
+    const pi = createFakePi();
+    setupGitHubCliReminder(pi);
+
+    const injection = await pi.emitBeforeAgentStart({
+      type: "before_agent_start",
+      prompt: "inspect an issue",
+    });
+    expect(injection?.message).toEqual({
+      customType: GITHUB_CLI_REMINDER_TYPE,
+      content: GITHUB_CLI_REMINDER,
+      display: false,
+    });
+    expect(
+      await pi.emitBeforeAgentStart({
+        type: "before_agent_start",
+        prompt: "continue implementation",
+      }),
+    ).toBeUndefined();
+
+    await pi.emitSessionCompact();
+    const refreshed = await pi.emitBeforeAgentStart({
+      type: "before_agent_start",
+      prompt: "continue after compaction",
+    });
+    expect(refreshed?.message.customType).toBe(GITHUB_CLI_REMINDER_TYPE);
+
+    for (const command of [
+      "gh repo view",
+      "gh issue view",
+      "gh issue list",
+      "gh pr view",
+      "gh pr list",
+      "gh api",
+    ]) {
+      expect(GITHUB_CLI_REMINDER).toContain(command);
+    }
+    expect(GITHUB_CLI_REMINDER).toContain(
+      "Use web_fetch only for non-GitHub public web pages.",
+    );
+    expect(GITHUB_CLI_REMINDER).toContain("Use the git CLI");
+  });
+
+  test("derives deduplication from the active persisted branch", async () => {
+    const pi = createFakePi();
+    let entries: unknown[] = [
+      {
+        type: "custom_message",
+        customType: GITHUB_CLI_REMINDER_TYPE,
+      },
+    ];
+    Object.assign(pi.ctx, {
+      sessionManager: {
+        buildContextEntries: () => entries,
+      },
+    });
+    setupGitHubCliReminder(pi);
+
+    expect(
+      await pi.emitBeforeAgentStart({
+        type: "before_agent_start",
+        prompt: "resume with the reminder present",
+      }),
+    ).toBeUndefined();
+
+    entries = [];
+    const refreshed = await pi.emitBeforeAgentStart({
+      type: "before_agent_start",
+      prompt: "navigate before the reminder",
+    });
+    expect(refreshed?.message.customType).toBe(GITHUB_CLI_REMINDER_TYPE);
+  });
+
+  test("the umbrella registers the reminder only for parent pi sessions", async () => {
+    const directory = await setupTestDirectory("pi-github-cli-reminder");
+    tempDirectories.push(directory);
+
+    const parent = createFakePi({ cwd: directory });
+    setupHarness(parent, makeConfig(directory));
+    const parentInjection = await parent.emitBeforeAgentStart({
+      type: "before_agent_start",
+      prompt: "inspect GitHub",
+    });
+    expect(parentInjection?.message.customType).toBe(GITHUB_CLI_REMINDER_TYPE);
+    expect(parentInjection?.message.display).toBe(false);
+
+    const child = createFakePi({ cwd: directory, hasUI: false });
+    setupHarness(child, makeConfig(directory, true));
+    expect(
+      await child.emitBeforeAgentStart({
+        type: "before_agent_start",
+        prompt: "inspect GitHub",
+      }),
+    ).toBeUndefined();
+  });
+
+  test("coexists with a hook-bridge before_agent_start message", async () => {
+    const directory = await setupTestDirectory("pi-github-cli-hook-bridge");
+    tempDirectories.push(directory);
+    const script = join(directory, "prompt-hook.sh");
+    await fs.writeFile(
+      script,
+      [
+        "#!/usr/bin/env bash",
+        "cat > /dev/null",
+        `printf '%s' '{"hookSpecificOutput":{"additionalContext":"hook context"}}'`,
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const fake = createFakePi({ cwd: directory });
+    const captured = captureBeforeAgentStartHandlers(fake);
+    const registry: BridgeHookSpec[] = [
+      {
+        id: "prompt-context",
+        stage: "before_agent_start",
+        script,
+        timeoutMs: 10_000,
+        maxOutputBytes: 65_536,
+      },
+    ];
+    setupHookBridge(captured.pi, makeConfig(directory), {
+      cwd: directory,
+      registry,
+    });
+    setupGitHubCliReminder(captured.pi);
+
+    const messages = [];
+    for (const handler of captured.handlers) {
+      const result = await handler(
+        { type: "before_agent_start", prompt: "inspect an issue" },
+        fake.ctx,
+      );
+      if (result?.message !== undefined) messages.push(result.message);
+    }
+
+    expect(messages.map(({ customType }) => customType)).toEqual([
+      "pi-harness-hook-bridge",
+      GITHUB_CLI_REMINDER_TYPE,
+    ]);
+    expect(messages[0]?.content).toBe("hook context");
+    expect(messages.every(({ display }) => display === false)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- inject hidden parent-session guidance that prefers `gh repo`, `gh issue`, `gh pr`, and `gh api` for GitHub inspection
- derive reminder presence from the active session branch to avoid per-turn and resume/reload duplicates
- keep child omission explicit and verify coexistence with hook-bridge context

## Testing

- `bun test tests/pi-harness/github-cli-reminder.test.ts tests/hooks/pi-harness/bridge-integration.test.ts` (15 pass)
- `bun run tsc`
- `bun run check:pi-imports`
- `bun run check:pi-compat`
- targeted Prettier and oxlint checks
- full `bun test`: 1287 pass, 2 skip; one unrelated statusline fixture timed out under parallel load and passed when rerun alone

Closes #58
