### PR TITLE
feat(pi): browse local bit issues in coordination TUI

### DIFF
--- a/pi/extensions/pi-harness/features/bit-issues/cli.ts
+++ b/pi/extensions/pi-harness/features/bit-issues/cli.ts
@@ -1,0 +1,532 @@
+import { spawn } from "node:child_process";
+import { realpath } from "node:fs/promises";
+import { isAbsolute } from "node:path";
+import { sanitizeChildEnv } from "../../lib/child-env";
+import { capUtf8, stripTerminalControls } from "../../lib/terminal-text";
+import {
+  BIT_ISSUE_COMMAND_TIMEOUT_MS,
+  BIT_ISSUE_COMMENT_MAX_BYTES,
+  BIT_ISSUE_DETAIL_MAX_BYTES,
+  BIT_ISSUE_LIST_MAX_BYTES,
+  BIT_ISSUE_LIST_SENTINEL_LIMIT,
+  BIT_ISSUE_STDERR_MAX_BYTES,
+  BitIssueCliError,
+  decodeBitIssueDetail,
+  decodeOpenBitIssueList,
+  type BitIssueComments,
+  type BitIssueDetailResult,
+  type BitIssueFailureKind,
+  type BitIssueListResult,
+} from "./model";
+
+const PROCESS_TERM_GRACE_MS = 250;
+const PROCESS_FORCE_SETTLE_MS = 250;
+const GIT_STDOUT_MAX_BYTES = 64 * 1024;
+
+export interface BoundedCommandOptions {
+  readonly cwd: string;
+  readonly env: Record<string, string>;
+  readonly signal?: AbortSignal;
+  readonly timeoutMs: number;
+  readonly stdoutMaxBytes: number;
+  readonly stderrMaxBytes: number;
+  readonly allowStdoutTruncation?: boolean;
+}
+
+export interface BoundedCommandResult {
+  readonly exitCode: number;
+  readonly stdout: Uint8Array;
+  readonly stderr: Uint8Array;
+  readonly stdoutTruncated: boolean;
+}
+
+export type RunBoundedCommand = (
+  command: string,
+  args: readonly string[],
+  options: BoundedCommandOptions,
+) => Promise<BoundedCommandResult>;
+
+type BoundedCommandFailureKind =
+  | "aborted"
+  | "missing"
+  | "oversize"
+  | "spawn"
+  | "timeout";
+
+export class BoundedCommandError extends Error {
+  constructor(
+    readonly kind: BoundedCommandFailureKind,
+    readonly command: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "BoundedCommandError";
+  }
+}
+
+const asBuffer = (chunk: string | Uint8Array): Buffer =>
+  typeof chunk === "string" ? Buffer.from(chunk, "utf8") : Buffer.from(chunk);
+
+const isAborted = (signal: AbortSignal | undefined): boolean =>
+  signal !== undefined && "aborted" in signal && signal.aborted === true;
+
+const addAbortListener = (
+  signal: AbortSignal | undefined,
+  listener: () => void,
+): void => {
+  if (
+    signal !== undefined &&
+    "addEventListener" in signal &&
+    typeof signal.addEventListener === "function"
+  ) {
+    signal.addEventListener("abort", listener, { once: true });
+  }
+};
+
+const removeAbortListener = (
+  signal: AbortSignal | undefined,
+  listener: () => void,
+): void => {
+  if (
+    signal !== undefined &&
+    "removeEventListener" in signal &&
+    typeof signal.removeEventListener === "function"
+  ) {
+    signal.removeEventListener("abort", listener);
+  }
+};
+
+const killProcessGroup = (
+  child: ReturnType<typeof spawn>,
+  signal: NodeJS.Signals,
+): void => {
+  if (child.pid !== undefined) {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch {
+      // Fall back to the direct child when the process group already vanished.
+    }
+  }
+  try {
+    child.kill(signal);
+  } catch {
+    // The child may already have exited.
+  }
+};
+
+export const runBoundedCommand: RunBoundedCommand = (command, args, options) =>
+  new Promise((resolve, reject) => {
+    if (isAborted(options.signal)) {
+      reject(
+        new BoundedCommandError("aborted", command, `${command} was aborted`),
+      );
+      return;
+    }
+
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(command, [...args], {
+        cwd: options.cwd,
+        env: options.env,
+        detached: true,
+        shell: false,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (error) {
+      reject(
+        new BoundedCommandError(
+          "spawn",
+          command,
+          `${command} could not start: ${String(error)}`,
+        ),
+      );
+      return;
+    }
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let stdoutTruncated = false;
+    let settled = false;
+    let terminationStarted = false;
+    let failure: BoundedCommandError | undefined;
+    let killTimer: ReturnType<typeof setTimeout> | undefined;
+    let forceTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const detachAbortListener = (): void => {
+      removeAbortListener(options.signal, onAbort);
+    };
+    const cleanup = (): void => {
+      clearTimeout(timeoutTimer);
+      if (killTimer !== undefined) clearTimeout(killTimer);
+      if (forceTimer !== undefined) clearTimeout(forceTimer);
+      detachAbortListener();
+    };
+    const finish = (exitCode: number | null): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (failure !== undefined) {
+        reject(failure);
+        return;
+      }
+      resolve({
+        exitCode: exitCode ?? 1,
+        stdout: Buffer.concat(stdoutChunks, stdoutBytes),
+        stderr: Buffer.concat(stderrChunks, stderrBytes),
+        stdoutTruncated,
+      });
+    };
+    const terminate = (): void => {
+      if (terminationStarted || settled) return;
+      terminationStarted = true;
+      killProcessGroup(child, "SIGTERM");
+      killTimer = setTimeout(() => {
+        killProcessGroup(child, "SIGKILL");
+        forceTimer = setTimeout(() => finish(null), PROCESS_FORCE_SETTLE_MS);
+        forceTimer.unref?.();
+      }, PROCESS_TERM_GRACE_MS);
+      killTimer.unref?.();
+    };
+    const fail = (next: BoundedCommandError): void => {
+      if (failure === undefined) failure = next;
+      terminate();
+    };
+    const append = (
+      chunks: Buffer[],
+      currentBytes: number,
+      chunk: Buffer,
+      limit: number,
+    ): { bytes: number; exceeded: boolean } => {
+      const remaining = Math.max(0, limit - currentBytes);
+      if (remaining > 0) chunks.push(chunk.subarray(0, remaining));
+      return {
+        bytes: currentBytes + Math.min(remaining, chunk.byteLength),
+        exceeded: chunk.byteLength > remaining,
+      };
+    };
+    const onAbort = (): void =>
+      fail(
+        new BoundedCommandError("aborted", command, `${command} was aborted`),
+      );
+
+    child.stdout?.on("data", (raw: string | Uint8Array) => {
+      if (settled || stdoutTruncated) return;
+      const result = append(
+        stdoutChunks,
+        stdoutBytes,
+        asBuffer(raw),
+        options.stdoutMaxBytes,
+      );
+      stdoutBytes = result.bytes;
+      if (!result.exceeded) return;
+      if (options.allowStdoutTruncation === true) {
+        stdoutTruncated = true;
+        terminate();
+        return;
+      }
+      fail(
+        new BoundedCommandError(
+          "oversize",
+          command,
+          `${command} stdout exceeded ${options.stdoutMaxBytes} bytes`,
+        ),
+      );
+    });
+    child.stderr?.on("data", (raw: string | Uint8Array) => {
+      if (settled) return;
+      const result = append(
+        stderrChunks,
+        stderrBytes,
+        asBuffer(raw),
+        options.stderrMaxBytes,
+      );
+      stderrBytes = result.bytes;
+      if (result.exceeded) {
+        fail(
+          new BoundedCommandError(
+            "oversize",
+            command,
+            `${command} stderr exceeded ${options.stderrMaxBytes} bytes`,
+          ),
+        );
+      }
+    });
+    child.once("error", (error: NodeJS.ErrnoException) => {
+      const kind = error.code === "ENOENT" ? "missing" : "spawn";
+      failure ??= new BoundedCommandError(
+        kind,
+        command,
+        `${command} could not start: ${error.message}`,
+      );
+      finish(null);
+    });
+    child.once("close", (code) => finish(code));
+
+    const timeoutTimer = setTimeout(() => {
+      fail(
+        new BoundedCommandError(
+          "timeout",
+          command,
+          `${command} timed out after ${options.timeoutMs}ms`,
+        ),
+      );
+    }, options.timeoutMs);
+    timeoutTimer.unref?.();
+    addAbortListener(options.signal, onAbort);
+    if (isAborted(options.signal)) onAbort();
+  });
+
+export interface BitIssueCliOptions {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly runCommand?: RunBoundedCommand;
+  readonly realpath?: (path: string) => Promise<string>;
+}
+
+const fatalDecoder = new TextDecoder(undefined, { fatal: true });
+const lossyDecoder = new TextDecoder();
+
+const decodeFatal = (bytes: Uint8Array, label: string): string => {
+  try {
+    return fatalDecoder.decode(bytes);
+  } catch {
+    throw new BitIssueCliError("invalid-data", `${label} is not valid UTF-8`);
+  }
+};
+
+const parseJson = (bytes: Uint8Array, label: string): unknown => {
+  try {
+    return JSON.parse(decodeFatal(bytes, label));
+  } catch (error) {
+    if (error instanceof BitIssueCliError) throw error;
+    throw new BitIssueCliError("invalid-data", `${label} is not valid JSON`);
+  }
+};
+
+const failureMessage = (result: BoundedCommandResult): string => {
+  const stderr = stripTerminalControls(lossyDecoder.decode(result.stderr), " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return capUtf8(
+    stderr === "" ? `exit code ${result.exitCode}` : stderr,
+    4 * 1024,
+  );
+};
+
+const mapCommandError = (
+  error: unknown,
+  command: "bit" | "git",
+): BitIssueCliError => {
+  if (error instanceof BitIssueCliError) return error;
+  if (!(error instanceof BoundedCommandError)) {
+    return new BitIssueCliError(
+      "command-failed",
+      `${command} command failed: ${String(error)}`,
+    );
+  }
+  let kind: BitIssueFailureKind;
+  if (error.kind === "missing")
+    kind = command === "bit" ? "missing-bit" : "missing-git";
+  else if (error.kind === "timeout") kind = "timeout";
+  else if (error.kind === "aborted") kind = "aborted";
+  else if (error.kind === "oversize") kind = "oversize";
+  else kind = "command-failed";
+  return new BitIssueCliError(kind, error.message);
+};
+
+const hasControlCharacter = (value: string): boolean =>
+  [...value].some((character) => {
+    const code = character.codePointAt(0);
+    return code !== undefined && (code <= 0x1f || code === 0x7f);
+  });
+
+export class BitIssueCli {
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly runCommand: RunBoundedCommand;
+  private readonly resolveRealpath: (path: string) => Promise<string>;
+
+  constructor(options: BitIssueCliOptions = {}) {
+    this.env = options.env ?? process.env;
+    this.runCommand = options.runCommand ?? runBoundedCommand;
+    this.resolveRealpath = options.realpath ?? realpath;
+  }
+
+  async listOpen(
+    cwd: string,
+    signal?: AbortSignal,
+  ): Promise<BitIssueListResult> {
+    const commonDir = await this.gitCommonDir(cwd, signal);
+    const result = await this.runBit(
+      cwd,
+      commonDir,
+      [
+        "issue",
+        "list",
+        "--open",
+        "--all",
+        "--limit",
+        String(BIT_ISSUE_LIST_SENTINEL_LIMIT),
+        "--format",
+        "json",
+      ],
+      BIT_ISSUE_LIST_MAX_BYTES,
+      signal,
+    );
+    if (result.exitCode !== 0) {
+      throw new BitIssueCliError(
+        "command-failed",
+        `bit issue list failed: ${failureMessage(result)}`,
+      );
+    }
+    return decodeOpenBitIssueList(
+      parseJson(result.stdout, "bit issue list output"),
+    );
+  }
+
+  async getDetail(
+    cwd: string,
+    id: string,
+    signal?: AbortSignal,
+  ): Promise<BitIssueDetailResult> {
+    if (!/^[A-Za-z0-9_-]{1,128}$/.test(id)) {
+      throw new BitIssueCliError("invalid-data", "bit issue id is invalid");
+    }
+    const commonDir = await this.gitCommonDir(cwd, signal);
+    const issueResult = await this.runBit(
+      cwd,
+      commonDir,
+      ["issue", "get", id, "--format", "json"],
+      BIT_ISSUE_DETAIL_MAX_BYTES,
+      signal,
+    );
+    if (issueResult.exitCode !== 0) {
+      throw new BitIssueCliError(
+        "command-failed",
+        `bit issue get failed: ${failureMessage(issueResult)}`,
+      );
+    }
+    const issue = decodeBitIssueDetail(
+      parseJson(issueResult.stdout, "bit issue detail output"),
+    );
+    if (issue.id !== id) {
+      throw new BitIssueCliError(
+        "invalid-data",
+        "bit issue detail id does not match the requested id",
+      );
+    }
+    let comments: BitIssueComments;
+    try {
+      const commentResult = await this.runBit(
+        cwd,
+        commonDir,
+        ["issue", "comment", "list", id],
+        BIT_ISSUE_COMMENT_MAX_BYTES,
+        signal,
+        true,
+      );
+      if (commentResult.exitCode !== 0 && !commentResult.stdoutTruncated) {
+        comments = {
+          status: "error",
+          message: `bit issue comments failed: ${failureMessage(commentResult)}`,
+        };
+      } else {
+        const decoded = commentResult.stdoutTruncated
+          ? lossyDecoder.decode(commentResult.stdout)
+          : decodeFatal(commentResult.stdout, "bit issue comment output");
+        const raw = stripTerminalControls(decoded);
+        if (raw.trim() === "No comments" || raw.trim() === "") {
+          comments = { status: "none" };
+        } else {
+          comments = {
+            status: "ready",
+            text: commentResult.stdoutTruncated
+              ? `${raw}\n\n… comments truncated at ${BIT_ISSUE_COMMENT_MAX_BYTES} bytes`
+              : raw,
+            truncated: commentResult.stdoutTruncated,
+          };
+        }
+      }
+    } catch (error) {
+      const mapped = mapCommandError(error, "bit");
+      if (mapped.kind === "aborted") throw mapped;
+      comments = { status: "error", message: mapped.message };
+    }
+    return { issue, comments };
+  }
+
+  private async gitCommonDir(
+    cwd: string,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    let result: BoundedCommandResult;
+    try {
+      result = await this.runCommand(
+        "git",
+        ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+        {
+          cwd,
+          env: sanitizeChildEnv(this.env, {}, { cwd }),
+          signal,
+          timeoutMs: BIT_ISSUE_COMMAND_TIMEOUT_MS,
+          stdoutMaxBytes: GIT_STDOUT_MAX_BYTES,
+          stderrMaxBytes: BIT_ISSUE_STDERR_MAX_BYTES,
+        },
+      );
+    } catch (error) {
+      throw mapCommandError(error, "git");
+    }
+    if (result.exitCode !== 0) {
+      throw new BitIssueCliError(
+        "non-git",
+        `Git repository unavailable: ${failureMessage(result)}`,
+      );
+    }
+    const output = decodeFatal(result.stdout, "git common-dir output");
+    const match = /^([^\r\n]+)(?:\r?\n)?$/.exec(output);
+    const commonDir = match?.[1];
+    if (
+      commonDir === undefined ||
+      !isAbsolute(commonDir) ||
+      hasControlCharacter(commonDir)
+    ) {
+      throw new BitIssueCliError("non-git", "Git common directory is invalid");
+    }
+    try {
+      const canonical = await this.resolveRealpath(commonDir);
+      if (!isAbsolute(canonical) || hasControlCharacter(canonical)) {
+        throw new Error("invalid canonical common directory");
+      }
+      return canonical;
+    } catch {
+      throw new BitIssueCliError(
+        "non-git",
+        "Git common directory does not resolve",
+      );
+    }
+  }
+
+  private async runBit(
+    cwd: string,
+    commonDir: string,
+    args: readonly string[],
+    stdoutMaxBytes: number,
+    signal?: AbortSignal,
+    allowStdoutTruncation = false,
+  ): Promise<BoundedCommandResult> {
+    try {
+      return await this.runCommand("bit", args, {
+        cwd,
+        env: sanitizeChildEnv(this.env, { GIT_DIR: commonDir }, { cwd }),
+        signal,
+        timeoutMs: BIT_ISSUE_COMMAND_TIMEOUT_MS,
+        stdoutMaxBytes,
+        stderrMaxBytes: BIT_ISSUE_STDERR_MAX_BYTES,
+        allowStdoutTruncation,
+      });
+    } catch (error) {
+      throw mapCommandError(error, "bit");
+    }
+  }
+}

--- a/pi/extensions/pi-harness/features/bit-issues/model.ts
+++ b/pi/extensions/pi-harness/features/bit-issues/model.ts
@@ -1,0 +1,211 @@
+import { capUtf8, stripTerminalControls } from "../../lib/terminal-text";
+
+export const BIT_ISSUE_DISPLAY_LIMIT = 100;
+export const BIT_ISSUE_LIST_SENTINEL_LIMIT = BIT_ISSUE_DISPLAY_LIMIT + 1;
+export const BIT_ISSUE_LIST_MAX_BYTES = 4 * 1024 * 1024;
+export const BIT_ISSUE_DETAIL_MAX_BYTES = 1024 * 1024;
+export const BIT_ISSUE_COMMENT_MAX_BYTES = 1024 * 1024;
+export const BIT_ISSUE_STDERR_MAX_BYTES = 64 * 1024;
+export const BIT_ISSUE_COMMAND_TIMEOUT_MS = 5_000;
+
+const MAX_DATE_SECONDS = 8_640_000_000_000;
+
+export type BitIssueState = "open" | "closed";
+
+export interface BitIssueSummary {
+  readonly id: string;
+  readonly title: string;
+  readonly state: BitIssueState;
+  readonly author: string;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+  readonly labels: readonly string[];
+}
+
+export interface BitIssueDetail extends BitIssueSummary {
+  readonly body: string;
+}
+
+export interface BitIssueListResult {
+  readonly issues: readonly BitIssueSummary[];
+  readonly truncated: boolean;
+}
+
+export type BitIssueComments =
+  | { readonly status: "none" }
+  | {
+      readonly status: "ready";
+      readonly text: string;
+      readonly truncated: boolean;
+    }
+  | { readonly status: "error"; readonly message: string };
+
+export interface BitIssueDetailResult {
+  readonly issue: BitIssueDetail;
+  readonly comments: BitIssueComments;
+}
+
+export type BitIssueFailureKind =
+  | "aborted"
+  | "command-failed"
+  | "invalid-data"
+  | "missing-bit"
+  | "missing-git"
+  | "non-git"
+  | "oversize"
+  | "timeout";
+
+export class BitIssueCliError extends Error {
+  constructor(
+    readonly kind: BitIssueFailureKind,
+    message: string,
+  ) {
+    super(message);
+    this.name = "BitIssueCliError";
+  }
+}
+
+export interface BitIssueSnapshot {
+  readonly issues: readonly BitIssueSummary[];
+  readonly truncated: boolean;
+  readonly loading: boolean;
+  readonly stale: boolean;
+  readonly error?: string;
+  readonly refreshedAt?: number;
+}
+
+export type BitIssueDetailState =
+  | { readonly status: "idle" }
+  | { readonly status: "loading" }
+  | { readonly status: "ready"; readonly detail: BitIssueDetailResult }
+  | { readonly status: "error"; readonly message: string };
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const requiredString = (
+  record: Record<string, unknown>,
+  key: string,
+): string => {
+  const value = record[key];
+  if (typeof value !== "string") {
+    throw new BitIssueCliError(
+      "invalid-data",
+      `bit issue field ${key} is not a string`,
+    );
+  }
+  return value;
+};
+
+const requiredTimestamp = (
+  record: Record<string, unknown>,
+  key: string,
+): number => {
+  const value = record[key];
+  if (
+    !Number.isSafeInteger(value) ||
+    (value as number) < 0 ||
+    (value as number) > MAX_DATE_SECONDS
+  ) {
+    throw new BitIssueCliError(
+      "invalid-data",
+      `bit issue field ${key} is not a timestamp`,
+    );
+  }
+  return value as number;
+};
+
+const decodeLabels = (value: unknown): readonly string[] => {
+  if (
+    !Array.isArray(value) ||
+    value.length > 128 ||
+    value.some((label) => typeof label !== "string")
+  ) {
+    throw new BitIssueCliError("invalid-data", "bit issue labels are invalid");
+  }
+  return value.map((label) =>
+    capUtf8(stripTerminalControls(label as string, " "), 256),
+  );
+};
+
+const decodeIssue = (value: unknown): BitIssueDetail => {
+  if (!isRecord(value)) {
+    throw new BitIssueCliError(
+      "invalid-data",
+      "bit issue JSON item is not an object",
+    );
+  }
+  const id = requiredString(value, "id");
+  if (!/^[A-Za-z0-9_-]{1,128}$/.test(id)) {
+    throw new BitIssueCliError("invalid-data", "bit issue id is invalid");
+  }
+  const rawState = requiredString(value, "state");
+  if (rawState !== "open" && rawState !== "closed") {
+    throw new BitIssueCliError("invalid-data", "bit issue state is invalid");
+  }
+  return {
+    id,
+    title: capUtf8(
+      stripTerminalControls(requiredString(value, "title"), " "),
+      16 * 1024,
+    ),
+    state: rawState,
+    author: capUtf8(
+      stripTerminalControls(requiredString(value, "author"), " "),
+      4 * 1024,
+    ),
+    createdAt: requiredTimestamp(value, "created_at"),
+    updatedAt: requiredTimestamp(value, "updated_at"),
+    labels: decodeLabels(value.labels),
+    body: capUtf8(
+      stripTerminalControls(requiredString(value, "body")),
+      BIT_ISSUE_DETAIL_MAX_BYTES,
+    ),
+  };
+};
+
+const asSummary = (issue: BitIssueDetail): BitIssueSummary => ({
+  id: issue.id,
+  title: issue.title,
+  state: issue.state,
+  author: issue.author,
+  createdAt: issue.createdAt,
+  updatedAt: issue.updatedAt,
+  labels: [...issue.labels],
+});
+
+export const decodeOpenBitIssueList = (value: unknown): BitIssueListResult => {
+  if (!Array.isArray(value) || value.length > BIT_ISSUE_LIST_SENTINEL_LIMIT) {
+    throw new BitIssueCliError(
+      "invalid-data",
+      "bit issue list JSON is invalid",
+    );
+  }
+  const seen = new Set<string>();
+  const open: BitIssueSummary[] = [];
+  for (const item of value) {
+    const issue = decodeIssue(item);
+    if (seen.has(issue.id)) {
+      throw new BitIssueCliError(
+        "invalid-data",
+        `duplicate bit issue id: ${issue.id}`,
+      );
+    }
+    seen.add(issue.id);
+    if (issue.state === "open") open.push(asSummary(issue));
+  }
+  open.sort((left, right) => {
+    const updatedOrder = right.updatedAt - left.updatedAt;
+    if (updatedOrder !== 0) return updatedOrder;
+    if (left.id < right.id) return -1;
+    if (left.id > right.id) return 1;
+    return 0;
+  });
+  return {
+    issues: open.slice(0, BIT_ISSUE_DISPLAY_LIMIT),
+    truncated: open.length > BIT_ISSUE_DISPLAY_LIMIT,
+  };
+};
+
+export const decodeBitIssueDetail = (value: unknown): BitIssueDetail =>
+  decodeIssue(value);

--- a/pi/extensions/pi-harness/features/bit-issues/registry.ts
+++ b/pi/extensions/pi-harness/features/bit-issues/registry.ts
@@ -1,0 +1,361 @@
+import { stripTerminalControls } from "../../lib/terminal-text";
+import { BitIssueCli } from "./cli";
+import {
+  BitIssueCliError,
+  type BitIssueDetailState,
+  type BitIssueFailureKind,
+  type BitIssueSnapshot,
+} from "./model";
+
+export type BitIssueRefreshOutcome =
+  | {
+      readonly ok: true;
+      readonly count: number;
+      readonly truncated: boolean;
+    }
+  | {
+      readonly ok: false;
+      readonly kind: BitIssueFailureKind;
+      readonly message: string;
+    };
+
+export type BitIssueDataSource = Pick<BitIssueCli, "listOpen" | "getDetail">;
+
+interface BitIssueRegistryOptions {
+  readonly cli?: BitIssueDataSource;
+  readonly now?: () => number;
+}
+
+interface AbortSignalLike {
+  readonly aborted: boolean;
+  addEventListener(
+    event: "abort",
+    listener: () => void,
+    options?: { once?: boolean },
+  ): void;
+  removeEventListener(event: "abort", listener: () => void): void;
+}
+
+interface AbortControllerLike {
+  readonly signal: AbortSignal & AbortSignalLike;
+  abort(): void;
+}
+
+interface LinkedController {
+  readonly controller: AbortControllerLike;
+  dispose(): void;
+}
+
+const isAbortSignal = (
+  value: unknown,
+): value is AbortSignal & AbortSignalLike =>
+  typeof value === "object" &&
+  value !== null &&
+  "aborted" in value &&
+  typeof value.aborted === "boolean" &&
+  "addEventListener" in value &&
+  typeof value.addEventListener === "function" &&
+  "removeEventListener" in value &&
+  typeof value.removeEventListener === "function";
+
+const createAbortController = (): AbortControllerLike => {
+  const controller: unknown = new AbortController();
+  if (
+    typeof controller !== "object" ||
+    controller === null ||
+    !("abort" in controller) ||
+    typeof controller.abort !== "function" ||
+    !("signal" in controller) ||
+    !isAbortSignal(controller.signal)
+  ) {
+    throw new Error("AbortController is unavailable");
+  }
+  const { abort, signal } = controller;
+  return {
+    signal,
+    abort: () => Reflect.apply(abort, controller, []),
+  };
+};
+
+const linkedController = (signal?: AbortSignal): LinkedController => {
+  const controller = createAbortController();
+  const abort = (): void => controller.abort();
+  if (isAbortSignal(signal))
+    signal.addEventListener("abort", abort, { once: true });
+  if (isAbortSignal(signal) && signal.aborted) abort();
+  return {
+    controller,
+    dispose() {
+      if (isAbortSignal(signal)) signal.removeEventListener("abort", abort);
+    },
+  };
+};
+
+const safeMessage = (error: unknown): string =>
+  stripTerminalControls(
+    error instanceof Error ? error.message : String(error),
+    " ",
+  )
+    .replace(/\s+/g, " ")
+    .trim();
+
+const asCliError = (error: unknown): BitIssueCliError =>
+  error instanceof BitIssueCliError
+    ? error
+    : new BitIssueCliError("command-failed", safeMessage(error));
+
+const initialSnapshot = (): BitIssueSnapshot => ({
+  issues: [],
+  truncated: false,
+  loading: false,
+  stale: false,
+});
+
+export class BitIssueRegistry {
+  private readonly cli: BitIssueDataSource;
+  private readonly now: () => number;
+  private readonly subscribers = new Set<() => void>();
+  private readonly detailStates = new Map<string, BitIssueDetailState>();
+  private readonly detailControllers = new Map<string, AbortControllerLike>();
+  private readonly detailTokens = new Map<string, number>();
+  private snapshot: BitIssueSnapshot = initialSnapshot();
+  private cwd: string | undefined;
+  private generation = 0;
+  private refreshController: AbortControllerLike | undefined;
+  private refreshPromise: Promise<BitIssueRefreshOutcome> | undefined;
+  private refreshRequests = 0;
+  private disposed = false;
+
+  constructor(options: BitIssueRegistryOptions = {}) {
+    this.cli = options.cli ?? new BitIssueCli();
+    this.now = options.now ?? Date.now;
+  }
+
+  beginSession(cwd: string): void {
+    if (this.disposed) return;
+    this.abortInFlight();
+    this.generation += 1;
+    this.cwd = cwd;
+    this.refreshRequests = 0;
+    this.snapshot = initialSnapshot();
+    this.detailStates.clear();
+    this.detailTokens.clear();
+    this.publish();
+  }
+
+  getSnapshot(): BitIssueSnapshot {
+    return {
+      ...this.snapshot,
+      issues: this.snapshot.issues.map((issue) => ({
+        ...issue,
+        labels: [...issue.labels],
+      })),
+    };
+  }
+
+  getDetailState(id: string): BitIssueDetailState {
+    return this.detailStates.get(id) ?? { status: "idle" };
+  }
+
+  prepareDetail(id: string): void {
+    if (this.disposed) return;
+    this.detailControllers.get(id)?.abort();
+    this.detailControllers.delete(id);
+    this.detailTokens.set(id, (this.detailTokens.get(id) ?? 0) + 1);
+    this.detailStates.set(id, { status: "loading" });
+    this.publish();
+  }
+
+  async refresh(
+    cwd: string,
+    signal?: AbortSignal,
+  ): Promise<BitIssueRefreshOutcome> {
+    if (this.disposed) {
+      return {
+        ok: false,
+        kind: "aborted",
+        message: "bit issue registry is disposed",
+      };
+    }
+    if (this.cwd !== cwd) this.beginSession(cwd);
+    this.refreshRequests += 1;
+    if (this.refreshPromise !== undefined) return this.refreshPromise;
+
+    const linked = linkedController(signal);
+    this.refreshController = linked.controller;
+    const { generation } = this;
+    this.snapshot = { ...this.snapshot, loading: true };
+    this.publish();
+
+    const refreshPromise = this.drainRefreshRequests(
+      cwd,
+      generation,
+      linked.controller.signal,
+    ).finally(() => {
+      linked.dispose();
+      if (this.refreshPromise !== refreshPromise) return;
+      this.refreshPromise = undefined;
+      this.refreshController = undefined;
+    });
+    this.refreshPromise = refreshPromise;
+    return refreshPromise;
+  }
+
+  private async drainRefreshRequests(
+    cwd: string,
+    generation: number,
+    signal: AbortSignal,
+  ): Promise<BitIssueRefreshOutcome> {
+    while (!this.disposed && generation === this.generation) {
+      const request = this.refreshRequests;
+      try {
+        const result = await this.cli.listOpen(cwd, signal);
+        if (this.disposed || generation !== this.generation) break;
+        if (request !== this.refreshRequests) continue;
+
+        this.snapshot = {
+          issues: result.issues,
+          truncated: result.truncated,
+          loading: false,
+          stale: false,
+          refreshedAt: this.now(),
+        };
+        this.publish();
+        if (request !== this.refreshRequests) {
+          this.snapshot = { ...this.snapshot, loading: true };
+          this.publish();
+          continue;
+        }
+        return {
+          ok: true,
+          count: result.issues.length,
+          truncated: result.truncated,
+        };
+      } catch (error) {
+        const failure = asCliError(error);
+        if (this.disposed || generation !== this.generation) break;
+        if (request !== this.refreshRequests && failure.kind !== "aborted") {
+          continue;
+        }
+        this.snapshot = {
+          ...this.snapshot,
+          loading: false,
+          stale: this.snapshot.refreshedAt !== undefined,
+          error: safeMessage(failure),
+        };
+        this.publish();
+        return {
+          ok: false,
+          kind: failure.kind,
+          message: safeMessage(failure),
+        };
+      }
+    }
+    return {
+      ok: false,
+      kind: "aborted",
+      message: "stale bit issue refresh discarded",
+    };
+  }
+
+  async loadDetail(
+    id: string,
+    signal?: AbortSignal,
+  ): Promise<BitIssueDetailState> {
+    if (this.disposed || this.cwd === undefined) {
+      return { status: "error", message: "bit issue session is unavailable" };
+    }
+    this.prepareDetail(id);
+    const token = this.detailTokens.get(id) ?? 0;
+    const linked = linkedController(signal);
+    this.detailControllers.set(id, linked.controller);
+    const { generation, cwd } = this;
+    try {
+      const detail = await this.cli.getDetail(
+        cwd,
+        id,
+        linked.controller.signal,
+      );
+      if (
+        this.disposed ||
+        generation !== this.generation ||
+        token !== this.detailTokens.get(id)
+      ) {
+        return { status: "error", message: "stale bit issue detail discarded" };
+      }
+      const state: BitIssueDetailState = { status: "ready", detail };
+      this.detailStates.set(id, state);
+      if (detail.issue.state !== "open") {
+        this.snapshot = {
+          ...this.snapshot,
+          issues: this.snapshot.issues.filter((issue) => issue.id !== id),
+        };
+      }
+      this.publish();
+      return state;
+    } catch (error) {
+      const failure = asCliError(error);
+      const state: BitIssueDetailState = {
+        status: "error",
+        message: safeMessage(failure),
+      };
+      if (
+        !this.disposed &&
+        generation === this.generation &&
+        token === this.detailTokens.get(id) &&
+        failure.kind !== "aborted"
+      ) {
+        this.detailStates.set(id, state);
+        this.publish();
+      }
+      return state;
+    } finally {
+      linked.dispose();
+      if (this.detailControllers.get(id) === linked.controller) {
+        this.detailControllers.delete(id);
+      }
+    }
+  }
+
+  cancelDetail(id: string): void {
+    this.detailControllers.get(id)?.abort();
+    this.detailControllers.delete(id);
+    this.detailTokens.set(id, (this.detailTokens.get(id) ?? 0) + 1);
+    this.detailStates.delete(id);
+  }
+
+  subscribe(listener: () => void): () => void {
+    if (this.disposed) return () => {};
+    this.subscribers.add(listener);
+    return () => this.subscribers.delete(listener);
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.abortInFlight();
+    this.subscribers.clear();
+    this.detailStates.clear();
+    this.detailTokens.clear();
+  }
+
+  private abortInFlight(): void {
+    this.refreshController?.abort();
+    this.refreshController = undefined;
+    this.refreshPromise = undefined;
+    for (const controller of this.detailControllers.values())
+      controller.abort();
+    this.detailControllers.clear();
+  }
+
+  private publish(): void {
+    if (this.disposed) return;
+    for (const subscriber of this.subscribers) {
+      try {
+        subscriber();
+      } catch {
+        // One TUI listener must not prevent updates reaching the others.
+      }
+    }
+  }
+}

--- a/pi/extensions/pi-harness/features/child-runs/README.md
+++ b/pi/extensions/pi-harness/features/child-runs/README.md
@@ -1,7 +1,8 @@
-# Child-session browser
+# Coordination browser
 
-The pi-harness `subagent` and `workflow` tools expose their child runs in a
-resident full-width TUI browser between the chat editor and statusline.
+pi-harness exposes child runs and open local `bit issue` records in one resident
+full-width TUI browser between the chat editor and statusline. It deliberately
+uses one `belowEditor` widget and one focus owner for both sources.
 
 ## Behavior
 
@@ -10,12 +11,20 @@ resident full-width TUI browser between the chat editor and statusline.
   do other work.
 - The first child invocation mounts the browser in pi's `belowEditor` widget
   slot without stealing focus from the main editor.
+- When `bit-task` is enabled, `session_start` refreshes open issues in the
+  current Git repository. One or more open issues also mount the browser without
+  stealing editor focus. Closed issues are never listed.
+- The header reports `Child sessions: N | Open bit issues: M`. One scrollable
+  list places child rows first when present, followed by issue rows sorted by
+  `updated_at` descending and stable issue id.
 - The browser receives the full terminal content width and remains in normal
   layout flow, so it does not cover chat or editor content.
 - Its height is approximately one quarter of the terminal, clamped to 4–10
   lines. The cap preserves useful editor and conversation space on common
   24-row and 40-row terminals; extremely short terminals may still be tight.
-- `/subagents` or `Ctrl+Alt+S` shows and focuses the browser.
+- `/subagents` or `Ctrl+Alt+S` shows and focuses the browser with a child row
+  preferred. `/bit-issues` or `Ctrl+Alt+I` refreshes and focuses it with an
+  issue row preferred.
 - When a cursor-aware editor has focus, Down keeps its native cursor/history
   behavior. If native Down changes neither editor text nor cursor at the bottom
   boundary, focus moves to the browser with its current run selected.
@@ -26,23 +35,33 @@ resident full-width TUI browser between the chat editor and statusline.
 - pi currently has a public focus setter but no public focus getter. The one
   private getter seam is capability-isolated. If a pi update removes or changes
   it, the resident list becomes passive, Down is left entirely to the editor,
-  and `/subagents` / `Ctrl+Alt+S` opens a fresh public `ui.custom` overlay. The
+  and the explicit browser commands open a fresh public `ui.custom` overlay. The
   degradation warns once and never disables child execution or other harness
   features.
 - `Esc` returns focus to the main editor while leaving the browser visible.
-- `q` hides the browser. A new child run, `/subagents`, or the shortcut shows
-  it again.
-- In the resident list, arrow keys only select runs. Enter opens the selected
-  run in a focused, near-full-screen overlay; raw Enter sequences are accepted
-  even when the editor keybinding adapter cannot classify them.
-- In the detail overlay, arrow keys only scroll that fixed transcript.
-  PageUp/PageDown move by a viewport, Home/End jump to the beginning/live end,
-  and Escape, Left, `b`, or `q` closes the overlay and returns to the list.
+- `q` hides the browser. Automatic issue refresh does not remount an explicitly
+  hidden browser. A new child run or either explicit browser command shows it
+  again.
+- In the resident list, Up/Down, `j`/`k`, and PageUp/PageDown select across both
+  row kinds. Enter or Right opens the selected child or issue. `r` refreshes
+  open issues without polling or relay-backed watch behavior.
+- Child and issue details use the same focused near-full-screen overlay.
+  PageUp/PageDown move by a viewport, Home/End jump to the ends, and Escape,
+  Left, `b`, or `q` closes the overlay and returns to the list. Child details
+  retain live-follow behavior.
+- Issue detail is loaded lazily with `bit issue get <id> --format json`, then
+  bounded raw output from `bit issue comment list <id>`. It shows metadata,
+  labels, body, and comments read-only. Human-readable comment output is not
+  parsed into synthetic comment records.
 - Completed transcripts open at the beginning. Running transcripts open in
   live-follow mode; scrolling upward pauses follow until End is pressed.
 - The normal subagent/workflow tool row remains a compact status summary.
 
 Closing, hiding, or unfocusing the browser never cancels child execution.
+Issue refresh also runs after the agent settles, when the panel gains focus,
+on explicit refresh, and immediately before issue detail loading. Refresh is
+single-flight and session-generation guarded; failures retain a stale
+last-known-good list.
 
 When an invocation completes, pi-harness persists its bounded transcript,
 adds one explicitly untrusted aggregate result to the parent context, and
@@ -83,6 +102,19 @@ likewise abort active process groups.
 Children still run with `--no-session`; browser entries are view-only and
 cannot be resumed or forked as native pi sessions.
 
+Bit issue rows and detail are also view-only. pi-harness never updates, closes,
+reopens, or comments on an issue from the TUI. Issue bodies and comments remain
+registry-local TUI state: they are not sent to the LLM, appended to pi session
+JSONL, or copied into child transcript persistence. Every untrusted title,
+body, label, author, and comment line is terminal-control sanitized and
+Unicode-width bounded before rendering.
+
+The adapter resolves an absolute Git common directory first, then directly
+spawns only `bit issue list --open --all --limit 101 --format json`, `bit issue
+get`, and `bit issue comment list` with a scrubbed child environment and the
+verified `GIT_DIR`. List/detail/comment output, stderr, time, and cancellation
+are bounded. Relay, import, sync, claim, and watch commands are never used.
+
 A dedicated parent custom entry persists a versioned, bounded transcript so
 completed background runs remain inspectable after resuming the parent
 session. Legacy synchronous tool-result transcript entries remain readable. The
@@ -114,8 +146,9 @@ raw source data.
 
 ## Interactive smoke check
 
-1. Start pi and launch a parallel `subagent` call or a multi-task `workflow`.
-2. Confirm the full-width list appears below the editor and above the
+1. Start pi in a Git repository with an open local bit issue, or launch a
+   parallel `subagent` call / multi-task `workflow`.
+2. Confirm one full-width combined list appears below the editor and above the
    statusline without taking editor focus.
 3. In a multi-line draft, press Down and confirm native cursor movement still
    works; at the bottom boundary, press Down again and confirm list focus.
@@ -125,8 +158,11 @@ raw source data.
    remains fixed; press End and confirm live-follow resumes.
 6. Press Escape and confirm focus returns to the resident list, then Escape
    again and confirm normal editor input continues.
-7. Press `q` in the list, then run `/subagents` and confirm it reappears.
-8. With the private focus capability disabled in a test runtime, confirm Down
+7. Select an issue, press Enter, and confirm its body and comments appear
+   without entering chat/session history. Use `r` to refresh closed/open state.
+8. Press `q`, trigger an automatic refresh, and confirm the browser stays
+   hidden; then run `/subagents` or `/bit-issues` and confirm it reappears.
+9. With the private focus capability disabled in a test runtime, confirm Down
    remains native and `/subagents` opens/closes the public overlay fallback.
-9. Resume the parent session and confirm completed transcripts open from the
-   beginning and remain scrollable within the documented retention bounds.
+10. Resume the parent session and confirm completed transcripts open from the
+    beginning and remain scrollable within the documented retention bounds.

--- a/pi/extensions/pi-harness/features/child-runs/index.ts
+++ b/pi/extensions/pi-harness/features/child-runs/index.ts
@@ -1,4 +1,6 @@
 import type { CtxLike, PiLike } from "../../lib/pi-like";
+import { BitIssueCli } from "../bit-issues/cli";
+import { BitIssueRegistry } from "../bit-issues/registry";
 import {
   CHILD_RUN_COMPLETION_ENTRY,
   BackgroundInvocationManager,
@@ -93,8 +95,15 @@ const appendBackgroundAgentSystemPrompt = (systemPrompt: string): string =>
 
 export interface ChildRunsIntegration {
   registry: ChildRunRegistry;
+  bitIssues?: BitIssueRegistry;
   background?: BackgroundInvocationManager;
   ensureVisible(ctx: CtxLike): void;
+}
+
+export interface SetupChildRunsOptions {
+  readonly bitIssues?: boolean;
+  readonly bitIssueCli?: BitIssueCli;
+  readonly childExecution?: boolean;
 }
 
 const replayBranch = (
@@ -106,11 +115,48 @@ const replayBranch = (
   registry.replacePersistedHistory(extractPersistedChildRuns(branch));
 };
 
-const setupChildRuns = (pi: PiLike): ChildRunsIntegration => {
+const setupChildRuns = (
+  pi: PiLike,
+  options: SetupChildRunsOptions = {},
+): ChildRunsIntegration => {
   const runtime = pi as unknown as RuntimePiLike;
   const registry = new ChildRunRegistry();
-  const panel = new ChildRunsPanelController(registry);
+  const bitIssues = options.bitIssues
+    ? new BitIssueRegistry({ cli: options.bitIssueCli })
+    : undefined;
+  let activeContext: RuntimeContextLike | undefined;
+  let lastExplicitWarning: string | undefined;
+  const refreshBitIssues = async (
+    ctx: RuntimeContextLike,
+    explicit: boolean = false,
+  ): Promise<void> => {
+    if (bitIssues === undefined) return;
+    const cwd = ctx.cwd ?? process.cwd();
+    const outcome = await bitIssues.refresh(cwd);
+    if (outcome.ok) {
+      lastExplicitWarning = undefined;
+      if (outcome.count > 0) panel.ensureVisibleForIssues(ctx);
+      return;
+    }
+    if (explicit) {
+      const warning = `${outcome.kind}:${outcome.message}`;
+      if (warning !== lastExplicitWarning) {
+        lastExplicitWarning = warning;
+        ctx.ui.notify(
+          `Open bit issues unavailable: ${outcome.message}`,
+          "warning",
+        );
+      }
+    }
+  };
+  const panel = new ChildRunsPanelController(registry, {
+    bitIssues,
+    refreshBitIssues: async () => {
+      if (activeContext !== undefined) await refreshBitIssues(activeContext);
+    },
+  });
   const background =
+    options.childExecution !== false &&
     typeof runtime.appendEntry === "function" &&
     typeof runtime.sendMessage === "function"
       ? new BackgroundInvocationManager(registry, {
@@ -146,6 +192,7 @@ const setupChildRuns = (pi: PiLike): ChildRunsIntegration => {
   runtime.registerCommand("subagents", {
     description: "Show and focus the live child-session browser",
     handler: async (_args, ctx) => {
+      activeContext = ctx;
       if (ctx.mode !== "tui") {
         if (ctx.hasUI) {
           ctx.ui.notify(
@@ -155,16 +202,46 @@ const setupChildRuns = (pi: PiLike): ChildRunsIntegration => {
         }
         return;
       }
-      await panel.showAndFocus(ctx);
+      await panel.showAndFocus(ctx, "child");
     },
   });
 
   runtime.registerShortcut("ctrl+alt+s", {
     description: "Show and focus child sessions",
     handler: async (ctx) => {
-      await panel.showAndFocus(ctx);
+      activeContext = ctx;
+      await panel.showAndFocus(ctx, "child");
     },
   });
+
+  if (bitIssues !== undefined) {
+    runtime.registerCommand("bit-issues", {
+      description: "Refresh, show, and focus open local bit issues",
+      handler: async (_args, ctx) => {
+        activeContext = ctx;
+        if (ctx.mode !== "tui") {
+          if (ctx.hasUI) {
+            ctx.ui.notify(
+              "The bit issue browser requires TUI mode.",
+              "warning",
+            );
+          }
+          return;
+        }
+        await refreshBitIssues(ctx, true);
+        await panel.showAndFocus(ctx, "issue", false);
+      },
+    });
+
+    runtime.registerShortcut("ctrl+alt+i", {
+      description: "Refresh, show, and focus open local bit issues",
+      handler: async (ctx) => {
+        activeContext = ctx;
+        await refreshBitIssues(ctx, true);
+        await panel.showAndFocus(ctx, "issue", false);
+      },
+    });
+  }
 
   runtime.on("tool_result", (rawEvent) => {
     const event = rawEvent as RuntimeToolResultEvent;
@@ -224,12 +301,19 @@ const setupChildRuns = (pi: PiLike): ChildRunsIntegration => {
   });
   runtime.on("agent_start", () => background?.markAgentStarted());
   runtime.on("agent_settled", (_event, ctx) => {
+    activeContext = ctx;
     const idle = typeof ctx.isIdle !== "function" || ctx.isIdle();
     background?.markAgentSettled(idle);
+    void refreshBitIssues(ctx);
   });
   runtime.on("session_start", (_event, ctx) => {
+    activeContext = ctx;
     clearTreeTransitions();
     replayBranch(registry, ctx);
+    if (bitIssues !== undefined) {
+      bitIssues.beginSession(ctx.cwd ?? process.cwd());
+      void refreshBitIssues(ctx);
+    }
   });
   runtime.on("session_before_tree", async (rawEvent) => {
     // Serialize navigation boundaries. Pi does not correlate session_tree with
@@ -295,14 +379,17 @@ const setupChildRuns = (pi: PiLike): ChildRunsIntegration => {
     else background?.completeBranchTransition();
   });
   runtime.on("session_shutdown", async () => {
+    activeContext = undefined;
     clearTreeTransitions();
     await background?.shutdown();
     panel.dispose();
+    bitIssues?.dispose();
     registry.dispose();
   });
 
   return {
     registry,
+    bitIssues,
     background,
     ensureVisible(ctx) {
       panel.ensureVisible(ctx as RuntimeContextLike);

--- a/pi/extensions/pi-harness/features/child-runs/ui.ts
+++ b/pi/extensions/pi-harness/features/child-runs/ui.ts
@@ -10,7 +10,14 @@ import {
   stripTerminalControls,
   truncateToWidth,
   visibleWidth,
+  wrapPlainText,
 } from "../../lib/terminal-text";
+import type {
+  BitIssueDetailResult,
+  BitIssueDetailState,
+  BitIssueSummary,
+} from "../bit-issues/model";
+import { BitIssueRegistry } from "../bit-issues/registry";
 import type {
   ChildInvocationSnapshot,
   ChildRunStatus,
@@ -173,10 +180,37 @@ const transcriptComponent = (
   );
 };
 
+type BrowserSelection =
+  | { readonly kind: "child"; readonly id: string }
+  | { readonly kind: "issue"; readonly id: string };
+
+interface BrowserRow {
+  readonly text: string;
+  readonly selection?: BrowserSelection;
+}
+
+export interface BitIssueBrowserBindings {
+  readonly registry: BitIssueRegistry;
+  readonly onInspect: (issueId: string) => void;
+  readonly onRefresh: () => void | Promise<void>;
+}
+
+const selectionToken = (selection: BrowserSelection): string =>
+  `${selection.kind}:${selection.id}`;
+
+const issueIcon = (issue: BitIssueSummary): string => {
+  if (issue.title.startsWith("[plan:")) return "◆";
+  if (issue.title.startsWith("[task:")) return "◇";
+  return "○";
+};
+
 export class ChildRunsBrowserComponent implements ComponentLike {
-  private selectedRunId: string | undefined;
+  private selection: BrowserSelection | undefined;
+  private pendingPreference: BrowserSelection["kind"] | undefined;
+  private selectedIndexHint = 0;
   private listOffset = 0;
-  private readonly unsubscribe: () => void;
+  private readonly unsubscribeChild: () => void;
+  private readonly unsubscribeIssues: (() => void) | undefined;
 
   constructor(
     private readonly registry: ChildRunRegistry,
@@ -185,43 +219,62 @@ export class ChildRunsBrowserComponent implements ComponentLike {
     private readonly onInspect: (runId: string) => void,
     private readonly onUnfocus: () => void,
     private readonly onHide: () => void,
+    private readonly bitIssues?: BitIssueBrowserBindings,
   ) {
-    this.unsubscribe = registry.subscribe(() => this.tui.requestRender());
+    this.unsubscribeChild = registry.subscribe(() => this.requestRender());
+    this.unsubscribeIssues = bitIssues?.registry.subscribe(() =>
+      this.requestRender(),
+    );
   }
 
   render(width: number): string[] {
     const safeWidth = Math.max(1, width);
-    // The browser now participates in normal layout flow with chat, editor,
-    // status rows, and footer. Keep its budget conservative rather than using
-    // the former overlay-sized 80%/30-row cap. Common 24/40-row terminals get
-    // at most 6/10 browser rows; very small terminals retain minimal controls.
+    // The browser participates in normal layout flow with chat, editor, status
+    // rows, and footer. Combining sources must not increase this old budget.
     const height = Math.max(
       4,
       Math.min(Math.floor(this.tui.terminal.rows / 4), 10),
     );
     const snapshots = this.registry.getSnapshots();
     const runs = flattenRuns(snapshots);
-    if (
-      this.selectedRunId === undefined ||
-      !runs.some(({ run }) => run.runId === this.selectedRunId)
-    ) {
-      this.selectedRunId = runs[0]?.run.runId;
-    }
+    const issueSnapshot = this.bitIssues?.registry.getSnapshot();
+    const issues = issueSnapshot?.issues ?? [];
+    this.syncSelection(runs, issues);
 
-    const body = this.renderList(snapshots, runs, safeWidth, height - 2);
-    const title = " Child sessions ";
+    const body = this.renderList(
+      snapshots,
+      runs,
+      issues,
+      safeWidth,
+      height - 2,
+    );
+    let issueState = "";
+    if (issueSnapshot?.loading === true) issueState = " · refreshing";
+    else if (issueSnapshot?.stale === true) issueState = " · stale";
+    else if (issueSnapshot?.error !== undefined) issueState = " · unavailable";
+    const title =
+      this.bitIssues === undefined
+        ? " Child sessions "
+        : ` Child sessions: ${runs.length} | Open bit issues: ${issues.length}${issueState} `;
+    const hint =
+      this.bitIssues === undefined
+        ? "↑↓ select  Enter inspect  Esc unfocus  q hide"
+        : "↑↓ select  Enter inspect  r refresh  Esc unfocus  q hide";
     const borderWidth = Math.max(1, safeWidth - visibleWidth(title));
     return [
       line(`${title}${"─".repeat(borderWidth)}`, safeWidth),
       ...body,
-      line("↑↓ select  Enter inspect  Esc unfocus  q hide", safeWidth),
+      line(hint, safeWidth),
     ].slice(0, height);
   }
 
   handleInput(data: string): void {
-    const runs = flattenRuns(this.registry.getSnapshots());
     if (data === "q") {
       this.onHide();
+      return;
+    }
+    if (data === "r" && this.bitIssues !== undefined) {
+      void this.bitIssues.onRefresh();
       return;
     }
     if (this.matches(data, "tui.select.cancel")) {
@@ -229,73 +282,203 @@ export class ChildRunsBrowserComponent implements ComponentLike {
       return;
     }
 
+    const selectable = this.selectableRows();
+    const token = this.selection && selectionToken(this.selection);
     const current = Math.max(
       0,
-      runs.findIndex(({ run }) => run.runId === this.selectedRunId),
+      selectable.findIndex((selection) => selectionToken(selection) === token),
     );
+    let nextIndex: number | undefined;
     if (this.matches(data, "tui.select.up") || data === "k") {
-      this.selectedRunId = runs[Math.max(0, current - 1)]?.run.runId;
+      nextIndex = Math.max(0, current - 1);
     } else if (this.matches(data, "tui.select.down") || data === "j") {
-      this.selectedRunId =
-        runs[Math.min(runs.length - 1, current + 1)]?.run.runId;
+      nextIndex = Math.min(selectable.length - 1, current + 1);
     } else if (this.matches(data, "tui.select.pageUp")) {
-      this.selectedRunId = runs[Math.max(0, current - 8)]?.run.runId;
+      nextIndex = Math.max(0, current - 8);
     } else if (this.matches(data, "tui.select.pageDown")) {
-      this.selectedRunId =
-        runs[Math.min(runs.length - 1, current + 8)]?.run.runId;
+      nextIndex = Math.min(selectable.length - 1, current + 8);
     } else if (
       this.matches(data, "tui.select.confirm") ||
       defaultKeyMatches(data, "tui.select.confirm") ||
       this.matches(data, "tui.editor.cursorRight")
     ) {
-      if (this.selectedRunId !== undefined) {
-        this.onInspect(this.selectedRunId);
+      if (this.selection?.kind === "child") this.onInspect(this.selection.id);
+      else if (this.selection?.kind === "issue") {
+        this.bitIssues?.onInspect(this.selection.id);
       }
     } else return;
-    this.tui.requestRender();
+
+    if (nextIndex !== undefined && nextIndex >= 0) {
+      this.pendingPreference = undefined;
+      this.selection = selectable[nextIndex];
+      this.selectedIndexHint = nextIndex;
+    }
+    this.requestRender();
   }
 
   invalidate(): void {}
 
   dispose(): void {
-    this.unsubscribe();
+    this.unsubscribeChild();
+    this.unsubscribeIssues?.();
   }
 
   getSelectedRunId(): string | undefined {
-    return this.selectedRunId;
+    return this.selection?.kind === "child" ? this.selection.id : undefined;
+  }
+
+  getSelectedIssueId(): string | undefined {
+    return this.selection?.kind === "issue" ? this.selection.id : undefined;
+  }
+
+  prefer(kind: BrowserSelection["kind"]): void {
+    this.pendingPreference = kind;
+    const selectable = this.selectableRows();
+    const preferred = selectable.find((selection) => selection.kind === kind);
+    if (preferred !== undefined) {
+      this.pendingPreference = undefined;
+      this.selection = preferred;
+      this.selectedIndexHint = selectable.findIndex(
+        (selection) => selectionToken(selection) === selectionToken(preferred),
+      );
+    }
+    this.requestRender();
+  }
+
+  private selectableRows(): BrowserSelection[] {
+    const children = flattenRuns(this.registry.getSnapshots()).map(
+      ({ run }): BrowserSelection => ({ kind: "child", id: run.runId }),
+    );
+    const issues =
+      this.bitIssues?.registry
+        .getSnapshot()
+        .issues.map(
+          (issue): BrowserSelection => ({ kind: "issue", id: issue.id }),
+        ) ?? [];
+    return [...children, ...issues];
+  }
+
+  private syncSelection(
+    runs: FlatRun[],
+    issues: readonly BitIssueSummary[],
+  ): void {
+    const selectable: BrowserSelection[] = [
+      ...runs.map(
+        ({ run }): BrowserSelection => ({
+          kind: "child",
+          id: run.runId,
+        }),
+      ),
+      ...issues.map(
+        (issue): BrowserSelection => ({ kind: "issue", id: issue.id }),
+      ),
+    ];
+    if (this.pendingPreference !== undefined) {
+      const preferred = selectable.find(
+        (selection) => selection.kind === this.pendingPreference,
+      );
+      if (preferred !== undefined) {
+        this.pendingPreference = undefined;
+        this.selection = preferred;
+        this.selectedIndexHint = selectable.indexOf(preferred);
+        return;
+      }
+    }
+    const token = this.selection && selectionToken(this.selection);
+    const retained = selectable.find(
+      (selection) => selectionToken(selection) === token,
+    );
+    if (retained !== undefined) {
+      this.selection = retained;
+      this.selectedIndexHint = selectable.indexOf(retained);
+      return;
+    }
+    this.selection =
+      selectable[Math.min(this.selectedIndexHint, selectable.length - 1)];
+    this.selectedIndexHint = Math.max(
+      0,
+      Math.min(this.selectedIndexHint, selectable.length - 1),
+    );
   }
 
   private renderList(
     snapshots: ChildInvocationSnapshot[],
     runs: FlatRun[],
+    issues: readonly BitIssueSummary[],
     width: number,
     viewport: number,
   ): string[] {
-    if (runs.length === 0) {
+    const issueSnapshot = this.bitIssues?.registry.getSnapshot();
+    if (runs.length === 0 && issues.length === 0) {
+      if (this.bitIssues === undefined) {
+        return [
+          line("No child runs on this session branch.", width),
+          line("Start subagent or workflow to populate this view.", width),
+        ];
+      }
+      let issueStatus = "Start subagent/workflow or create a local bit issue.";
+      if (issueSnapshot?.loading === true)
+        issueStatus = "Loading open bit issues…";
+      else if (issueSnapshot?.error !== undefined) {
+        issueStatus = `Open bit issues unavailable: ${issueSnapshot.error}`;
+      }
       return [
-        line("No child runs on this session branch.", width),
-        line("Start subagent or workflow to populate this view.", width),
+        line("No child runs or open bit issues.", width),
+        line(issueStatus, width),
       ];
     }
-    const rendered: { text: string; runId?: string }[] = [];
-    for (const invocation of snapshots) {
-      rendered.push({
-        text: `${invocation.label} · ${invocation.source} · ${invocation.runs.length} run(s)`,
-      });
-      for (const run of invocation.runs) {
-        const stage =
-          run.stageIndex === undefined
-            ? `${run.taskIndex + 1}`
-            : `S${run.stageIndex + 1}/T${run.taskIndex + 1}`;
+
+    const rendered: BrowserRow[] = [];
+    if (runs.length > 0) {
+      if (this.bitIssues !== undefined)
+        rendered.push({ text: "Child sessions" });
+      for (const invocation of snapshots) {
         rendered.push({
-          runId: run.runId,
-          text: `${run.runId === this.selectedRunId ? ">" : " "} ${statusIcon(run.status)} ${stage} ${run.agent} — ${taskOneLine(run.task)}`,
+          text: `${invocation.label} · ${invocation.source} · ${invocation.runs.length} run(s)`,
         });
+        for (const run of invocation.runs) {
+          const stage =
+            run.stageIndex === undefined
+              ? `${run.taskIndex + 1}`
+              : `S${run.stageIndex + 1}/T${run.taskIndex + 1}`;
+          const selection: BrowserSelection = {
+            kind: "child",
+            id: run.runId,
+          };
+          rendered.push({
+            selection,
+            text: `${this.isSelected(selection) ? ">" : " "} ${statusIcon(run.status)} ${stage} ${run.agent} — ${taskOneLine(run.task)}`,
+          });
+        }
       }
     }
+    if (issues.length > 0) {
+      rendered.push({ text: "Open bit issues" });
+      for (const issue of issues) {
+        const selection: BrowserSelection = { kind: "issue", id: issue.id };
+        rendered.push({
+          selection,
+          text: `${this.isSelected(selection) ? ">" : " "} ${issueIcon(issue)} #${issue.id.slice(0, 8)} ${taskOneLine(issue.title)}`,
+        });
+      }
+      if (issueSnapshot?.truncated === true) {
+        rendered.push({ text: "… more than 100 open bit issues" });
+      }
+    }
+    if (issueSnapshot?.error !== undefined) {
+      rendered.push({
+        text: `${issueSnapshot.stale ? "stale" : "issue refresh failed"}: ${issueSnapshot.error}`,
+      });
+    }
+
+    const selectedToken = this.selection && selectionToken(this.selection);
     const selectedLine = Math.max(
       0,
-      rendered.findIndex((item) => item.runId === this.selectedRunId),
+      rendered.findIndex(
+        (item) =>
+          item.selection !== undefined &&
+          selectionToken(item.selection) === selectedToken,
+      ),
     );
     this.listOffset = Math.max(
       0,
@@ -311,6 +494,21 @@ export class ChildRunsBrowserComponent implements ComponentLike {
     return rendered
       .slice(this.listOffset, this.listOffset + viewport)
       .map((item) => line(item.text, width));
+  }
+
+  private isSelected(selection: BrowserSelection): boolean {
+    return (
+      this.selection !== undefined &&
+      selectionToken(this.selection) === selectionToken(selection)
+    );
+  }
+
+  private requestRender(): void {
+    this.syncSelection(
+      flattenRuns(this.registry.getSnapshots()),
+      this.bitIssues?.registry.getSnapshot().issues ?? [],
+    );
+    this.tui.requestRender();
   }
 
   private matches(data: string, keybinding: string): boolean {
@@ -582,6 +780,250 @@ export class ChildRunDetailComponent implements ComponentLike {
   }
 }
 
+const formatBitTimestamp = (seconds: number): string =>
+  new Date(seconds * 1_000).toISOString();
+
+const issueDetailContentLines = (
+  detail: BitIssueDetailResult,
+  width: number,
+  theme: ChildRunTheme,
+): string[] => {
+  const { issue, comments } = detail;
+  const root = new Container();
+  const metadata = new Box(1, 0, (text) => theme.bg("selectedBg", text));
+  const stateColor: ThemeColor = issue.state === "open" ? "success" : "warning";
+  metadata.addChild(
+    new Text(
+      `${theme.fg("toolTitle", theme.bold(`#${issue.id} ${taskOneLine(issue.title)}`))}  ${theme.fg(stateColor, issue.state)}`,
+      0,
+      0,
+    ),
+  );
+  metadata.addChild(
+    new Text(theme.fg("muted", `author  ${taskOneLine(issue.author)}`), 0, 0),
+  );
+  metadata.addChild(
+    new Text(
+      theme.fg(
+        "muted",
+        `created ${formatBitTimestamp(issue.createdAt)} · updated ${formatBitTimestamp(issue.updatedAt)}`,
+      ),
+      0,
+      0,
+    ),
+  );
+  if (issue.labels.length > 0) {
+    metadata.addChild(
+      new Text(
+        theme.fg(
+          "muted",
+          `labels  ${issue.labels.map(taskOneLine).join(", ")}`,
+        ),
+        0,
+        0,
+      ),
+    );
+  }
+  root.addChild(metadata);
+  root.addChild(new Text(theme.fg("accent", theme.bold("Body")), 0, 0));
+  const body = new Box(1, 0);
+  body.addChild(
+    new Text(
+      theme.fg(
+        "toolOutput",
+        wrapPlainText(
+          issue.body === "" ? "(empty body)" : safeBlock(issue.body),
+          Math.max(1, width - 2),
+        ).join("\n"),
+      ),
+      0,
+      0,
+    ),
+  );
+  root.addChild(body);
+  root.addChild(new Text(theme.fg("accent", theme.bold("Comments")), 0, 0));
+  const commentBox = new Box(1, 0);
+  if (comments.status === "none") {
+    commentBox.addChild(new Text(theme.fg("dim", "(no comments)"), 0, 0));
+  } else if (comments.status === "error") {
+    commentBox.addChild(
+      new Text(
+        theme.fg(
+          "warning",
+          `Comments unavailable: ${taskOneLine(comments.message)}`,
+        ),
+        0,
+        0,
+      ),
+    );
+  } else {
+    commentBox.addChild(
+      new Text(
+        theme.fg(
+          comments.truncated ? "warning" : "toolOutput",
+          wrapPlainText(safeBlock(comments.text), Math.max(1, width - 2)).join(
+            "\n",
+          ),
+        ),
+        0,
+        0,
+      ),
+    );
+  }
+  root.addChild(commentBox);
+  return root.render(Math.max(1, width));
+};
+
+/** Focused, near-full-screen read-only viewer for one local bit issue. */
+export class BitIssueDetailComponent implements ComponentLike {
+  private offset = 0;
+  private lastMaxOffset = 0;
+  private lastViewport = 1;
+  private readonly unsubscribe: () => void;
+  private readonly theme: ChildRunTheme;
+
+  constructor(
+    private readonly registry: BitIssueRegistry,
+    private readonly issueId: string,
+    private readonly tui: TuiLike,
+    private readonly keybindings: KeybindingsLike,
+    private readonly onClose: () => void,
+    theme?: unknown,
+  ) {
+    this.theme = resolveTheme(theme);
+    this.unsubscribe = registry.subscribe(() => this.tui.requestRender());
+  }
+
+  render(width: number): string[] {
+    const safeWidth = Math.max(1, width);
+    const height = Math.max(1, this.tui.terminal.rows - 2);
+    const showTitle = height >= 2;
+    const showHint = height >= 3;
+    const chrome = Number(showTitle) + Number(showHint);
+    const viewport = Math.max(1, height - chrome);
+    this.lastViewport = viewport;
+    const state = this.registry.getDetailState(this.issueId);
+    const allLines = this.contentLines(state, safeWidth);
+    this.lastMaxOffset = Math.max(0, allLines.length - viewport);
+    this.offset = Math.min(this.offset, this.lastMaxOffset);
+
+    const visible = allLines.slice(this.offset, this.offset + viewport);
+    while (visible.length < viewport) visible.push("");
+
+    const title = this.theme.fg(
+      "toolTitle",
+      this.theme.bold(` Bit issue #${this.issueId} `),
+    );
+    const borderWidth = Math.max(1, safeWidth - visibleWidth(title));
+    const first = allLines.length === 0 ? 0 : this.offset + 1;
+    const last = Math.min(allLines.length, this.offset + viewport);
+    const position = `${first}-${last}/${allLines.length}`;
+    const output: string[] = [];
+    if (showTitle) {
+      output.push(
+        styledLine(
+          `${title}${this.theme.fg("borderMuted", "─".repeat(borderWidth))}`,
+          safeWidth,
+        ),
+      );
+    }
+    output.push(...visible.map((item) => styledLine(item, safeWidth)));
+    if (showHint) {
+      const hint = this.theme.fg(
+        "dim",
+        "↑↓ scroll  PgUp/PgDn page  Home/End  Esc/←/b/q close  ",
+      );
+      output.push(
+        styledLine(`${hint}${this.theme.fg("muted", position)}`, safeWidth),
+      );
+    }
+    return output.slice(0, height);
+  }
+
+  handleInput(data: string): void {
+    if (
+      data === "q" ||
+      data === "b" ||
+      this.matches(data, "tui.select.cancel") ||
+      this.matches(data, "tui.editor.cursorLeft") ||
+      defaultKeyMatches(data, "tui.select.cancel") ||
+      defaultKeyMatches(data, "tui.editor.cursorLeft")
+    ) {
+      this.onClose();
+      return;
+    }
+
+    const page = Math.max(1, this.lastViewport - 1);
+    if (
+      data === "k" ||
+      this.matches(data, "tui.select.up") ||
+      defaultKeyMatches(data, "tui.select.up")
+    ) {
+      this.offset = Math.max(0, this.offset - 1);
+    } else if (
+      this.matches(data, "tui.select.pageUp") ||
+      defaultKeyMatches(data, "tui.select.pageUp")
+    ) {
+      this.offset = Math.max(0, this.offset - page);
+    } else if (
+      data === "j" ||
+      this.matches(data, "tui.select.down") ||
+      defaultKeyMatches(data, "tui.select.down")
+    ) {
+      this.offset = Math.min(this.lastMaxOffset, this.offset + 1);
+    } else if (
+      this.matches(data, "tui.select.pageDown") ||
+      defaultKeyMatches(data, "tui.select.pageDown")
+    ) {
+      this.offset = Math.min(this.lastMaxOffset, this.offset + page);
+    } else if (
+      this.matches(data, "tui.editor.cursorLineStart") ||
+      defaultKeyMatches(data, "tui.editor.cursorLineStart")
+    ) {
+      this.offset = 0;
+    } else if (
+      this.matches(data, "tui.editor.cursorLineEnd") ||
+      defaultKeyMatches(data, "tui.editor.cursorLineEnd")
+    ) {
+      this.offset = this.lastMaxOffset;
+    } else return;
+    this.tui.requestRender();
+  }
+
+  invalidate(): void {}
+
+  dispose(): void {
+    this.unsubscribe();
+  }
+
+  getOffset(): number {
+    return this.offset;
+  }
+
+  private contentLines(state: BitIssueDetailState, width: number): string[] {
+    if (state.status === "ready") {
+      return issueDetailContentLines(state.detail, width, this.theme);
+    }
+    const message =
+      state.status === "loading" || state.status === "idle"
+        ? `Loading bit issue #${this.issueId}…`
+        : `Bit issue detail unavailable: ${taskOneLine(state.message)}`;
+    return new Text(
+      this.theme.fg(state.status === "error" ? "warning" : "dim", message),
+      0,
+      0,
+    ).render(width);
+  }
+
+  private matches(data: string, keybinding: string): boolean {
+    try {
+      return this.keybindings.matches(data, keybinding);
+    } catch {
+      return false;
+    }
+  }
+}
+
 type MountState = "unmounted" | "mounted" | "disposed";
 
 export const CHILD_RUNS_WIDGET_KEY = "pi-harness-child-runs";
@@ -655,6 +1097,11 @@ const sameCursor = (
  * Remapped Down is honored when the editor exposes its runtime keybindings
  * manager; otherwise only the fallback default terminal sequences are known.
  */
+export interface ChildRunsPanelOptions {
+  readonly bitIssues?: BitIssueRegistry;
+  readonly refreshBitIssues?: () => void | Promise<unknown>;
+}
+
 export class ChildRunsPanelController {
   private state: MountState = "unmounted";
   private component: ChildRunsBrowserComponent | undefined;
@@ -665,32 +1112,52 @@ export class ChildRunsPanelController {
   private unsubscribeInput: (() => void) | undefined;
   private detailClose: (() => void) | undefined;
   private detailPromise: Promise<void> | undefined;
+  private detailIssueId: string | undefined;
   private fallbackClose: (() => void) | undefined;
   private fallbackPromise: Promise<void> | undefined;
   private focusDegraded = false;
   private focusWarningShown = false;
+  private hiddenByUser = false;
   private readonly keybindings: KeybindingsLike = {
     matches: (data, keybinding) =>
       this.editor?.keybindings?.matches(data, keybinding) ??
       defaultKeyMatches(data, keybinding),
   };
 
-  constructor(private readonly registry: ChildRunRegistry) {}
+  constructor(
+    private readonly registry: ChildRunRegistry,
+    private readonly options: ChildRunsPanelOptions = {},
+  ) {}
 
   ensureVisible(ctx: BrowserContextLike): void {
+    this.hiddenByUser = false;
     this.show(ctx, false);
   }
 
-  async showAndFocus(ctx: BrowserContextLike): Promise<void> {
-    if (!this.show(ctx, false)) return;
-    if (this.focusBrowser()) return;
-    await this.openFallbackBrowser();
+  ensureVisibleForIssues(ctx: BrowserContextLike): void {
+    if (this.hiddenByUser) return;
+    this.show(ctx, false);
+  }
+
+  async showAndFocus(
+    ctx: BrowserContextLike,
+    preferred: BrowserSelection["kind"] = "child",
+    refreshOnFocus = true,
+  ): Promise<void> {
+    this.hiddenByUser = false;
+    if (!this.show(ctx, false, preferred)) return;
+    if (this.focusBrowser(preferred, refreshOnFocus)) return;
+    await this.openFallbackBrowser(preferred, refreshOnFocus);
   }
 
   dispose(): void {
     if (this.state === "disposed") return;
     this.detailClose?.();
     this.detailClose = undefined;
+    if (this.detailIssueId !== undefined) {
+      this.options.bitIssues?.cancelDetail(this.detailIssueId);
+      this.detailIssueId = undefined;
+    }
     this.fallbackClose?.();
     this.fallbackClose = undefined;
     if (this.isResidentFocused()) this.restoreFocus();
@@ -711,10 +1178,17 @@ export class ChildRunsPanelController {
     return this.state;
   }
 
-  private show(ctx: BrowserContextLike, focus: boolean): boolean {
+  private show(
+    ctx: BrowserContextLike,
+    focus: boolean,
+    preferred?: BrowserSelection["kind"],
+  ): boolean {
     if (ctx.mode !== "tui" || this.state === "disposed") return false;
     if (this.state === "mounted") {
-      if (focus && !this.focusBrowser()) void this.openFallbackBrowser();
+      if (preferred !== undefined) this.component?.prefer(preferred);
+      if (focus && !this.focusBrowser(preferred)) {
+        void this.openFallbackBrowser(preferred);
+      }
       return true;
     }
 
@@ -734,7 +1208,9 @@ export class ChildRunsPanelController {
             (runId) => this.openDetail(runId),
             () => this.restoreFocus(),
             () => this.hide(),
+            this.bitIssueBindings(),
           );
+          if (preferred !== undefined) component.prefer(preferred);
           this.component = component;
           return component;
         },
@@ -744,25 +1220,30 @@ export class ChildRunsPanelController {
         throw new Error("widget factory did not mount a component");
       }
       this.state = "mounted";
-      if (focus && !this.focusBrowser()) void this.openFallbackBrowser();
+      if (focus && !this.focusBrowser(preferred)) {
+        void this.openFallbackBrowser(preferred);
+      }
       return true;
     } catch (error) {
       this.state = "unmounted";
       this.component?.dispose();
       this.component = undefined;
       ui.notify(
-        `Child-session browser could not open: ${String(error)}`,
+        `Coordination browser could not open: ${String(error)}`,
         "warning",
       );
       return false;
     }
   }
 
-  private async openFallbackBrowser(): Promise<void> {
+  private async openFallbackBrowser(
+    preferred?: BrowserSelection["kind"],
+    refreshOnFocus = true,
+  ): Promise<void> {
     const { ui } = this;
     if (ui?.custom === undefined || this.state !== "mounted") {
       ui?.notify(
-        "Child-session browser focus requires custom TUI support on this pi version.",
+        "Coordination browser focus requires custom TUI support on this pi version.",
         "warning",
       );
       return;
@@ -780,7 +1261,7 @@ export class ChildRunsPanelController {
             done(undefined);
           };
           this.fallbackClose = close;
-          return new ChildRunsBrowserComponent(
+          const component = new ChildRunsBrowserComponent(
             this.registry,
             tui,
             keybindings,
@@ -790,7 +1271,11 @@ export class ChildRunsPanelController {
               this.hide();
               close();
             },
+            this.bitIssueBindings(),
           );
+          if (preferred !== undefined) component.prefer(preferred);
+          if (refreshOnFocus) void this.options.refreshBitIssues?.();
+          return component;
         },
         {
           overlay: true,
@@ -804,7 +1289,7 @@ export class ChildRunsPanelController {
       );
     } catch (error) {
       ui.notify(
-        `Child-session browser fallback could not open: ${String(error)}`,
+        `Coordination browser fallback could not open: ${String(error)}`,
         "warning",
       );
       return;
@@ -814,7 +1299,7 @@ export class ChildRunsPanelController {
     await fallbackPromise
       .catch((error) => {
         ui.notify(
-          `Child-session browser fallback could not open: ${String(error)}`,
+          `Coordination browser fallback could not open: ${String(error)}`,
           "warning",
         );
       })
@@ -889,6 +1374,99 @@ export class ChildRunsPanelController {
       });
   }
 
+  private openIssueDetail(issueId: string): void {
+    const { ui } = this;
+    const registry = this.options.bitIssues;
+    if (registry === undefined) return;
+    if (ui?.custom === undefined) {
+      ui?.notify(
+        "Bit issue detail view requires custom TUI support.",
+        "warning",
+      );
+      return;
+    }
+    if (this.detailPromise !== undefined) return;
+
+    registry.prepareDetail(issueId);
+    this.detailIssueId = issueId;
+    let detailPromise: Promise<void>;
+    try {
+      detailPromise = ui.custom<void>(
+        (tui, theme, keybindings, done) => {
+          let closed = false;
+          const close = () => {
+            if (closed) return;
+            closed = true;
+            registry.cancelDetail(issueId);
+            done(undefined);
+          };
+          this.detailClose = close;
+          return new BitIssueDetailComponent(
+            registry,
+            issueId,
+            tui,
+            keybindings,
+            close,
+            theme,
+          );
+        },
+        {
+          overlay: true,
+          overlayOptions: {
+            width: "100%",
+            maxHeight: "100%",
+            anchor: "center",
+            margin: 1,
+          },
+        },
+      );
+    } catch (error) {
+      registry.cancelDetail(issueId);
+      this.detailIssueId = undefined;
+      ui.notify(
+        `Bit issue detail view could not open: ${String(error)}`,
+        "warning",
+      );
+      return;
+    }
+
+    this.detailPromise = detailPromise;
+    void (async () => {
+      try {
+        await this.options.refreshBitIssues?.();
+      } catch {
+        // Detail retrieval still provides a useful latest-state error.
+      }
+      if (this.detailIssueId === issueId) await registry.loadDetail(issueId);
+    })();
+    void detailPromise
+      .catch((error) => {
+        ui.notify(
+          `Bit issue detail view could not open: ${String(error)}`,
+          "warning",
+        );
+      })
+      .finally(() => {
+        if (this.detailPromise !== detailPromise) return;
+        registry.cancelDetail(issueId);
+        this.detailPromise = undefined;
+        this.detailClose = undefined;
+        this.detailIssueId = undefined;
+      });
+  }
+
+  private bitIssueBindings(): BitIssueBrowserBindings | undefined {
+    const registry = this.options.bitIssues;
+    if (registry === undefined) return undefined;
+    return {
+      registry,
+      onInspect: (issueId) => this.openIssueDetail(issueId),
+      onRefresh: async () => {
+        await this.options.refreshBitIssues?.();
+      },
+    };
+  }
+
   private installInputListener(ui: WidgetUiLike): void {
     if (
       this.focusDegraded ||
@@ -945,7 +1523,10 @@ export class ChildRunsPanelController {
     if (isEditorLike(candidate)) this.editor = candidate;
   }
 
-  private focusBrowser(): boolean {
+  private focusBrowser(
+    preferred?: BrowserSelection["kind"],
+    refreshOnFocus = true,
+  ): boolean {
     if (
       this.state !== "mounted" ||
       this.component === undefined ||
@@ -956,12 +1537,14 @@ export class ChildRunsPanelController {
     if (focused === undefined || focused === null) return false;
     this.captureFocusTarget(focused);
     if (this.returnFocus === undefined || this.tui === undefined) return false;
+    if (preferred !== undefined) this.component.prefer(preferred);
     const result = setFocusSafely(this.tui, this.component);
     if (!result.ok) {
       this.degradeFocus(result.reason);
       return false;
     }
     this.tui.requestRender();
+    if (refreshOnFocus) void this.options.refreshBitIssues?.();
     return true;
   }
 
@@ -1003,14 +1586,19 @@ export class ChildRunsPanelController {
     }
     if (this.focusWarningShown) return;
     this.focusWarningShown = true;
+    const fallbackKeys =
+      this.options.bitIssues === undefined
+        ? "/subagents or Ctrl+Alt+S"
+        : "/subagents, /bit-issues, Ctrl+Alt+S, or Ctrl+Alt+I";
     this.ui?.notify(
-      `Child-session browser focus degraded: ${reason}. Use /subagents or Ctrl+Alt+S for the public overlay fallback.`,
+      `Coordination browser focus degraded: ${reason}. Use ${fallbackKeys} for the public overlay fallback.`,
       "warning",
     );
   }
 
   private hide(): void {
     if (this.state !== "mounted") return;
+    this.hiddenByUser = true;
     if (this.isResidentFocused()) this.restoreFocus();
     this.state = "unmounted";
     this.component = undefined;

--- a/pi/extensions/pi-harness/index.ts
+++ b/pi/extensions/pi-harness/index.ts
@@ -68,8 +68,13 @@ const setupHarness = (
   // async before_agent_start handler. This manager has no tool_call handler, so
   // the npm preflight still remains first in the command-permission chain.
   const childRuns =
-    config.features.subagent || config.features.workflow
-      ? setupChildRuns(pi)
+    config.features.subagent ||
+    config.features.workflow ||
+    config.features["bit-task"]
+      ? setupChildRuns(pi, {
+          bitIssues: config.features["bit-task"],
+          childExecution: config.features.subagent || config.features.workflow,
+        })
       : undefined;
 
   // Parent turns receive hidden user-facing guidance. Child processes omit it

--- a/tests/pi-harness/bit-issue-browser.test.ts
+++ b/tests/pi-harness/bit-issue-browser.test.ts
@@ -1,0 +1,630 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { execFile } from "node:child_process";
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import {
+  BitIssueCli,
+  BoundedCommandError,
+  runBoundedCommand,
+  type BoundedCommandOptions,
+  type BoundedCommandResult,
+  type RunBoundedCommand,
+} from "../../pi/extensions/pi-harness/features/bit-issues/cli";
+import {
+  BitIssueCliError,
+  decodeOpenBitIssueList,
+  type BitIssueDetailResult,
+  type BitIssueListResult,
+} from "../../pi/extensions/pi-harness/features/bit-issues/model";
+import {
+  BitIssueRegistry,
+  type BitIssueDataSource,
+} from "../../pi/extensions/pi-harness/features/bit-issues/registry";
+import { cleanupTestDirectory, setupTestDirectory } from "../test-helpers";
+
+const execFileAsync = promisify(execFile);
+const tempDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirectories.splice(0).map(cleanupTestDirectory));
+});
+
+const rawIssue = (
+  id: string,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> => ({
+  id,
+  title: `Issue ${id}`,
+  state: "open",
+  author: "Pi Tester",
+  created_at: 10,
+  updated_at: 20,
+  body: `Body ${id}`,
+  labels: ["test"],
+  parent_id: null,
+  ...overrides,
+});
+
+const result = (
+  stdout: string,
+  overrides: Partial<BoundedCommandResult> = {},
+): BoundedCommandResult => ({
+  exitCode: 0,
+  stdout: Buffer.from(stdout),
+  stderr: Buffer.alloc(0),
+  stdoutTruncated: false,
+  ...overrides,
+});
+
+interface CommandCall {
+  command: string;
+  args: readonly string[];
+  options: BoundedCommandOptions;
+}
+
+const queuedRunner = (responses: BoundedCommandResult[]) => {
+  const calls: CommandCall[] = [];
+  const run: RunBoundedCommand = async (command, args, options) => {
+    calls.push({ command, args, options });
+    const response = responses.shift();
+    if (response === undefined) throw new Error("missing fake response");
+    return response;
+  };
+  return { calls, run };
+};
+
+const listResult = (id: string): BitIssueListResult => ({
+  issues: [
+    {
+      id,
+      title: `Issue ${id}`,
+      state: "open",
+      author: "Pi Tester",
+      createdAt: 10,
+      updatedAt: 20,
+      labels: ["test"],
+    },
+  ],
+  truncated: false,
+});
+
+const detailResult = (
+  id: string,
+  state: "open" | "closed" = "open",
+): BitIssueDetailResult => ({
+  issue: {
+    id,
+    title: `Issue ${id}`,
+    state,
+    author: "Pi Tester",
+    createdAt: 10,
+    updatedAt: 20,
+    labels: ["test"],
+    body: `Body ${id}`,
+  },
+  comments: { status: "none" },
+});
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((onResolve, onReject) => {
+    resolve = onResolve;
+    reject = onReject;
+  });
+  return { promise, resolve, reject };
+};
+
+describe("bit issue JSON model", () => {
+  test("keeps only open issues, sanitizes text, sorts stably, and honors the sentinel", () => {
+    const items = Array.from({ length: 101 }, (_, index) =>
+      rawIssue(String(index).padStart(3, "0"), {
+        title: `Issue ${index}\u001b]2;spoof\u0007`,
+        updated_at: index === 99 || index === 100 ? 500 : index,
+      }),
+    );
+    items[4] = rawIssue("closed", { state: "closed", updated_at: 999 });
+
+    const decoded = decodeOpenBitIssueList(items);
+    expect(decoded.issues).toHaveLength(100);
+    expect(decoded.truncated).toBe(false);
+    expect(decoded.issues[0]?.id).toBe("099");
+    expect(decoded.issues[1]?.id).toBe("100");
+    expect(decoded.issues.some((issue) => issue.id === "closed")).toBe(false);
+    expect(decoded.issues.map((issue) => issue.title).join("\n")).not.toContain(
+      "spoof",
+    );
+  });
+
+  test("marks 101 open issues as truncated", () => {
+    const decoded = decodeOpenBitIssueList(
+      Array.from({ length: 101 }, (_, index) => rawIssue(`id-${index}`)),
+    );
+    expect(decoded.issues).toHaveLength(100);
+    expect(decoded.truncated).toBe(true);
+  });
+
+  test("rejects malformed records, duplicate ids, and oversized arrays", () => {
+    expect(() =>
+      decodeOpenBitIssueList([rawIssue("same"), rawIssue("same")]),
+    ).toThrow("duplicate bit issue id");
+    expect(() =>
+      decodeOpenBitIssueList([rawIssue("bad", { labels: "no" })]),
+    ).toThrow("labels");
+    expect(() =>
+      decodeOpenBitIssueList([
+        rawIssue("bad-time", { updated_at: Number.MAX_SAFE_INTEGER }),
+      ]),
+    ).toThrow("timestamp");
+    expect(() =>
+      decodeOpenBitIssueList(
+        Array.from({ length: 102 }, (_, index) => rawIssue(`id-${index}`)),
+      ),
+    ).toThrow("list JSON is invalid");
+  });
+});
+
+describe("bit issue CLI adapter", () => {
+  test("uses exact list argv, verified GIT_DIR, and a sanitized environment", async () => {
+    const fake = queuedRunner([
+      result("/repo/.git\n"),
+      result(
+        JSON.stringify([rawIssue("new", { updated_at: 30 }), rawIssue("old")]),
+      ),
+    ]);
+    const cli = new BitIssueCli({
+      env: {
+        PATH: "/repo/bin:/usr/bin",
+        GIT_DIR: "/attacker/.git",
+        GIT_COMMON_DIR: "/attacker/common",
+        BASH_ENV: "/attacker/startup",
+      },
+      runCommand: fake.run,
+      realpath: async (path) => path,
+    });
+
+    const open = await cli.listOpen("/repo");
+    expect(open.issues.map((issue) => issue.id)).toEqual(["new", "old"]);
+    expect(fake.calls).toHaveLength(2);
+    expect(fake.calls[0]?.command).toBe("git");
+    expect(fake.calls[0]?.args).toEqual([
+      "rev-parse",
+      "--path-format=absolute",
+      "--git-common-dir",
+    ]);
+    expect(fake.calls[0]?.options.env.GIT_DIR).toBeUndefined();
+    expect(fake.calls[0]?.options.env.GIT_COMMON_DIR).toBeUndefined();
+    expect(fake.calls[0]?.options.env.BASH_ENV).toBeUndefined();
+    expect(fake.calls[0]?.options.env.PATH).toBe("/usr/bin");
+    expect(fake.calls[1]?.command).toBe("bit");
+    expect(fake.calls[1]?.args).toEqual([
+      "issue",
+      "list",
+      "--open",
+      "--all",
+      "--limit",
+      "101",
+      "--format",
+      "json",
+    ]);
+    expect(fake.calls[1]?.options.env.GIT_DIR).toBe("/repo/.git");
+  });
+
+  test("uses one canonical bit store from a main checkout and linked worktree", async () => {
+    const root = await setupTestDirectory("pi-bit-browser-linked");
+    tempDirectories.push(root);
+    const repository = join(root, "repository");
+    const linked = join(root, "linked");
+    const fakeBin = join(root, "fake-bin");
+    const record = join(root, "bit-calls.log");
+    await fs.mkdir(repository);
+    await fs.mkdir(fakeBin);
+    await execFileAsync("git", ["init", "-q"], { cwd: repository });
+    await execFileAsync("git", ["config", "user.name", "Pi Test"], {
+      cwd: repository,
+    });
+    await execFileAsync("git", ["config", "user.email", "pi@example.invalid"], {
+      cwd: repository,
+    });
+    await fs.writeFile(join(repository, "README.md"), "test\n");
+    await execFileAsync("git", ["add", "README.md"], { cwd: repository });
+    await execFileAsync("git", ["commit", "-qm", "initial"], {
+      cwd: repository,
+    });
+    await execFileAsync("git", ["worktree", "add", "-qb", "linked", linked], {
+      cwd: repository,
+    });
+
+    const payload = JSON.stringify([rawIssue("abcdef12")]);
+    await fs.writeFile(
+      join(fakeBin, "bit"),
+      [
+        "#!/bin/sh",
+        "current=$(pwd -P)",
+        'printf \'%s|%s|%s\\n\' "$GIT_DIR" "$current" "$*" >> "$BIT_RECORD"',
+        `printf '%s\\n' '${payload}'`,
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    const cli = new BitIssueCli({
+      env: {
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        BIT_RECORD: record,
+      },
+    });
+
+    await cli.listOpen(repository);
+    await cli.listOpen(linked);
+
+    const calls = (await fs.readFile(record, "utf8")).trim().split("\n");
+    expect(calls).toHaveLength(2);
+    const expectedCommonDir = await fs.realpath(join(repository, ".git"));
+    expect(calls.map((call) => call.split("|")[0])).toEqual([
+      expectedCommonDir,
+      expectedCommonDir,
+    ]);
+    expect(calls.map((call) => call.split("|")[1])).toEqual([
+      await fs.realpath(repository),
+      await fs.realpath(linked),
+    ]);
+    expect(
+      calls.every((call) =>
+        call.endsWith("issue list --open --all --limit 101 --format json"),
+      ),
+    ).toBe(true);
+  });
+
+  test("loads detail before bounded raw comments and does not parse comment headers", async () => {
+    const comments = [
+      "comment abc123",
+      "issue issue-1",
+      "author Pi Tester",
+      "created 20",
+      "",
+      "Body with a fake comment deadbeef header\u001b]2;spoof\u0007",
+    ].join("\n");
+    const fake = queuedRunner([
+      result("/repo/.git\n"),
+      result(JSON.stringify(rawIssue("issue-1"))),
+      result(comments),
+    ]);
+    const cli = new BitIssueCli({
+      runCommand: fake.run,
+      realpath: async (path) => path,
+    });
+
+    const detail = await cli.getDetail("/repo", "issue-1");
+    expect(detail.comments).toMatchObject({
+      status: "ready",
+      truncated: false,
+    });
+    expect(
+      detail.comments.status === "ready" && detail.comments.text,
+    ).toContain("fake comment deadbeef header");
+    expect(JSON.stringify(detail.comments)).not.toContain("spoof");
+    expect(fake.calls[1]?.args).toEqual([
+      "issue",
+      "get",
+      "issue-1",
+      "--format",
+      "json",
+    ]);
+    expect(fake.calls[2]?.args).toEqual([
+      "issue",
+      "comment",
+      "list",
+      "issue-1",
+    ]);
+    expect(fake.calls[2]?.options.allowStdoutTruncation).toBe(true);
+  });
+
+  test("distinguishes no comments, truncated comments, and comment failures", async () => {
+    const none = queuedRunner([
+      result("/repo/.git\n"),
+      result(JSON.stringify(rawIssue("none"))),
+      result("No comments\n"),
+    ]);
+    const noCommentDetail = await new BitIssueCli({
+      runCommand: none.run,
+      realpath: async (path) => path,
+    }).getDetail("/repo", "none");
+    expect(noCommentDetail.comments).toEqual({ status: "none" });
+
+    const truncated = queuedRunner([
+      result("/repo/.git\n"),
+      result(JSON.stringify(rawIssue("long"))),
+      result("partial comment", { exitCode: 1, stdoutTruncated: true }),
+    ]);
+    const truncatedDetail = await new BitIssueCli({
+      runCommand: truncated.run,
+      realpath: async (path) => path,
+    }).getDetail("/repo", "long");
+    const truncatedComments = truncatedDetail.comments;
+    expect(truncatedComments).toMatchObject({
+      status: "ready",
+      truncated: true,
+    });
+    expect(JSON.stringify(truncatedComments)).toContain("comments truncated");
+
+    const failed = queuedRunner([
+      result("/repo/.git\n"),
+      result(JSON.stringify(rawIssue("failed"))),
+      result("", { exitCode: 2, stderr: Buffer.from("comments unavailable") }),
+    ]);
+    const failedDetail = await new BitIssueCli({
+      runCommand: failed.run,
+      realpath: async (path) => path,
+    }).getDetail("/repo", "failed");
+    expect(failedDetail.comments).toEqual({
+      status: "error",
+      message: "bit issue comments failed: comments unavailable",
+    });
+  });
+
+  test("rejects mismatched detail ids and invalid UTF-8 comments", async () => {
+    const mismatch = queuedRunner([
+      result("/repo/.git\n"),
+      result(JSON.stringify(rawIssue("other-id"))),
+    ]);
+    await expect(
+      new BitIssueCli({
+        runCommand: mismatch.run,
+        realpath: async (path) => path,
+      }).getDetail("/repo", "requested-id"),
+    ).rejects.toMatchObject({ kind: "invalid-data" });
+    expect(mismatch.calls).toHaveLength(2);
+
+    const invalidComment = queuedRunner([
+      result("/repo/.git\n"),
+      result(JSON.stringify(rawIssue("invalid-comment"))),
+      result("", { stdout: Buffer.from([0xff]) }),
+    ]);
+    const detail = await new BitIssueCli({
+      runCommand: invalidComment.run,
+      realpath: async (path) => path,
+    }).getDetail("/repo", "invalid-comment");
+    expect(detail.comments).toMatchObject({
+      status: "error",
+      message: "bit issue comment output is not valid UTF-8",
+    });
+  });
+
+  test("classifies missing bit, non-git directories, and malformed JSON", async () => {
+    const missingRunner: RunBoundedCommand = async (command) => {
+      if (command === "git") return result("/repo/.git\n");
+      throw new BoundedCommandError("missing", "bit", "bit missing");
+    };
+    await expect(
+      new BitIssueCli({
+        runCommand: missingRunner,
+        realpath: async (path) => path,
+      }).listOpen("/repo"),
+    ).rejects.toMatchObject({ kind: "missing-bit" });
+
+    const nonGit = queuedRunner([
+      result("", {
+        exitCode: 128,
+        stderr: Buffer.from("not a git repository"),
+      }),
+    ]);
+    await expect(
+      new BitIssueCli({ runCommand: nonGit.run }).listOpen("/tmp"),
+    ).rejects.toMatchObject({
+      kind: "non-git",
+    });
+
+    const malformed = queuedRunner([result("/repo/.git\n"), result("{broken")]);
+    await expect(
+      new BitIssueCli({
+        runCommand: malformed.run,
+        realpath: async (path) => path,
+      }).listOpen("/repo"),
+    ).rejects.toMatchObject({ kind: "invalid-data" });
+  });
+});
+
+describe("bounded bit process runner", () => {
+  const options = (
+    overrides: Partial<BoundedCommandOptions> = {},
+  ): BoundedCommandOptions => ({
+    cwd: process.cwd(),
+    env: { ...process.env } as Record<string, string>,
+    timeoutMs: 1_000,
+    stdoutMaxBytes: 1024,
+    stderrMaxBytes: 1024,
+    ...overrides,
+  });
+
+  test("enforces stdout byte caps", async () => {
+    await expect(
+      runBoundedCommand(
+        process.execPath,
+        ["-e", "process.stdout.write('x'.repeat(4096))"],
+        options({ stdoutMaxBytes: 64 }),
+      ),
+    ).rejects.toMatchObject({ kind: "oversize" });
+  });
+
+  test("supports bounded raw truncation", async () => {
+    const output = await runBoundedCommand(
+      process.execPath,
+      ["-e", "process.stdout.write('x'.repeat(4096))"],
+      options({ stdoutMaxBytes: 64, allowStdoutTruncation: true }),
+    );
+    expect(output.stdout.byteLength).toBe(64);
+    expect(output.stdoutTruncated).toBe(true);
+  });
+
+  test("enforces timeout and AbortSignal", async () => {
+    await expect(
+      runBoundedCommand(
+        process.execPath,
+        ["-e", "setInterval(() => {}, 1000)"],
+        options({ timeoutMs: 10 }),
+      ),
+    ).rejects.toMatchObject({ kind: "timeout" });
+
+    const controller = new AbortController() as unknown as {
+      readonly signal: AbortSignal;
+      abort(): void;
+    };
+    const pending = runBoundedCommand(
+      process.execPath,
+      ["-e", "setInterval(() => {}, 1000)"],
+      options({ signal: controller.signal }),
+    );
+    controller.abort();
+    await expect(pending).rejects.toMatchObject({ kind: "aborted" });
+  });
+});
+
+describe("bit issue registry", () => {
+  test("coalesces an in-flight request into one trailing refresh", async () => {
+    const first = deferred<BitIssueListResult>();
+    const trailing = deferred<BitIssueListResult>();
+    let calls = 0;
+    const source: BitIssueDataSource = {
+      listOpen: async () => {
+        calls += 1;
+        return calls === 1 ? first.promise : trailing.promise;
+      },
+      getDetail: async (_cwd, id) => detailResult(id),
+    };
+    const registry = new BitIssueRegistry({ cli: source });
+    registry.beginSession("/repo");
+    const initial = registry.refresh("/repo");
+    const coalesced = registry.refresh("/repo");
+    expect(calls).toBe(1);
+
+    first.resolve(listResult("stale"));
+    await Bun.sleep(0);
+    expect(calls).toBe(2);
+    expect(registry.getSnapshot().issues).toEqual([]);
+    trailing.resolve(listResult("latest"));
+    await Promise.all([initial, coalesced]);
+    expect(registry.getSnapshot().issues[0]?.id).toBe("latest");
+  });
+
+  test("discards an old generation after a session switch", async () => {
+    const old = deferred<BitIssueListResult>();
+    const next = deferred<BitIssueListResult>();
+    const source: BitIssueDataSource = {
+      listOpen: (cwd) => (cwd === "/old" ? old.promise : next.promise),
+      getDetail: async (_cwd, id) => detailResult(id),
+    };
+    const registry = new BitIssueRegistry({ cli: source, now: () => 50 });
+    registry.beginSession("/old");
+    const oldRefresh = registry.refresh("/old");
+    registry.beginSession("/next");
+    const nextRefresh = registry.refresh("/next");
+    next.resolve(listResult("next"));
+    await nextRefresh;
+    old.resolve(listResult("old"));
+    await oldRefresh;
+
+    expect(registry.getSnapshot().issues.map((issue) => issue.id)).toEqual([
+      "next",
+    ]);
+  });
+
+  test("retains the last-known-good list when refresh fails", async () => {
+    let calls = 0;
+    const source: BitIssueDataSource = {
+      async listOpen() {
+        calls += 1;
+        if (calls === 1) return listResult("kept");
+        throw new BitIssueCliError("timeout", "refresh timeout");
+      },
+      getDetail: async (_cwd, id) => detailResult(id),
+    };
+    const registry = new BitIssueRegistry({ cli: source, now: () => calls });
+    registry.beginSession("/repo");
+    await registry.refresh("/repo");
+    const failed = await registry.refresh("/repo");
+
+    expect(failed).toMatchObject({ ok: false, kind: "timeout" });
+    expect(registry.getSnapshot()).toMatchObject({
+      stale: true,
+      error: "refresh timeout",
+    });
+    expect(registry.getSnapshot().issues[0]?.id).toBe("kept");
+  });
+
+  test("does not let an older same-id detail overwrite a newer load", async () => {
+    const older = deferred<BitIssueDetailResult>();
+    const newer = deferred<BitIssueDetailResult>();
+    let calls = 0;
+    const source: BitIssueDataSource = {
+      listOpen: async () => listResult("same-detail"),
+      getDetail: async () => {
+        calls += 1;
+        return calls === 1 ? older.promise : newer.promise;
+      },
+    };
+    const registry = new BitIssueRegistry({ cli: source });
+    registry.beginSession("/repo");
+    const first = registry.loadDetail("same-detail");
+    const second = registry.loadDetail("same-detail");
+    const newest = detailResult("same-detail");
+    newer.resolve({
+      ...newest,
+      issue: { ...newest.issue, body: "newest body" },
+    });
+    await second;
+    older.resolve(detailResult("same-detail"));
+    await first;
+
+    expect(registry.getDetailState("same-detail")).toMatchObject({
+      status: "ready",
+      detail: { issue: { body: "newest body" } },
+    });
+  });
+
+  test("keeps an open overlay detail readable across list refresh", async () => {
+    let updatedAt = 20;
+    const source: BitIssueDataSource = {
+      listOpen: async () => {
+        const base = listResult("open-detail");
+        const [summary] = base.issues;
+        if (summary === undefined) throw new Error("missing issue summary");
+        return {
+          ...base,
+          issues: [{ ...summary, updatedAt }],
+        };
+      },
+      getDetail: async (_cwd, id) => detailResult(id),
+    };
+    const registry = new BitIssueRegistry({ cli: source });
+    registry.beginSession("/repo");
+    await registry.refresh("/repo");
+    await registry.loadDetail("open-detail");
+    updatedAt = 21;
+    await registry.refresh("/repo");
+
+    expect(registry.getDetailState("open-detail")).toMatchObject({
+      status: "ready",
+      detail: { issue: { body: "Body open-detail" } },
+    });
+  });
+
+  test("loads comments lazily and removes an issue proven closed", async () => {
+    const source: BitIssueDataSource = {
+      listOpen: async () => listResult("closing"),
+      getDetail: async (_cwd, id) => detailResult(id, "closed"),
+    };
+    const registry = new BitIssueRegistry({ cli: source });
+    registry.beginSession("/repo");
+    await registry.refresh("/repo");
+    expect(registry.getDetailState("closing")).toEqual({ status: "idle" });
+
+    const pending = registry.loadDetail("closing");
+    expect(registry.getDetailState("closing")).toEqual({ status: "loading" });
+    await pending;
+    expect(registry.getDetailState("closing")).toMatchObject({
+      status: "ready",
+      detail: { issue: { state: "closed" } },
+    });
+    expect(registry.getSnapshot().issues).toEqual([]);
+  });
+});

--- a/tests/pi-harness/child-run-layout.test.ts
+++ b/tests/pi-harness/child-run-layout.test.ts
@@ -7,6 +7,10 @@ import {
   type EditorTheme,
   type Terminal,
 } from "@earendil-works/pi-tui";
+import {
+  BitIssueRegistry,
+  type BitIssueDataSource,
+} from "../../pi/extensions/pi-harness/features/bit-issues/registry";
 import { ChildRunRegistry } from "../../pi/extensions/pi-harness/features/child-runs/registry";
 import { ChildRunsBrowserComponent } from "../../pi/extensions/pi-harness/features/child-runs/ui";
 
@@ -43,7 +47,11 @@ const createTerminal = (columns: number, rows: number): Terminal => ({
   setProgress() {},
 });
 
-const createLayout = (rows: number, columns: number) => {
+const createLayout = async (
+  rows: number,
+  columns: number,
+  includeIssues: boolean = false,
+) => {
   let id = 0;
   const registry = new ChildRunRegistry({
     idFactory: () => `layout-${++id}`,
@@ -60,6 +68,41 @@ const createLayout = (rows: number, columns: number) => {
       stageIndex: 0,
     })),
   });
+
+  const issueSource: BitIssueDataSource = {
+    listOpen: async () => ({
+      issues: Array.from({ length: 30 }, (_, index) => ({
+        id: `issue-${index}`,
+        title: `inspect issue ${index}`,
+        state: "open" as const,
+        author: "Pi Tester",
+        createdAt: 1,
+        updatedAt: 100 - index,
+        labels: [],
+      })),
+      truncated: false,
+    }),
+    getDetail: async (_cwd, id) => ({
+      issue: {
+        id,
+        title: id,
+        state: "open",
+        author: "Pi Tester",
+        createdAt: 1,
+        updatedAt: 1,
+        labels: [],
+        body: "body",
+      },
+      comments: { status: "none" },
+    }),
+  };
+  const issues = includeIssues
+    ? new BitIssueRegistry({ cli: issueSource })
+    : undefined;
+  if (issues !== undefined) {
+    issues.beginSession("/repo");
+    await issues.refresh("/repo");
+  }
 
   const terminal = createTerminal(columns, rows);
   const tui = new TUI(terminal);
@@ -81,6 +124,9 @@ const createLayout = (rows: number, columns: number) => {
     () => {},
     () => {},
     () => {},
+    issues === undefined
+      ? undefined
+      : { registry: issues, onInspect: () => {}, onRefresh: () => {} },
   );
   const footer = new Text("footer-main\nfooter-detail", 0, 0);
 
@@ -108,8 +154,8 @@ describe("child-session browser normal-flow layout", () => {
     [24, 80, 6],
     [40, 120, 10],
   ] as const) {
-    test(`keeps the editor visible in a ${rows}-row terminal`, () => {
-      const { editorLines, browserLines, viewport } = createLayout(
+    test(`keeps the editor visible in a ${rows}-row terminal`, async () => {
+      const { editorLines, browserLines, viewport } = await createLayout(
         rows,
         columns,
       );
@@ -127,4 +173,24 @@ describe("child-session browser normal-flow layout", () => {
       expect(viewport.at(-1)?.trimEnd()).toBe("footer-detail");
     });
   }
+
+  test("keeps the same total budget when child and issue sections coexist", async () => {
+    for (const [rows, columns, expectedPanelHeight] of [
+      [24, 80, 6],
+      [40, 120, 10],
+    ] as const) {
+      const { editorLines, browserLines, viewport } = await createLayout(
+        rows,
+        columns,
+        true,
+      );
+      expect(browserLines).toHaveLength(expectedPanelHeight);
+      expect(browserLines[0]).toContain("Open bit issues: 30");
+      for (const editorLine of new Set(editorLines)) {
+        expect(countLine(viewport, editorLine)).toBeGreaterThanOrEqual(
+          countLine(editorLines, editorLine),
+        );
+      }
+    }
+  });
 });

--- a/tests/pi-harness/child-run-ui.test.ts
+++ b/tests/pi-harness/child-run-ui.test.ts
@@ -4,8 +4,17 @@ import {
   readFocusedComponent,
   setFocusSafely,
 } from "../../pi/extensions/pi-harness/features/child-runs/focus-capability";
+import type {
+  BitIssueDetailResult,
+  BitIssueListResult,
+} from "../../pi/extensions/pi-harness/features/bit-issues/model";
+import {
+  BitIssueRegistry,
+  type BitIssueDataSource,
+} from "../../pi/extensions/pi-harness/features/bit-issues/registry";
 import { ChildRunRegistry } from "../../pi/extensions/pi-harness/features/child-runs/registry";
 import {
+  BitIssueDetailComponent,
   ChildRunDetailComponent,
   ChildRunsBrowserComponent,
 } from "../../pi/extensions/pi-harness/features/child-runs/ui";
@@ -164,6 +173,8 @@ describe("child-session browser component", () => {
     const { component } = setup();
     const lines = component.render(24);
     expect(lines.join("\n")).toContain("No child runs");
+    expect(lines.join("\n")).not.toContain("Open bit issues");
+    expect(lines.at(-1)).not.toContain("r refresh");
     expect(lines.every((item) => visibleWidth(item) <= 24)).toBe(true);
   });
 
@@ -553,5 +564,242 @@ describe("child-session detail component", () => {
     detail.handleInput("left");
     detail.handleInput("b");
     expect(closes).toBe(3);
+  });
+});
+
+const bitList = (...ids: string[]): BitIssueListResult => ({
+  issues: ids.map((id, index) => ({
+    id,
+    title: index === 0 ? `[plan:test#1] ${id}` : `[task:test#2:1] ${id}`,
+    state: "open",
+    author: "Pi Tester",
+    createdAt: 10,
+    updatedAt: 100 - index,
+    labels: ["session:test"],
+  })),
+  truncated: false,
+});
+
+const bitDetail = (
+  id: string,
+  options: {
+    state?: "open" | "closed";
+    comments?: BitIssueDetailResult["comments"];
+  } = {},
+): BitIssueDetailResult => ({
+  issue: {
+    id,
+    title: `[plan:test#1] ${id}`,
+    state: options.state ?? "open",
+    author: "Pi Tester",
+    createdAt: 10,
+    updatedAt: 100,
+    labels: ["session:test"],
+    body: `Body for ${id}\nwith CJK 界 and emoji 😀`,
+  },
+  comments: options.comments ?? { status: "none" },
+});
+
+const setupCombined = async (issueIds: string[], childCount = 0) => {
+  const base = setup(40);
+  base.component.dispose();
+  if (childCount > 0) addRuns(base.registry, childCount);
+  let currentList = bitList(...issueIds);
+  const details = new Map(issueIds.map((id) => [id, bitDetail(id)] as const));
+  const source: BitIssueDataSource = {
+    listOpen: async () => currentList,
+    getDetail: async (_cwd, id) => details.get(id) ?? bitDetail(id),
+  };
+  const issues = new BitIssueRegistry({ cli: source, now: () => 200 });
+  issues.beginSession("/repo");
+  await issues.refresh("/repo");
+  const inspectedIssues: string[] = [];
+  let refreshes = 0;
+  const component = new ChildRunsBrowserComponent(
+    base.registry,
+    base.tui,
+    base.keybindings,
+    (runId) => base.inspected.push(runId),
+    () => {},
+    () => {},
+    {
+      registry: issues,
+      onInspect: (id) => inspectedIssues.push(id),
+      onRefresh: () => {
+        refreshes += 1;
+      },
+    },
+  );
+  return {
+    ...base,
+    component,
+    issues,
+    details,
+    inspectedIssues,
+    getRefreshes: () => refreshes,
+    setIssueIds(ids: string[]) {
+      currentList = bitList(...ids);
+    },
+  };
+};
+
+describe("combined coordination browser", () => {
+  test("renders issue-only and combined sections in the old height budget", async () => {
+    const issueOnly = await setupCombined(["issue-a", "issue-b"]);
+    const onlyLines = issueOnly.component.render(80);
+    expect(onlyLines[0]).toContain("Child sessions: 0 | Open bit issues: 2");
+    expect(onlyLines.join("\n")).toContain("Open bit issues");
+    expect(onlyLines.join("\n")).toContain("#issue-a");
+    expect(issueOnly.component.getSelectedIssueId()).toBe("issue-a");
+
+    const combined = await setupCombined(["issue-a"], 1);
+    const combinedLines = combined.component.render(80);
+    expect(combinedLines.length).toBeLessThanOrEqual(10);
+    expect(combinedLines.join("\n")).toContain("Child sessions");
+    expect(combinedLines.join("\n")).toContain("Open bit issues");
+    expect(combinedLines.indexOf("Child sessions")).toBeLessThan(
+      combinedLines.indexOf("Open bit issues"),
+    );
+    expect(combinedLines.every((item) => visibleWidth(item) <= 80)).toBe(true);
+  });
+
+  test("moves selection across child and issue rows and dispatches typed detail", async () => {
+    const combined = await setupCombined(["issue-a", "issue-b"], 1);
+    const [runId] = combined.registry.getSnapshots()[0]?.runs ?? [];
+    combined.component.render(80);
+    expect(combined.component.getSelectedRunId()).toBe(runId?.runId);
+
+    combined.component.handleInput("down");
+    combined.component.handleInput("enter");
+    expect(combined.inspectedIssues).toEqual(["issue-a"]);
+    expect(combined.inspected).toEqual([]);
+
+    combined.component.handleInput("up");
+    combined.component.handleInput("right");
+    expect(combined.inspected).toEqual([runId?.runId]);
+  });
+
+  test("keeps issue-id selection stable and chooses the nearby row after close", async () => {
+    const combined = await setupCombined(["issue-a", "issue-b"]);
+    combined.component.render(80);
+    combined.component.handleInput("down");
+    expect(combined.component.getSelectedIssueId()).toBe("issue-b");
+
+    combined.details.set("issue-b", bitDetail("issue-b", { state: "closed" }));
+    await combined.issues.loadDetail("issue-b");
+    combined.component.render(80);
+    expect(combined.component.getSelectedIssueId()).toBe("issue-a");
+    expect(combined.component.render(80).join("\n")).not.toContain("#issue-b");
+  });
+
+  test("supports immediate and pending source preference plus explicit r refresh", async () => {
+    const combined = await setupCombined(["issue-a"], 1);
+    combined.component.render(80);
+    combined.component.prefer("issue");
+    expect(combined.component.getSelectedIssueId()).toBe("issue-a");
+    combined.component.handleInput("r");
+    expect(combined.getRefreshes()).toBe(1);
+
+    const pending = await setupCombined(["issue-a"]);
+    pending.component.render(80);
+    pending.component.prefer("child");
+    const [runId] = addRuns(pending.registry, 1);
+    expect(pending.component.getSelectedRunId()).toBe(runId);
+  });
+});
+
+describe("bit issue detail component", () => {
+  test("renders loading, body, raw comments, sanitization, and scrolling", async () => {
+    const { tui, keybindings } = setup(16);
+    const source: BitIssueDataSource = {
+      listOpen: async () => bitList("issue-a"),
+      getDetail: async () =>
+        bitDetail("issue-a", {
+          comments: {
+            status: "ready",
+            text: `comment abc\n\n${"long comment 界😀 ".repeat(60)}\u001b]2;spoof\u0007`,
+            truncated: false,
+          },
+        }),
+    };
+    const registry = new BitIssueRegistry({ cli: source });
+    registry.beginSession("/repo");
+    registry.prepareDetail("issue-a");
+    const detail = new BitIssueDetailComponent(
+      registry,
+      "issue-a",
+      tui,
+      keybindings,
+      () => {},
+    );
+    expect(detail.render(32).join("\n")).toContain("Loading bit issue");
+
+    await registry.loadDetail("issue-a");
+    const lines = detail.render(32);
+    expect(lines.join("\n")).toContain("Body");
+    expect(lines.join("\n")).toContain("Comments");
+    expect(lines.join("\n")).not.toContain("spoof");
+    expect(lines.every((item) => visibleWidth(item) <= 32)).toBe(true);
+    detail.handleInput("end");
+    expect(detail.getOffset()).toBeGreaterThan(0);
+    detail.handleInput("home");
+    expect(detail.getOffset()).toBe(0);
+  });
+
+  test("keeps the final comment state reachable on tiny terminals", async () => {
+    for (const [rows, expectedHeight] of [
+      [4, 2],
+      [3, 1],
+    ] as const) {
+      const { tui, keybindings } = setup(rows);
+      const source: BitIssueDataSource = {
+        listOpen: async () => bitList("issue-a"),
+        getDetail: async () => bitDetail("issue-a"),
+      };
+      const registry = new BitIssueRegistry({ cli: source });
+      registry.beginSession("/repo");
+      await registry.loadDetail("issue-a");
+      const detail = new BitIssueDetailComponent(
+        registry,
+        "issue-a",
+        tui,
+        keybindings,
+        () => {},
+      );
+      detail.render(40);
+      detail.handleInput("end");
+      const lines = detail.render(40);
+      expect(lines).toHaveLength(expectedHeight);
+      expect(lines.join("\n")).toContain("(no comments)");
+    }
+  });
+
+  test("distinguishes no comments and detail errors", async () => {
+    const { tui, keybindings } = setup(24);
+    let fail = false;
+    const source: BitIssueDataSource = {
+      listOpen: async () => bitList("issue-a"),
+      getDetail: async () => {
+        if (fail) throw new Error("detail failed");
+        return bitDetail("issue-a");
+      },
+    };
+    const registry = new BitIssueRegistry({ cli: source });
+    registry.beginSession("/repo");
+    await registry.loadDetail("issue-a");
+    const detail = new BitIssueDetailComponent(
+      registry,
+      "issue-a",
+      tui,
+      keybindings,
+      () => {},
+    );
+    expect(detail.render(60).join("\n")).toContain("(no comments)");
+
+    fail = true;
+    await registry.loadDetail("issue-a");
+    expect(detail.render(60).join("\n")).toContain(
+      "Bit issue detail unavailable: detail failed",
+    );
   });
 });

--- a/tests/pi-harness/fake-pi.ts
+++ b/tests/pi-harness/fake-pi.ts
@@ -270,7 +270,12 @@ export function createFakePi(
 
   return {
     on<K extends PiEventName>(event: K, handler: PiEventHandler<K>) {
-      registrars[event](handler);
+      const registrar = (
+        registrars as Partial<
+          Record<string, (candidate: PiEventHandler<PiEventName>) => void>
+        >
+      )[event];
+      registrar?.(handler as unknown as PiEventHandler<PiEventName>);
     },
     registerTool(tool) {
       tools.push(tool);

--- a/tests/pi-harness/harness-composition.test.ts
+++ b/tests/pi-harness/harness-composition.test.ts
@@ -1,0 +1,424 @@
+import { describe, expect, test } from "bun:test";
+import {
+  loadConfig,
+  type HarnessConfig,
+} from "../../pi/extensions/pi-harness/config";
+import {
+  BitIssueCli,
+  BoundedCommandError,
+  type BoundedCommandResult,
+  type RunBoundedCommand,
+} from "../../pi/extensions/pi-harness/features/bit-issues/cli";
+import setupChildRuns from "../../pi/extensions/pi-harness/features/child-runs/index";
+import { setupHarness } from "../../pi/extensions/pi-harness/index";
+import type { PiLike } from "../../pi/extensions/pi-harness/lib/pi-like";
+import { resolvePaths } from "../../pi/extensions/pi-harness/lib/paths";
+import { createFakePi } from "./fake-pi";
+
+const config = (
+  name: string,
+  features: Pick<
+    HarnessConfig["features"],
+    "bit-task" | "subagent" | "workflow"
+  >,
+): HarnessConfig => ({
+  isChild: false,
+  features: {
+    "hook-bridge": false,
+    subagent: features.subagent,
+    workflow: features.workflow,
+    "bit-task": features["bit-task"],
+    statusline: false,
+    "provider-log": false,
+    "asuku-notify": false,
+    "ask-user-question": false,
+  },
+  trust: { trustedRoots: [] },
+  paths: resolvePaths(`/tmp/${name}`),
+});
+
+const registration = (value: HarnessConfig) => {
+  const pi = createFakePi({ cwd: value.paths.home });
+  const registerKnownEvent = pi.on.bind(pi);
+  const childOnlyEvents = new Set([
+    "agent_start",
+    "message_end",
+    "message_start",
+    "session_tree",
+  ]);
+  Object.assign(pi, {
+    on(
+      event: Parameters<typeof pi.on>[0],
+      handler: Parameters<typeof pi.on>[1],
+    ) {
+      if (childOnlyEvents.has(event)) return;
+      registerKnownEvent(event, handler);
+    },
+  });
+  setupHarness(pi, value);
+  return {
+    pi,
+    commands: pi.commands,
+    shortcuts: pi.shortcuts,
+    tools: pi.tools.map((tool) => tool.name),
+  };
+};
+
+describe("pi-harness coordination browser composition", () => {
+  test("mounts the shared browser surface for bit-task only", async () => {
+    const registered = registration(
+      config("pi-composition-bit", {
+        subagent: false,
+        workflow: false,
+        "bit-task": true,
+      }),
+    );
+    expect(registered.commands.has("subagents")).toBe(true);
+    expect(registered.commands.has("bit-issues")).toBe(true);
+    expect(registered.shortcuts.has("ctrl+alt+s")).toBe(true);
+    expect(registered.shortcuts.has("ctrl+alt+i")).toBe(true);
+    expect(registered.tools).toContain("task_completed");
+    expect(registered.tools).not.toContain("subagent");
+    expect(registered.tools).not.toContain("workflow");
+    const injection = await registered.pi.emitBeforeAgentStart({
+      type: "before_agent_start",
+      prompt: "inspect local issues",
+      systemPrompt: "base",
+    });
+    expect(injection?.systemPrompt).not.toContain(
+      "Background agent completion",
+    );
+  });
+
+  test("does not register the bit source for child-only composition", () => {
+    const registered = registration(
+      config("pi-composition-child", {
+        subagent: true,
+        workflow: false,
+        "bit-task": false,
+      }),
+    );
+    expect(registered.commands.has("subagents")).toBe(true);
+    expect(registered.commands.has("bit-issues")).toBe(false);
+    expect(registered.shortcuts.has("ctrl+alt+i")).toBe(false);
+    expect(registered.tools).toContain("subagent");
+  });
+
+  test("registers one shared command pair when both sources are enabled", () => {
+    const registered = registration(
+      config("pi-composition-both", {
+        subagent: true,
+        workflow: true,
+        "bit-task": true,
+      }),
+    );
+    expect(
+      [...registered.commands].filter((name) => name === "subagents"),
+    ).toHaveLength(1);
+    expect(
+      [...registered.commands].filter((name) => name === "bit-issues"),
+    ).toHaveLength(1);
+    expect(registered.tools).toEqual(
+      expect.arrayContaining([
+        "subagent",
+        "workflow",
+        "worktree_create",
+        "worktree_remove",
+        "task_completed",
+      ]),
+    );
+  });
+
+  test("omits the browser when all three sources are disabled", () => {
+    const registered = registration(
+      config("pi-composition-disabled", {
+        subagent: false,
+        workflow: false,
+        "bit-task": false,
+      }),
+    );
+    expect(registered.commands.has("subagents")).toBe(false);
+    expect(registered.commands.has("bit-issues")).toBe(false);
+    expect(registered.shortcuts.has("ctrl+alt+s")).toBe(false);
+    expect(registered.shortcuts.has("ctrl+alt+i")).toBe(false);
+  });
+
+  test("PI_HARNESS_CHILD=1 disables both resident sources", () => {
+    const childConfig = loadConfig(
+      { PI_HARNESS_CHILD: "1" },
+      resolvePaths("/tmp/pi-composition-child-profile"),
+    );
+    const registered = registration(childConfig);
+    expect(childConfig.features.subagent).toBe(false);
+    expect(childConfig.features.workflow).toBe(false);
+    expect(childConfig.features["bit-task"]).toBe(false);
+    expect(registered.commands.has("subagents")).toBe(false);
+    expect(registered.commands.has("bit-issues")).toBe(false);
+  });
+});
+
+interface RuntimeComponent {
+  render(width: number): string[];
+  invalidate(): void;
+  handleInput?(data: string): void;
+  dispose?(): void;
+}
+
+const commandResult = (stdout: string): BoundedCommandResult => ({
+  exitCode: 0,
+  stdout: Buffer.from(stdout),
+  stderr: Buffer.alloc(0),
+  stdoutTruncated: false,
+});
+
+const createIssueRuntime = () => {
+  const handlers = new Map<
+    string,
+    ((event: unknown, ctx: typeof context) => unknown)[]
+  >();
+  const commands = new Map<
+    string,
+    { handler: (args: string, ctx: typeof context) => Promise<void> }
+  >();
+  const shortcuts = new Map<
+    string,
+    { handler: (ctx: typeof context) => Promise<void> | void }
+  >();
+  const keybindings = {
+    matches(data: string, key: string) {
+      const map: Record<string, string> = {
+        "tui.editor.cursorDown": "down",
+        "tui.select.confirm": "enter",
+        "tui.select.cancel": "escape",
+        "tui.select.up": "up",
+        "tui.select.down": "down",
+      };
+      return map[key] === data;
+    },
+  };
+  const editor: RuntimeComponent & {
+    keybindings: typeof keybindings;
+    getText(): string;
+    getCursor(): { line: number; col: number };
+  } = {
+    keybindings,
+    render: () => ["editor"],
+    invalidate() {},
+    handleInput() {},
+    getText: () => "",
+    getCursor: () => ({ line: 0, col: 0 }),
+  };
+  const tui = {
+    terminal: { rows: 24 },
+    focusedComponent: editor as RuntimeComponent | null,
+    setFocus(component: RuntimeComponent | null) {
+      this.focusedComponent = component;
+    },
+    requestRender() {},
+  };
+  let component: RuntimeComponent | undefined;
+  let terminalInput:
+    | ((data: string) => { consume?: boolean; data?: string } | undefined)
+    | undefined;
+  const notifications: string[] = [];
+  const context = {
+    cwd: "/repo",
+    mode: "tui",
+    hasUI: true,
+    isIdle: () => true,
+    sessionManager: { getBranch: () => [] },
+    ui: {
+      select: async () => undefined,
+      confirm: async () => false,
+      input: async () => undefined,
+      notify: (message: string) => notifications.push(message),
+      setWidget(
+        _key: string,
+        factory:
+          | ((runtimeTui: typeof tui, theme: unknown) => RuntimeComponent)
+          | undefined,
+      ) {
+        component?.dispose?.();
+        component = factory?.(tui, {});
+        if (component === undefined && tui.focusedComponent !== editor) {
+          tui.setFocus(editor);
+        }
+      },
+      onTerminalInput(
+        handler: (
+          data: string,
+        ) => { consume?: boolean; data?: string } | undefined,
+      ) {
+        terminalInput = handler;
+        return () => {
+          if (terminalInput === handler) terminalInput = undefined;
+        };
+      },
+    },
+  };
+  const pi = {
+    on(
+      event: string,
+      handler: (event: unknown, eventContext: typeof context) => unknown,
+    ) {
+      const list = handlers.get(event) ?? [];
+      list.push(handler);
+      handlers.set(event, list);
+    },
+    registerCommand(
+      name: string,
+      options: {
+        handler: (args: string, ctx: typeof context) => Promise<void>;
+      },
+    ) {
+      commands.set(name, options);
+    },
+    registerShortcut(
+      name: string,
+      options: { handler: (ctx: typeof context) => Promise<void> | void },
+    ) {
+      shortcuts.set(name, options);
+    },
+  } as unknown as PiLike;
+  return {
+    pi,
+    context,
+    commands,
+    shortcuts,
+    tui,
+    notifications,
+    getComponent: () => component,
+    hasTerminalInput: () => terminalInput !== undefined,
+    async emit(event: string) {
+      for (const handler of handlers.get(event) ?? []) {
+        await handler({ type: event }, context);
+      }
+    },
+  };
+};
+
+describe("open bit issue browser lifecycle", () => {
+  test("gates child background guidance independently from the bit browser", async () => {
+    const bitOnly = createFakePi({ cwd: "/repo" });
+    Object.assign(bitOnly, { sendMessage() {} });
+    setupChildRuns(bitOnly, { bitIssues: true, childExecution: false });
+    const bitOnlyInjection = await bitOnly.emitBeforeAgentStart({
+      type: "before_agent_start",
+      prompt: "inspect issues",
+      systemPrompt: "base",
+    });
+    expect(bitOnlyInjection?.systemPrompt).toBeUndefined();
+
+    const withChildren = createFakePi({ cwd: "/repo" });
+    Object.assign(withChildren, { sendMessage() {} });
+    setupChildRuns(withChildren, { bitIssues: true, childExecution: true });
+    const childInjection = await withChildren.emitBeforeAgentStart({
+      type: "before_agent_start",
+      prompt: "run child",
+      systemPrompt: "base",
+    });
+    expect(childInjection?.systemPrompt).toContain(
+      "Background agent completion",
+    );
+  });
+
+  test("keeps automatic missing-bit failure silent and deduplicates explicit warnings", async () => {
+    const runtime = createIssueRuntime();
+    const runCommand: RunBoundedCommand = async (command) => {
+      if (command === "git") return commandResult("/repo/.git\n");
+      throw new BoundedCommandError("missing", "bit", "bit is unavailable");
+    };
+    const cli = new BitIssueCli({
+      runCommand,
+      realpath: async (path) => path,
+    });
+    setupChildRuns(runtime.pi, { bitIssues: true, bitIssueCli: cli });
+
+    await runtime.emit("session_start");
+    await Bun.sleep(0);
+    expect(runtime.notifications).toEqual([]);
+    const command = runtime.commands.get("bit-issues");
+    if (command === undefined) throw new Error("bit-issues command missing");
+    await command.handler("", runtime.context);
+    await command.handler("", runtime.context);
+    expect(runtime.notifications).toEqual([
+      "Open bit issues unavailable: bit is unavailable",
+    ]);
+  });
+
+  test("background-mounts, focuses explicitly, refreshes, honors q, and disposes", async () => {
+    const runtime = createIssueRuntime();
+    let listCalls = 0;
+    const runCommand: RunBoundedCommand = async (command, args) => {
+      if (command === "git") return commandResult("/repo/.git\n");
+      if (args[1] === "list") {
+        listCalls += 1;
+        return commandResult(
+          JSON.stringify([
+            {
+              id: "issue-a",
+              title: "[task:test#1:1] issue a",
+              state: "open",
+              author: "Pi Tester",
+              created_at: 10,
+              updated_at: 20,
+              body: "body",
+              labels: ["session:test"],
+            },
+          ]),
+        );
+      }
+      throw new Error(`unexpected bit argv: ${args.join(" ")}`);
+    };
+    const cli = new BitIssueCli({
+      runCommand,
+      realpath: async (path) => path,
+    });
+    setupChildRuns(runtime.pi, { bitIssues: true, bitIssueCli: cli });
+
+    await runtime.emit("session_start");
+    await Bun.sleep(0);
+    const mounted = runtime.getComponent();
+    expect(mounted).toBeDefined();
+    expect(mounted?.render(80)[0]).toContain("Open bit issues: 1");
+    expect(runtime.tui.focusedComponent).not.toBe(mounted ?? null);
+
+    const bitIssuesCommand = runtime.commands.get("bit-issues");
+    if (bitIssuesCommand === undefined)
+      throw new Error("bit-issues command missing");
+    const callsBeforeCommand = listCalls;
+    await bitIssuesCommand.handler("", runtime.context);
+    await Bun.sleep(0);
+    expect(listCalls).toBe(callsBeforeCommand + 1);
+    const focused = runtime.getComponent();
+    expect(focused).toBeDefined();
+    expect(runtime.tui.focusedComponent).toBe(focused ?? null);
+    expect(
+      (
+        runtime.getComponent() as RuntimeComponent & {
+          getSelectedIssueId(): string | undefined;
+        }
+      ).getSelectedIssueId(),
+    ).toBe("issue-a");
+
+    const callsBeforeR = listCalls;
+    runtime.getComponent()?.handleInput?.("r");
+    await Bun.sleep(0);
+    expect(listCalls).toBeGreaterThan(callsBeforeR);
+
+    runtime.getComponent()?.handleInput?.("q");
+    expect(runtime.getComponent()).toBeUndefined();
+    await runtime.emit("agent_settled");
+    await Bun.sleep(0);
+    expect(runtime.getComponent()).toBeUndefined();
+
+    const bitIssuesShortcut = runtime.shortcuts.get("ctrl+alt+i");
+    if (bitIssuesShortcut === undefined)
+      throw new Error("bit-issues shortcut missing");
+    await bitIssuesShortcut.handler(runtime.context);
+    expect(runtime.getComponent()).toBeDefined();
+    await runtime.emit("session_shutdown");
+    expect(runtime.getComponent()).toBeUndefined();
+    expect(runtime.hasTerminalInput()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- extend the existing Child sessions TUI into one read-only coordination browser for child runs and open local `bit issue` records
- add repository-scoped, bounded `bit` CLI loading with safe refresh/detail concurrency and linked-worktree canonicalization
- add issue detail/comments display, `/bit-issues`, `Ctrl+Alt+I`, lifecycle integration, and bit-task-only composition
- preserve one `belowEditor` widget, one focus owner, and child-only behavior when bit tasks are disabled

## Validation

- `bun test` — 1451 passed, 2 skipped, 0 failed
- `bun run tsc`
- `bun run check:pi-imports`
- `bun run check:pi-compat`
- `bun run check:pi-baseline`
- `bun run check:pi-schemas`
- `bun run lint` — 0 errors
- Prettier check
- `git diff --check`

Closes #57
