### PR TITLE
fix(pi): avoid polling background agents

### DIFF
--- a/pi/extensions/pi-harness/features/child-runs/README.md
+++ b/pi/extensions/pi-harness/features/child-runs/README.md
@@ -50,6 +50,14 @@ requests an automatic follow-up parent turn. Completion delivery is serialized:
 only one result is handed to pi at a time, while later results remain in the
 manager-local queue until the preceding notification turn settles.
 
+Whenever that background delivery runtime is available, pi-harness also
+appends parent system-prompt guidance before every agent run. It tells the
+parent never to wait with `sleep`, shell polling, repeated status checks, or
+other blocking calls: the parent may continue independent work, but otherwise
+must return control to pi until the automatic completion message starts the
+next turn. The guidance is omitted for the legacy synchronous fallback, where
+the tool call itself waits and returns the final result.
+
 A permission-policy block in a no-UI child emits a diagnostic signal bound to a
 random per-spawn token and makes that child run fail even if the model responds
 with a normal final message and pi exits zero. The signal is filtered from child

--- a/pi/extensions/pi-harness/features/child-runs/index.ts
+++ b/pi/extensions/pi-harness/features/child-runs/index.ts
@@ -26,6 +26,10 @@ interface RuntimeToolResultEvent {
   isError?: boolean;
 }
 
+interface RuntimeBeforeAgentStartEvent {
+  systemPrompt?: unknown;
+}
+
 interface RuntimePiLike {
   on(
     event: string,
@@ -77,6 +81,15 @@ const completionInvocationId = (details: unknown): string | undefined => {
   const invocationId = (details as { invocationId?: unknown }).invocationId;
   return typeof invocationId === "string" ? invocationId : undefined;
 };
+
+const BACKGROUND_AGENT_SYSTEM_PROMPT = `## Background agent completion
+
+The subagent and workflow tools run child agents asynchronously. After either tool accepts a background invocation, never use sleep, shell polling, repeated status checks, or any other blocking or waiting call to wait for it. Pi delivers completion automatically as a new message and starts the continuation turn. Continue only work that is independent of the child; otherwise end the current response and return control to Pi.`;
+
+const appendBackgroundAgentSystemPrompt = (systemPrompt: string): string =>
+  systemPrompt === ""
+    ? BACKGROUND_AGENT_SYSTEM_PROMPT
+    : `${systemPrompt}\n\n${BACKGROUND_AGENT_SYSTEM_PROMPT}`;
 
 export interface ChildRunsIntegration {
   registry: ChildRunRegistry;
@@ -199,8 +212,15 @@ const setupChildRuns = (pi: PiLike): ChildRunsIntegration => {
       background?.acknowledgeToolResult(event.message.toolCallId);
     }
   });
-  runtime.on("before_agent_start", () => {
+  runtime.on("before_agent_start", (rawEvent) => {
     background?.markAgentPreflightStarted();
+    if (background === undefined) return undefined;
+
+    const event = rawEvent as RuntimeBeforeAgentStartEvent;
+    if (typeof event.systemPrompt !== "string") return undefined;
+    return {
+      systemPrompt: appendBackgroundAgentSystemPrompt(event.systemPrompt),
+    };
   });
   runtime.on("agent_start", () => background?.markAgentStarted());
   runtime.on("agent_settled", (_event, ctx) => {

--- a/tests/pi-harness/background-agent-prompt.test.ts
+++ b/tests/pi-harness/background-agent-prompt.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import setupChildRuns from "../../pi/extensions/pi-harness/features/child-runs/index";
+import type { PiLike } from "../../pi/extensions/pi-harness/lib/pi-like";
+
+type RuntimeHandler = (
+  event: unknown,
+  ctx: unknown,
+) => unknown | Promise<unknown>;
+
+const createRuntime = (background: boolean) => {
+  const handlers = new Map<string, RuntimeHandler[]>();
+  const runtime = {
+    on(event: string, handler: RuntimeHandler) {
+      const registered = handlers.get(event) ?? [];
+      registered.push(handler);
+      handlers.set(event, registered);
+    },
+    registerCommand() {},
+    registerShortcut() {},
+    ...(background
+      ? {
+          appendEntry() {},
+          sendMessage() {},
+        }
+      : {}),
+  };
+
+  return {
+    pi: runtime as unknown as PiLike,
+    async emit(event: string, payload: unknown): Promise<unknown> {
+      let result: unknown;
+      for (const handler of handlers.get(event) ?? []) {
+        const next = await handler(payload, {});
+        if (next !== undefined) result = next;
+      }
+      return result;
+    },
+  };
+};
+
+describe("background-agent system prompt", () => {
+  test("forbids active waiting when automatic completion delivery is available", async () => {
+    const runtime = createRuntime(true);
+    setupChildRuns(runtime.pi);
+
+    const result = await runtime.emit("before_agent_start", {
+      type: "before_agent_start",
+      systemPrompt: "Base system prompt.",
+    });
+
+    const systemPrompt = (result as { systemPrompt?: unknown }).systemPrompt;
+    expect(typeof systemPrompt).toBe("string");
+    if (typeof systemPrompt !== "string") {
+      throw new Error("background guidance did not return a system prompt");
+    }
+    expect(systemPrompt).toStartWith(
+      "Base system prompt.\n\n## Background agent completion",
+    );
+    expect(systemPrompt).toContain("never use sleep");
+    expect(systemPrompt).toContain(
+      "Pi delivers completion automatically as a new message",
+    );
+    expect(systemPrompt).toContain("return control to Pi");
+
+    await runtime.emit("session_shutdown", { type: "session_shutdown" });
+  });
+
+  test("omits asynchronous guidance for the synchronous fallback", async () => {
+    const runtime = createRuntime(false);
+    setupChildRuns(runtime.pi);
+
+    const result = await runtime.emit("before_agent_start", {
+      type: "before_agent_start",
+      systemPrompt: "Base system prompt.",
+    });
+
+    expect(result).toBeUndefined();
+    await runtime.emit("session_shutdown", { type: "session_shutdown" });
+  });
+});


### PR DESCRIPTION
## Summary

- append parent system-prompt guidance when automatic background completion delivery is available
- explicitly prevent waiting through sleep, shell polling, or repeated status checks
- preserve the synchronous fallback behavior and document/test both paths

## Testing

- `bun test` (1287 passed, 2 skipped)
- `bun run tsc`
- `bun run lint`
- `bun run check:pi-compat`
- `bun run check:pi-imports`
- `bun run check:pi-rules`
- `bun run check:pi-schemas`