### PR TITLE
feat(pi): prompt progress after silent tool turns

### DIFF
--- a/pi/extensions/pi-harness/features/progress-reminder/index.ts
+++ b/pi/extensions/pi-harness/features/progress-reminder/index.ts
@@ -1,0 +1,103 @@
+import type { PiLike } from "../../lib/pi-like";
+
+const SILENT_TURN_THRESHOLD = 10;
+const PROGRESS_REMINDER_CUSTOM_TYPE = "pi-harness-progress-reminder";
+const PROGRESS_REMINDER = `<system-reminder>
+You have completed 10 or more turns without giving the user a visible progress update.
+Before continuing with more tool calls, provide a concise progress summary covering:
+- what has been investigated or changed
+- current findings
+- what remains to be done
+</system-reminder>`;
+
+interface ContentBlockLike {
+  type?: unknown;
+  text?: unknown;
+}
+
+interface MessageLike {
+  role?: unknown;
+  content?: unknown;
+  customType?: unknown;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const asMessage = (value: unknown): MessageLike | undefined =>
+  isRecord(value) ? value : undefined;
+
+const hasVisibleAssistantText = (message: unknown): boolean => {
+  const candidate = asMessage(message);
+  if (candidate?.role !== "assistant" || !Array.isArray(candidate.content)) {
+    return false;
+  }
+
+  return candidate.content.some((block: unknown) => {
+    if (!isRecord(block)) return false;
+    const candidateBlock: ContentBlockLike = block;
+    return (
+      candidateBlock.type === "text" &&
+      typeof candidateBlock.text === "string" &&
+      candidateBlock.text.trim().length > 0
+    );
+  });
+};
+
+const containsProgressReminder = (messages: readonly unknown[]): boolean =>
+  messages.some((message) => {
+    const candidate = asMessage(message);
+    return (
+      candidate?.role === "custom" &&
+      candidate.customType === PROGRESS_REMINDER_CUSTOM_TYPE
+    );
+  });
+
+const progressReminderMessage = () => ({
+  role: "custom" as const,
+  customType: PROGRESS_REMINDER_CUSTOM_TYPE,
+  content: PROGRESS_REMINDER,
+  display: false,
+  timestamp: Date.now(),
+});
+
+const setupProgressReminder = (pi: PiLike): void => {
+  let silentTurns = 0;
+  const reset = (): void => {
+    silentTurns = 0;
+  };
+
+  pi.on("session_start", reset);
+  pi.on("input", reset);
+  pi.on("before_agent_start", reset);
+  pi.on("session_shutdown", reset);
+
+  pi.on("turn_end", (event) => {
+    if (hasVisibleAssistantText(event.message)) {
+      reset();
+      return;
+    }
+    silentTurns += 1;
+  });
+
+  pi.on("context", (event) => {
+    if (
+      silentTurns < SILENT_TURN_THRESHOLD ||
+      containsProgressReminder(event.messages)
+    ) {
+      return undefined;
+    }
+
+    return {
+      messages: [...event.messages, progressReminderMessage()],
+    };
+  });
+};
+
+export {
+  hasVisibleAssistantText,
+  PROGRESS_REMINDER,
+  PROGRESS_REMINDER_CUSTOM_TYPE,
+  SILENT_TURN_THRESHOLD,
+};
+export default setupProgressReminder;

--- a/pi/extensions/pi-harness/index.ts
+++ b/pi/extensions/pi-harness/index.ts
@@ -21,6 +21,7 @@ import {
 } from "./features/permission-policy/block";
 import setupHookBridge from "./features/hook-bridge/index";
 import setupGitHubCliReminder from "./features/github-cli-reminder/index";
+import setupProgressReminder from "./features/progress-reminder/index";
 import {
   buildRegistry,
   partitionBridgeRegistry,
@@ -71,9 +72,12 @@ const setupHarness = (
       ? setupChildRuns(pi)
       : undefined;
 
-  // Parent turns receive one hidden soft-policy reminder. Child processes omit
-  // it to avoid duplicating guidance already supplied by their orchestrator.
-  if (!config.isChild) setupGitHubCliReminder(pi);
+  // Parent turns receive hidden user-facing guidance. Child processes omit it
+  // because their progress is reported through the parent orchestrator.
+  if (!config.isChild) {
+    setupGitHubCliReminder(pi);
+    setupProgressReminder(pi);
+  }
 
   // Reject package runners with an equivalent project script before the local
   // judge can ask. A hook pass, timeout, or error still falls through to the

--- a/pi/extensions/pi-harness/lib/pi-like.ts
+++ b/pi/extensions/pi-harness/lib/pi-like.ts
@@ -41,6 +41,18 @@ export interface ContextEvent {
   messages: unknown[];
 }
 
+/** Returned by context handlers to replace messages for later handlers. */
+export interface ContextUpdate {
+  messages?: unknown[];
+}
+
+export interface TurnEndEvent {
+  type: "turn_end";
+  turnIndex: number;
+  message: unknown;
+  toolResults: unknown[];
+}
+
 export interface SessionBeforeTreeEvent {
   type: "session_before_tree";
   preparation: {
@@ -81,6 +93,7 @@ export interface PiEventMap {
   input: InputEvent;
   before_agent_start: BeforeAgentStartEvent;
   context: ContextEvent;
+  turn_end: TurnEndEvent;
   tool_call: ToolCallEvent;
   tool_result: ToolResultEvent;
   agent_settled: GenericEvent;
@@ -122,7 +135,8 @@ export interface PiEventResultMap {
   session_start: void;
   input: void;
   before_agent_start: AgentStartInjection | undefined | void;
-  context: void;
+  context: ContextUpdate | undefined | void;
+  turn_end: void;
   tool_call: ToolCallBlockResult | undefined | void;
   tool_result: ToolResultPatch | undefined | void;
   agent_settled: void;

--- a/tests/pi-harness/fake-pi.ts
+++ b/tests/pi-harness/fake-pi.ts
@@ -10,6 +10,8 @@
  *   short-circuits the chain (V2 verified block + verbatim reason delivery
  *   with a single handler; multi-handler ordering follows pi docs "load
  *   order chaining").
+ * - context: handlers chain middleware-style; a messages replacement returned
+ *   by one handler is visible to the next without mutating the caller's input.
  * - tool_result: handlers chain middleware-style; a patch returned by one
  *   handler is visible to the next (pi docs).
  * - Blocked tool calls fire NO tool_result event (V2 measurement: blocked
@@ -18,6 +20,7 @@
 import type {
   AgentStartInjection,
   BeforeAgentStartEvent,
+  ContextUpdate,
   ContextUsageLike,
   CtxLike,
   DialogOptionsLike,
@@ -40,6 +43,7 @@ import type {
   ToolDefLike,
   ToolResultEvent,
   ToolResultPatch,
+  TurnEndEvent,
 } from "../../pi/extensions/pi-harness/lib/pi-like";
 
 interface Notification {
@@ -70,6 +74,7 @@ interface HandlerStore {
   input: PiEventHandler<"input">[];
   before_agent_start: PiEventHandler<"before_agent_start">[];
   context: PiEventHandler<"context">[];
+  turn_end: PiEventHandler<"turn_end">[];
   tool_call: PiEventHandler<"tool_call">[];
   tool_result: PiEventHandler<"tool_result">[];
   agent_settled: PiEventHandler<"agent_settled">[];
@@ -86,7 +91,8 @@ export interface FakePi extends PiLike {
   emitBeforeAgentStart(
     payload: BeforeAgentStartEvent,
   ): Promise<AgentStartInjection | undefined>;
-  emitContext(messages: unknown[]): Promise<void>;
+  emitContext(messages: unknown[]): Promise<unknown[]>;
+  emitTurnEnd(payload: TurnEndEvent): Promise<void>;
   emitToolCall(
     payload: ToolCallEvent,
   ): Promise<ToolCallBlockResult | undefined>;
@@ -155,6 +161,7 @@ export function createFakePi(
     input: [],
     before_agent_start: [],
     context: [],
+    turn_end: [],
     tool_call: [],
     tool_result: [],
     agent_settled: [],
@@ -248,6 +255,7 @@ export function createFakePi(
     input: (handler) => store.input.push(handler),
     before_agent_start: (handler) => store.before_agent_start.push(handler),
     context: (handler) => store.context.push(handler),
+    turn_end: (handler) => store.turn_end.push(handler),
     tool_call: (handler) => store.tool_call.push(handler),
     tool_result: (handler) => store.tool_result.push(handler),
     agent_settled: (handler) => store.agent_settled.push(handler),
@@ -313,9 +321,18 @@ export function createFakePi(
       return injection;
     },
     async emitContext(messages) {
+      let current = structuredClone(messages);
       for (const handler of store.context) {
-        await handler({ type: "context", messages }, ctx);
+        const result: ContextUpdate | undefined | void = await handler(
+          { type: "context", messages: current },
+          ctx,
+        );
+        if (result?.messages !== undefined) current = result.messages;
       }
+      return current;
+    },
+    async emitTurnEnd(payload) {
+      for (const handler of store.turn_end) await handler(payload, ctx);
     },
     async emitToolCall(payload) {
       for (const handler of store.tool_call) {

--- a/tests/pi-harness/progress-reminder.test.ts
+++ b/tests/pi-harness/progress-reminder.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, test } from "bun:test";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { HarnessConfig } from "../../pi/extensions/pi-harness/config";
+import setupProgressReminder, {
+  hasVisibleAssistantText,
+  PROGRESS_REMINDER,
+  PROGRESS_REMINDER_CUSTOM_TYPE,
+  SILENT_TURN_THRESHOLD,
+} from "../../pi/extensions/pi-harness/features/progress-reminder/index";
+import { setupHarness } from "../../pi/extensions/pi-harness/index";
+import type {
+  PiLike,
+  TurnEndEvent,
+} from "../../pi/extensions/pi-harness/lib/pi-like";
+import { resolvePaths } from "../../pi/extensions/pi-harness/lib/paths";
+import { createFakePi, type FakePi } from "./fake-pi";
+
+const REAL_PI_CONTRACT: ExtensionAPI extends PiLike ? true : false = true;
+
+const makeConfig = (isChild = false): HarnessConfig => ({
+  isChild,
+  features: {
+    "hook-bridge": false,
+    subagent: false,
+    workflow: false,
+    "bit-task": false,
+    statusline: false,
+    "provider-log": false,
+    "asuku-notify": false,
+    "ask-user-question": false,
+  },
+  trust: { trustedRoots: [] },
+  paths: resolvePaths("/tmp/pi-progress-reminder-test"),
+});
+
+const silentTurn = (turnIndex = 0): TurnEndEvent => ({
+  type: "turn_end",
+  turnIndex,
+  message: {
+    role: "assistant",
+    content: [
+      { type: "thinking", thinking: "still working" },
+      { type: "toolCall", id: "call-1", name: "read", arguments: {} },
+    ],
+  },
+  toolResults: [],
+});
+
+const emitSilentTurns = async (
+  pi: FakePi,
+  count = SILENT_TURN_THRESHOLD,
+): Promise<void> => {
+  for (let turn = 0; turn < count; turn += 1) {
+    await pi.emitTurnEnd(silentTurn(turn));
+  }
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const reminders = (messages: readonly unknown[]): Record<string, unknown>[] =>
+  messages.filter(
+    (message): message is Record<string, unknown> =>
+      isRecord(message) && message.customType === PROGRESS_REMINDER_CUSTOM_TYPE,
+  );
+
+describe("visible assistant text classification", () => {
+  test.each([
+    ["thinking", [{ type: "thinking", thinking: "analysis" }]],
+    ["tool call", [{ type: "toolCall", name: "read", arguments: {} }]],
+    ["empty text", [{ type: "text", text: "  \n" }]],
+    ["non-assistant text", [{ type: "text", text: "user text" }]],
+  ])("does not treat %s as visible feedback", (kind, content) => {
+    const role = kind === "non-assistant text" ? "user" : "assistant";
+    expect(hasVisibleAssistantText({ role, content })).toBe(false);
+  });
+
+  test("accepts non-whitespace assistant text mixed with hidden blocks", () => {
+    expect(
+      hasVisibleAssistantText({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "analysis" },
+          { type: "text", text: "  Progress update. " },
+          { type: "toolCall", name: "read", arguments: {} },
+        ],
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("progress reminder lifecycle", () => {
+  test("matches the real pi public event contract", () => {
+    expect(REAL_PI_CONTRACT).toBe(true);
+  });
+
+  test("injects one hidden transient reminder only after ten silent turns", async () => {
+    const pi = createFakePi();
+    setupProgressReminder(pi);
+    const history = [{ role: "user", content: "work" }];
+
+    await emitSilentTurns(pi, SILENT_TURN_THRESHOLD - 1);
+    expect(await pi.emitContext(history)).toEqual(history);
+
+    await pi.emitTurnEnd(silentTurn(SILENT_TURN_THRESHOLD - 1));
+    const messages = await pi.emitContext(history);
+    const injected = reminders(messages);
+    expect(injected).toHaveLength(1);
+    expect(injected[0]).toMatchObject({
+      role: "custom",
+      customType: PROGRESS_REMINDER_CUSTOM_TYPE,
+      content: PROGRESS_REMINDER,
+      display: false,
+    });
+    expect(history).toEqual([{ role: "user", content: "work" }]);
+    expect(pi.appendedEntries).toEqual([]);
+
+    expect(reminders(await pi.emitContext(history))).toHaveLength(1);
+    expect(reminders(await pi.emitContext(messages))).toHaveLength(1);
+  });
+
+  test("keeps reminding after ignored tool-only turns until text is visible", async () => {
+    const pi = createFakePi();
+    setupProgressReminder(pi);
+    await emitSilentTurns(pi);
+
+    expect(reminders(await pi.emitContext([]))).toHaveLength(1);
+    await pi.emitTurnEnd(silentTurn(SILENT_TURN_THRESHOLD));
+    expect(reminders(await pi.emitContext([]))).toHaveLength(1);
+
+    await pi.emitTurnEnd({
+      type: "turn_end",
+      turnIndex: SILENT_TURN_THRESHOLD + 1,
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Here is the progress so far." }],
+      },
+      toolResults: [],
+    });
+    expect(await pi.emitContext([])).toEqual([]);
+  });
+
+  test.each([
+    {
+      name: "before_agent_start",
+      reset: (pi: FakePi) =>
+        pi.emitBeforeAgentStart({
+          type: "before_agent_start",
+          prompt: "new user prompt",
+        }),
+    },
+    {
+      name: "queued steer input",
+      reset: (pi: FakePi) =>
+        pi.emitInput({
+          type: "input",
+          text: "queued user prompt",
+          source: "interactive",
+          streamingBehavior: "steer",
+        }),
+    },
+    {
+      name: "queued follow-up input",
+      reset: (pi: FakePi) =>
+        pi.emitInput({
+          type: "input",
+          text: "queued user prompt",
+          source: "interactive",
+          streamingBehavior: "followUp",
+        }),
+    },
+    {
+      name: "session_start",
+      reset: (pi: FakePi) =>
+        pi.emitSessionStart({ type: "session_start", reason: "resume" }),
+    },
+    {
+      name: "session_shutdown",
+      reset: (pi: FakePi) => pi.emitSessionShutdown(),
+    },
+  ])("$name resets pending reminder state", async ({ reset }) => {
+    const pi = createFakePi();
+    setupProgressReminder(pi);
+    await emitSilentTurns(pi);
+    expect(reminders(await pi.emitContext([]))).toHaveLength(1);
+
+    await reset(pi);
+    expect(await pi.emitContext([])).toEqual([]);
+  });
+
+  test("composes context handlers in registration order", async () => {
+    const pi = createFakePi();
+    setupProgressReminder(pi);
+    let messagesSeenByLaterHandler: unknown[] = [];
+    pi.on("context", (event) => {
+      messagesSeenByLaterHandler = event.messages;
+      return {
+        messages: [
+          ...event.messages,
+          {
+            role: "custom",
+            customType: "later-handler",
+            content: "later context",
+            display: false,
+            timestamp: Date.now(),
+          },
+        ],
+      };
+    });
+    await emitSilentTurns(pi);
+
+    const messages = await pi.emitContext([]);
+    expect(reminders(messagesSeenByLaterHandler)).toHaveLength(1);
+    expect(reminders(messages)).toHaveLength(1);
+    expect(
+      messages.some(
+        (message) =>
+          isRecord(message) && message.customType === "later-handler",
+      ),
+    ).toBe(true);
+  });
+
+  test("the umbrella registers reminders only in parent sessions", async () => {
+    const parent = createFakePi();
+    setupHarness(parent, makeConfig());
+    await emitSilentTurns(parent);
+    expect(reminders(await parent.emitContext([]))).toHaveLength(1);
+
+    const child = createFakePi({ hasUI: false });
+    setupHarness(child, makeConfig(true));
+    await emitSilentTurns(child);
+    expect(await child.emitContext([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- track consecutive `turn_end` responses without visible assistant text
- inject a hidden, context-only progress-summary reminder after 10 silent turns until visible feedback is returned
- reset reminder state across visible text, new and queued prompts, and session lifecycle boundaries
- extend the PiLike/fake-pi contracts for `turn_end` and registration-order `context` chaining
- enable the reminder for parent sessions and cover the behavior with focused tests

## Validation

- `bun test` — 1417 passed, 2 gated skips, 0 failed
- `bun run tsc`
- `bun run check:pi-compat`
- `bun run check:pi-baseline`
- `bun run check:pi-schemas`
- `bun run check:pi-rules`
- `bun run check:pi-imports`
- `bun run check:codex-agents`
- `bun run check:codex-rules`
- `bun run lint`
- `bun run lint:sh`

Closes #59
