### PR TITLE
fix(pi): show extension statuses in custom footer

### DIFF
--- a/pi/extensions/pi-harness/features/statusline/index.ts
+++ b/pi/extensions/pi-harness/features/statusline/index.ts
@@ -36,6 +36,7 @@ import {
   type GitStatus,
   parseStatuslineCache,
   remainingContextPercent,
+  renderExtensionStatuses,
   renderStatusline,
   STATUSLINE_WIDGET_KEY,
   type StatuslineCache,
@@ -108,6 +109,15 @@ const EMPTY_GIT_STATUS: GitStatus = {
 };
 
 const IDENTITY_THEME: ThemeLike = { fg: (_color, text) => text };
+
+interface ExtensionStatusFooterData {
+  getExtensionStatuses(): ReadonlyMap<string, string>;
+}
+
+const hasExtensionStatusData = (
+  footerData: object,
+): footerData is object & ExtensionStatusFooterData =>
+  typeof Reflect.get(footerData, "getExtensionStatuses") === "function";
 
 // The shell library tests markers with [ -f ] (regular file, symlinks
 // followed); existsSync would also accept directories and make the two
@@ -421,7 +431,7 @@ export default function setupStatusline(
             invalidate() {},
             render(width: number): string[] {
               const current = activeContext;
-              return renderStatusline(
+              const lines = renderStatusline(
                 snapshot,
                 {
                   branch:
@@ -436,6 +446,14 @@ export default function setupStatusline(
                 width,
                 theme,
               );
+              const extensionStatus = hasExtensionStatusData(footerData)
+                ? renderExtensionStatuses(
+                    footerData.getExtensionStatuses(),
+                    width,
+                  )
+                : undefined;
+              if (extensionStatus !== undefined) lines.push(extensionStatus);
+              return lines;
             },
             dispose() {
               unsubscribeBranch();

--- a/pi/extensions/pi-harness/features/statusline/render.ts
+++ b/pi/extensions/pi-harness/features/statusline/render.ts
@@ -1,3 +1,4 @@
+import { truncateToWidth as truncateStyledToWidth } from "@earendil-works/pi-tui";
 import type {
   ContextUsageLike,
   ModelLike,
@@ -90,6 +91,155 @@ const graphemes = (value: string): string[] =>
 const graphemeWidth = (grapheme: string): number => visibleWidth(grapheme);
 
 export const visibleStatuslineWidth = visibleWidth;
+
+const consumeCsi = (
+  value: string,
+  start: number,
+): { end: number; final?: string; valid: boolean } => {
+  let valid = true;
+  for (let index = start; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 64 && code <= 126) {
+      return { end: index + 1, final: value[index], valid };
+    }
+    if (code < 32 || code > 63) valid = false;
+  }
+  return { end: value.length, valid: false };
+};
+
+const sgrIsOnlyFullReset = (body: string): boolean =>
+  body
+    .split(";")
+    .every((parameter) => parameter === "" || /^0+$/.test(parameter));
+
+const consumeControlString = (value: string, start: number): number => {
+  for (let index = start; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code === 7 || code === 156) return index + 1;
+    if (value[index] === "\u001b" && value[index + 1] === "\\") {
+      return index + 2;
+    }
+  }
+  return value.length;
+};
+
+const consumeEscapeSequence = (value: string, start: number): number => {
+  for (let index = start; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 48 && code <= 126) return index + 1;
+    if (code < 32 || code > 47) return index + 1;
+  }
+  return value.length;
+};
+
+/**
+ * Preserve extension SGR styling, but collapse whitespace and every other
+ * terminal control so one status cannot alter or add footer lines.
+ */
+const singleLineExtensionStatus = (value: string): string | undefined => {
+  let output = "";
+  let pendingSpace = false;
+  let hasVisibleCharacter = false;
+  let sgrNeedsReset = false;
+  let index = 0;
+
+  while (index < value.length) {
+    const code = value.charCodeAt(index);
+    if (value[index] === "\u001b") {
+      const next = value[index + 1];
+      if (next === "[") {
+        const csi = consumeCsi(value, index + 2);
+        if (csi.valid && csi.final === "m") {
+          output += value.slice(index, csi.end);
+          sgrNeedsReset = !sgrIsOnlyFullReset(
+            value.slice(index + 2, csi.end - 1),
+          );
+        } else pendingSpace = true;
+        index = csi.end;
+        continue;
+      }
+      if (
+        next === "]" ||
+        next === "P" ||
+        next === "X" ||
+        next === "^" ||
+        next === "_"
+      ) {
+        pendingSpace = true;
+        index = consumeControlString(value, index + 2);
+        continue;
+      }
+      pendingSpace = true;
+      index = consumeEscapeSequence(value, index + 1);
+      continue;
+    }
+    if (code === 155) {
+      const csi = consumeCsi(value, index + 1);
+      if (csi.valid && csi.final === "m") {
+        output += `\u001b[${value.slice(index + 1, csi.end)}`;
+        sgrNeedsReset = !sgrIsOnlyFullReset(
+          value.slice(index + 1, csi.end - 1),
+        );
+      } else pendingSpace = true;
+      index = csi.end;
+      continue;
+    }
+    if (
+      code === 157 ||
+      code === 144 ||
+      code === 152 ||
+      code === 158 ||
+      code === 159
+    ) {
+      pendingSpace = true;
+      index = consumeControlString(value, index + 1);
+      continue;
+    }
+    if (
+      code <= 32 ||
+      (code >= 127 && code <= 159) ||
+      code === 8232 ||
+      code === 8233
+    ) {
+      pendingSpace = true;
+      index += 1;
+      continue;
+    }
+
+    if (pendingSpace && hasVisibleCharacter) output += " ";
+    output += value[index];
+    pendingSpace = false;
+    hasVisibleCharacter = true;
+    index += 1;
+  }
+
+  if (!hasVisibleCharacter || visibleWidth(output) === 0) return undefined;
+  return sgrNeedsReset ? `${output}\u001b[0m` : output;
+};
+
+const compareExtensionStatusKeys = (
+  [left]: readonly [string, string],
+  [right]: readonly [string, string],
+): number => {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+};
+
+/** Render every extension status on one stable, terminal-width-safe line. */
+export const renderExtensionStatuses = (
+  statuses: ReadonlyMap<string, string>,
+  width: number,
+): string | undefined => {
+  if (width <= 0) return undefined;
+  const statusLine = [...statuses.entries()]
+    .sort(compareExtensionStatusKeys)
+    .map(([, text]) => singleLineExtensionStatus(text))
+    .filter((text): text is string => text !== undefined)
+    .join(" ");
+  if (statusLine === "") return undefined;
+  return truncateStyledToWidth(statusLine, width, "…");
+};
 
 const appendSpan = (spans: Span[], span: Span): void => {
   if (span.text === "") return;

--- a/tests/pi-harness/statusline.test.ts
+++ b/tests/pi-harness/statusline.test.ts
@@ -13,6 +13,7 @@ import {
   type GitStatus,
   parseStatuslineCache,
   remainingContextPercent,
+  renderExtensionStatuses,
   renderStatusline,
   STATUSLINE_WIDGET_KEY,
   type StatuslineSnapshot,
@@ -20,7 +21,11 @@ import {
 } from "../../pi/extensions/pi-harness/features/statusline/render";
 import type { DetachedSpawnFunction } from "../../pi/extensions/pi-harness/lib/detached";
 import { resolvePaths } from "../../pi/extensions/pi-harness/lib/paths";
-import type { ThemeLike } from "../../pi/extensions/pi-harness/lib/pi-like";
+import type {
+  FooterComponentLike,
+  ThemeLike,
+  TuiLike,
+} from "../../pi/extensions/pi-harness/lib/pi-like";
 import { worktreeIdentityDetails } from "../../pi/extensions/pi-harness/lib/worktree-identity";
 import { cleanupTestDirectory, setupTestDirectory } from "../test-helpers";
 import { createFakePi } from "./fake-pi";
@@ -192,6 +197,71 @@ describe("Claude-compatible statusline rendering", () => {
     expect(lines).toEqual([
       "ushironoko/dotfiles | dotfiles | feat/pi | +12 -3 | TS L✓ T… X✗ | Opus 4.8 | 42%",
     ]);
+  });
+
+  test("renders extension statuses safely in stable key order", () => {
+    const line = renderExtensionStatuses(
+      new Map([
+        ["z-last", "\u001b[31m赤い状態\u001b[0m"],
+        ["a-first", "  first\r\nstatus\tready\vnow\u2028safe  "],
+        ["m-empty", "\n\t"],
+      ]),
+      200,
+    );
+
+    expect(line).toBe(
+      "first status ready now safe \u001b[31m赤い状態\u001b[0m",
+    );
+    expect(renderExtensionStatuses(new Map(), 80)).toBeUndefined();
+    expect(
+      renderExtensionStatuses(new Map([["busy", "answering"]]), 0),
+    ).toBeUndefined();
+    expect(
+      renderExtensionStatuses(new Map([["empty", "\r\n\t"]]), 80),
+    ).toBeUndefined();
+    expect(
+      renderExtensionStatuses(
+        new Map([["styled-empty", "\u001b[31m \t\r\u001b[0m"]]),
+        80,
+      ),
+    ).toBeUndefined();
+
+    const sanitized = renderExtensionStatuses(
+      new Map([
+        [
+          "unsafe",
+          "safe\u001b[2Jspoof\u001b]0;bad\u0007end\u0008done\u001b[31\u0007mring",
+        ],
+      ]),
+      200,
+    );
+    expect(sanitized).toBe("safe spoof end done ring");
+    expect(
+      renderExtensionStatuses(
+        new Map([
+          ["a-styled", "\u001b[31mbusy"],
+          ["b-plain", "ready"],
+        ]),
+        80,
+      ),
+    ).toBe("\u001b[31mbusy\u001b[0m ready");
+    expect(
+      renderExtensionStatuses(
+        new Map([
+          ["a-extended-color", "\u001b[38;5;0mblack"],
+          ["b-plain", "ready"],
+        ]),
+        80,
+      ),
+    ).toBe("\u001b[38;5;0mblack\u001b[0m ready");
+
+    const truncated = renderExtensionStatuses(
+      new Map([["colored", "\u001b[31m回答生成中です回答生成中です\u001b[0m"]]),
+      7,
+    );
+    expect(truncated).toContain("\u001b[31m");
+    expect(truncated).not.toMatch(/[\r\n\t]/);
+    expect(piVisibleWidth(truncated ?? "")).toBeLessThanOrEqual(7);
   });
 
   test("renders pending checks before the first cache file exists", () => {
@@ -815,6 +885,63 @@ describe("pi-harness statusline lifecycle", () => {
     ]);
     expect(pi.widgets.get(STATUSLINE_WIDGET_KEY)).toBeUndefined();
     expect(pi.footerRenderRequests).toBeGreaterThan(0);
+  });
+
+  test("reflects live extension status updates without reinstalling", async () => {
+    const home = await tempDirectory("pi-statusline-extension-status");
+    const project = join(home, "repo");
+    await fs.mkdir(project, { recursive: true });
+
+    const pi = createFakePi({ cwd: project, gitBranch: "main" });
+    const statuses = new Map<string, string>();
+    let footer: FooterComponentLike | undefined;
+    let footerInstallations = 0;
+    let renderRequests = 0;
+    const tui: TuiLike = {
+      requestRender() {
+        renderRequests += 1;
+      },
+    };
+    const footerData = {
+      getGitBranch: () => "main",
+      getExtensionStatuses: () => statuses,
+      onBranchChange: (_callback: () => void) => () => {},
+    };
+    pi.ctx.ui.setFooter = (factory) => {
+      footerInstallations += 1;
+      footer?.dispose?.();
+      footer = factory?.(tui, identityTheme, footerData);
+    };
+    const statusUi = pi.ctx.ui as typeof pi.ctx.ui & {
+      setStatus(key: string, value: string | undefined): void;
+    };
+    statusUi.setStatus = (key, value) => {
+      if (value === undefined) statuses.delete(key);
+      else statuses.set(key, value);
+      tui.requestRender();
+    };
+
+    setupStatusline(pi, makeConfig(home, [project]), {
+      getGitStatus: async () => gitStatus({ repository: undefined }),
+    });
+    await pi.emitSessionStart({ type: "session_start", reason: "startup" });
+    const requestsAfterInstall = renderRequests;
+
+    expect(footer?.render(100)).toEqual(["repo | main"]);
+    statusUi.setStatus("pi-harness-btw", "btw: answering");
+    expect(footer?.render(100)).toEqual(["repo | main", "btw: answering"]);
+    statusUi.setStatus("pi-harness-btw", "btw: retrying");
+    expect(footer?.render(100)).toEqual(["repo | main", "btw: retrying"]);
+    statusUi.setStatus("other-extension", "other: busy");
+    expect(footer?.render(100)).toEqual([
+      "repo | main",
+      "other: busy btw: retrying",
+    ]);
+    statusUi.setStatus("other-extension", undefined);
+    statusUi.setStatus("pi-harness-btw", undefined);
+    expect(footer?.render(100)).toEqual(["repo | main"]);
+    expect(footerInstallations).toBe(1);
+    expect(renderRequests).toBe(requestsAfterInstall + 5);
   });
 
   test("branch, model, and context updates are reflected without reinstalling", async () => {


### PR DESCRIPTION
## Summary

- render live Pi extension statuses on a dedicated second custom-footer line
- sort statuses deterministically and sanitize terminal controls while preserving isolated SGR styling
- re-read status state on every render so `/btw` updates and clears without reinstalling the footer
- keep the existing Claude-compatible primary statusline and RPC fallback unchanged

## Testing

- `bun test tests/pi-harness/statusline.test.ts tests/pi-harness/btw.test.ts`
- `bun run tsc`
- `bun run lint` (0 errors)
- `bun run check:pi-imports`
- `bun run check:pi-compat`
- `bun run check:pi-baseline`
- `bun run check:pi-schemas`
- `bun run check:pi-rules`

Closes #56