### PR TITLE
feat(pi): audit Bash permission decisions

### DIFF
--- a/pi/LOCAL_PERMISSION_JUDGE.md
+++ b/pi/LOCAL_PERMISSION_JUDGE.md
@@ -80,6 +80,12 @@ JSON require confirmation or block.
 Interactive permission confirmations have no countdown: they remain open until
 the user responds or aborts the active pi operation (for example with Esc).
 
+The permission audit is mandatory and has no feature toggle. Disabling the
+local judge changes residual command routing but does not disable deterministic,
+hook, confirmation, or final-boundary audit records. If the audit sink is not
+writable, pi-harness blocks Bash release rather than executing an unaudited
+ALLOW or accepted ASK.
+
 ## Command hygiene guidance
 
 Before each parent or child agent run, the mandatory permission-policy feature
@@ -184,6 +190,11 @@ deterministic floor, explicit confirmation, or local judge.
     response, and exactly one structured decision containing only `safety` and
     `relevance`. Both must be `ALLOW`; either `ASK` or any invalid response asks
     the user or blocks without UI.
+15. Append one terminal V1 audit record after every pi-harness permission stage
+    has passed, or at the exact stage that blocks. A successful ALLOW or accepted
+    ASK is released only after the append succeeds. `release` describes the
+    pi-harness boundary; a later third-party extension can still veto or mutate
+    the call because Pi exposes no final immutable pre-execution hook.
 
 Pi runs the shared `npm_script_preference` hook as a blocking preflight before
 this decision. Because it precedes permission-policy, pi launches it with
@@ -286,6 +297,78 @@ verified-project fingerprint, and bounded request envelope. Raw task, assistant
 text, command, and omitted worktree text is not retained in cache entries. ASK,
 timeout, malformed, aborted, unverified, unavailable, and uncorrelated outcomes
 are never cached.
+
+## Permission audit storage and analysis
+
+The cache privacy statement above does not apply to the separate corpus audit.
+The audit intentionally stores raw commands and the bounded task/run/project
+context used for classification, plus deterministic route basis, rule source,
+verified navigation, exact live judge gates, cache source, hook stages, and
+confirmation outcome. This makes the records useful for replay-free offline
+analysis, but it also means they may contain credentials, private paths, and
+other sensitive text.
+
+Records use schema `pi-harness/bash-permission`, version 1, and are written to:
+
+```text
+~/.pi/agent/pi-harness/logs/permission-YYYY-MM-DD-<writer-uuid>.jsonl
+```
+
+The directory is `0700`; files are exclusive-created at `0600`. Every extension
+instance uses a distinct writer UUID, so reloads and parent/child processes do
+not share an append target. Records contain writer sequence, Pi session ID, and
+non-secret parent lineage / invocation / run IDs. Those inherited IDs are join
+hints under the trusted-local-account model, not cryptographic identities. The
+authenticated child permission-signal token is consumed separately and never
+stored.
+
+A top-level writer removes records older than 90 days only after `lstat`
+confirms an owner-matching, single-link regular `0600` file. Symlinks, FIFOs,
+hardlinks, unexpected modes/owners, and malformed names are skipped. The
+serialized record limit is 1 MiB. An oversized call is blocked and represented
+by a compact hash/size marker. Short writes are retried; a failed partial write
+is truncated back to its original offset, and rollback failure poisons that
+writer. A complete kernel write is considered persisted for release; no
+per-command filesystem sync is performed, so crash/power-loss durability is not
+guaranteed. Node has no portable `openat` binding, leaving a documented
+same-user parent-directory replacement residual despite no-follow and directory
+identity checks.
+
+The pure helpers in `features/permission-audit/analysis.ts` validate V1 JSONL,
+report malformed/truncated tails, aggregate decisions/routes/reasons/gates/cache
+and confirmations, and emit qualification candidates. A confirmation stage
+normally makes the effective decision `ask`, including rejected, UI-less, and
+aborted challenges; however, a separate later explicit deny or internal error
+is terminal and takes precedence as `deny`. Candidates deliberately
+have no `expected` verdict: model output and user approval are observations, not
+ground truth. Review a candidate manually before adding it to the qualification
+corpus or deriving a deterministic ALLOW rule. Do not commit or publish raw logs
+or exports without secret review.
+
+A minimal local frequency summary is:
+
+```bash
+jq -s '
+  group_by([.effectiveDecision, .boundaryDisposition]) |
+  map({decision: .[0].effectiveDecision,
+       disposition: .[0].boundaryDisposition,
+       count: length})
+' ~/.pi/agent/pi-harness/logs/permission-*.jsonl
+```
+
+If directory/file verification, serialization, or append fails, pi-harness
+blocks the call and shows at most one generic UI warning per session. While the
+sink is healthy there is exactly one terminal record per observed Bash call;
+the impossible claim that an unavailable sink also contains its failed record
+is not made.
+
+Repeated confirmation is also used as bounded usability feedback, not as a
+safety label. After every three Bash confirmations actually displayed in one
+parent session (`accepted`, `rejected`, or `aborted`), pi-harness injects one
+hidden transient reminder asking the agent to narrow or split later command
+shapes without changing their intent. Intermediate ASK verdicts and UI-less
+`not-shown` outcomes do not count. This reminder cannot alter permission
+routing, update rules, or promote observed approval into qualification corpus.
 
 ## Security limitations
 

--- a/pi/README.md
+++ b/pi/README.md
@@ -117,9 +117,19 @@ deterministic ask floor. An unavailable judge asks in interactive sessions and
 blocks in child/non-UI sessions; set `permissionJudge.enabled` to `false` for
 the previous rule-only behavior. Existing broad explicit grants still bypass
 the fallback by design except for helper-capable Git reads and `rg` reads that
-have not independently satisfied the no-config/canonical-path conditions. See
-[`LOCAL_PERMISSION_JUDGE.md`](./LOCAL_PERMISSION_JUDGE.md) for setup,
-configuration, data boundaries, and qualification steps.
+have not independently satisfied the no-config/canonical-path conditions.
+
+The safety layer also writes an always-on, versioned permission audit record for
+every Bash call it observes, in parent and pi-harness child processes. One JSONL
+record combines npm preflight, deterministic route/basis, verified project and
+worktree scope, local-judge safety/relevance gates and cache source, later hook
+stages, confirmation outcome, and the final pi-harness boundary disposition.
+ALLOW or an accepted ASK is not released unless that record append succeeds;
+an unavailable sink blocks the command. These records intentionally retain the
+raw shell command and bounded task/run/project context for corpus review, so
+they are sensitive local data. See
+[`LOCAL_PERMISSION_JUDGE.md`](./LOCAL_PERMISSION_JUDGE.md) for storage,
+retention, schema, analysis, limitations, judge setup, and qualification steps.
 
 An explicitly invoked `/skill:<name>` may pre-approve parent-session Bash
 commands through its `allowed-tools` frontmatter. The permission policy records
@@ -203,6 +213,7 @@ typebox baseline + acceptance/rejection through pi's real `validateToolArguments
 | AskUserQuestion                      | exact-name `AskUserQuestion` compatibility tool                              |
 | Notification (asuku)                 | asuku-notify feature (`agent_settled`, detached)                             |
 | permissions.deny / auto fallback     | permission-policy rules + local Ollama judge (fail-closed)                   |
+| permission decision corpus           | always-on private versioned JSONL audit (parent + child lineage)             |
 | statusLine                           | statusline feature (Claude-equivalent custom footer)                         |
 | logproxy                             | provider-log feature (opt-in, reduced scope)                                 |
 
@@ -289,6 +300,62 @@ Collision behavior (pi 0.80.6, docs/skills.md): discovery scans
 `~/.pi/agent/skills` before `~/.agents/skills` and keeps the **first** skill
 on a name collision, so the forks shadow the Claude versions for pi. pi may
 log a duplicate-name warning at startup — expected.
+
+## Permission audit log
+
+Permission decisions are stored under
+`~/.pi/agent/pi-harness/logs/permission-YYYY-MM-DD-<writer-uuid>.jsonl`.
+The directory is forced to `0700`; each per-writer file is created exclusively
+at `0600`. Parent and child processes never append to one shared file. Files
+older than 90 days are removed only when they are regular, owner-matching,
+single-link `0600` files; suspicious symlinks, FIFOs, hardlinks, ownership, or
+mode mismatches are skipped.
+
+The V1 schema is `pi-harness/bash-permission`. It records writer sequence,
+process/session/parent-child correlation, command text/hash/size, bounded task
+and authenticated same-run evidence, project/worktree/navigation context,
+ordered typed stages, `allow|ask|deny`, and the pi-harness boundary disposition
+`release|block`. `release` means later pi handlers may run; Pi exposes no final
+immutable pre-execution hook, so it is not proof that a later extension did not
+veto or mutate the call. Observed decisions are telemetry, not ground-truth
+labels. The analysis helper emits candidates without an `expected` verdict;
+manual review is required before adding one to the checked-in qualification
+corpus or deterministic ALLOW rules.
+
+Records retain commands and task text that may contain credentials, private
+paths, or other secrets. Do not publish or commit them without review. The
+serialized record ceiling is 1 MiB; oversized input is blocked and represented
+by a compact hash/size marker. A short/partial write is rolled back before the
+next append. If rollback or the current append fails, the affected call remains
+blocked and the UI receives one generic warning without record contents. A
+completed kernel write is the release boundary; no per-command filesystem sync
+is performed, so crash/power-loss durability is not guaranteed.
+
+Example local aggregation (treat output as sensitive):
+
+```bash
+jq -s '
+  group_by([.effectiveDecision, .boundaryDisposition]) |
+  map({decision: .[0].effectiveDecision,
+       disposition: .[0].boundaryDisposition,
+       count: length})
+' ~/.pi/agent/pi-harness/logs/permission-*.jsonl
+```
+
+Pure parsing, diagnostics, aggregation, and unlabeled candidate conversion live
+in `features/permission-audit/analysis.ts`. Malformed and truncated JSONL tails
+are reported rather than silently treated as valid records.
+
+### Repeated ASK reminder
+
+In a parent session, every third Bash confirmation that was actually displayed
+(`accepted`, `rejected`, or `aborted`) schedules one hidden transient system
+reminder for the next agent context. Intermediate ASK verdicts and headless
+`not-shown` outcomes are not counted. The reminder asks the agent to preserve
+intent while narrowing the next command, separating navigation from action,
+and avoiding unnecessary compound or indirect shell syntax. It never changes a
+permission decision, weakens policy, or promotes prior approval into an ALLOW
+rule or qualification label. The counter resets at the session boundary.
 
 ## provider-log scope (V10, measured 2026-07-11)
 

--- a/pi/extensions/pi-harness/features/hook-bridge/index.ts
+++ b/pi/extensions/pi-harness/features/hook-bridge/index.ts
@@ -3,6 +3,8 @@ import {
   interpretPostToolUse,
   interpretPreToolUse,
   interpretUserPromptSubmit,
+  parseHookJson,
+  type RawHookResult,
   makePostToolUseStdin,
   makePreToolUseStdin,
   makeUserPromptSubmitStdin,
@@ -19,7 +21,24 @@ import {
   selectMatchingSpecs,
 } from "./mapping";
 import type { PermissionBlockResult } from "../permission-policy/block";
+import {
+  PERMISSION_AUDIT_UNAVAILABLE_REASON,
+  type PermissionAuditIntegration,
+} from "../permission-audit/index";
 import { buildRegistry, type BridgeHookSpec } from "./registry";
+
+const hookContinueReasonCode = (raw: RawHookResult): string => {
+  if (raw.timedOut) return "hook-timeout";
+  if (raw.exitCode !== 0) return "hook-nonzero-exit";
+  if (raw.stdout.trim() === "") return "hook-continue";
+  const output = parseHookJson(raw.stdout);
+  if (output === undefined) return "hook-malformed-output";
+  const permissionDecision = output.hookSpecificOutput?.permissionDecision;
+  return permissionDecision !== undefined &&
+    !["allow", "ask", "deny"].includes(permissionDecision)
+    ? "hook-unknown-permission-decision"
+    : "hook-continue";
+};
 
 export default function setupHookBridge(
   pi: PiLike,
@@ -29,6 +48,8 @@ export default function setupHookBridge(
     cwd?: string;
     env?: Record<string, string | undefined>;
     blockToolCall?: (reason: string) => PermissionBlockResult;
+    permissionAudit?: PermissionAuditIntegration;
+    auditPhase?: "preflight" | "remaining";
   },
 ): void {
   const fullRegistry = options?.registry ?? buildRegistry(config.paths);
@@ -46,47 +67,127 @@ export default function setupHookBridge(
     ctx.cwd ?? options?.cwd ?? process.cwd();
 
   pi.on("tool_call", async (event, ctx) => {
-    const cwd = resolveCwd(ctx);
-    const invocation = mapToolCall(event.toolName, event.input);
-    const specs = selectMatchingSpecs(
-      registry,
-      "tool_call",
-      invocation.toolName,
-    );
+    const audit =
+      event.toolName === "bash" ? options?.permissionAudit : undefined;
+    const auditPhase = options?.auditPhase ?? "remaining";
+    const signalAborted = (): boolean =>
+      ctx.signal !== undefined &&
+      "aborted" in ctx.signal &&
+      ctx.signal.aborted === true;
+    const block = (reason: string): PermissionBlockResult =>
+      options?.blockToolCall?.(reason) ?? { block: true, reason };
+    const finalizeBlock = async (
+      reasonCode: string,
+      reason: string,
+    ): Promise<PermissionBlockResult> => {
+      if (audit === undefined) return block(reason);
+      return (await audit.finalizeBlock(event.toolCallId, reasonCode))
+        ? block(reason)
+        : block(PERMISSION_AUDIT_UNAVAILABLE_REASON);
+    };
 
-    for (const spec of specs) {
-      const raw = await runHook(
-        spec.script,
-        JSON.stringify(makePreToolUseStdin(invocation, cwd)),
-        {
-          cwd,
-          env: options?.env,
-          timeoutMs: spec.timeoutMs,
-          maxOutputBytes: spec.maxOutputBytes,
-        },
+    try {
+      const cwd = resolveCwd(ctx);
+      const invocation = mapToolCall(event.toolName, event.input);
+      const specs = selectMatchingSpecs(
+        registry,
+        "tool_call",
+        invocation.toolName,
       );
-      const outcome = interpretPreToolUse(raw);
-      if (outcome.notify !== undefined) {
-        ctx.ui.notify(outcome.notify.message, outcome.notify.level);
-      }
-      if (outcome.kind === "block") {
-        const reason =
-          outcome.reason ?? "A PreToolUse hook blocked this tool call.";
-        return options?.blockToolCall?.(reason) ?? { block: true, reason };
-      }
-      if (outcome.kind === "ask") {
-        const reason =
-          outcome.reason ?? "A PreToolUse hook requires confirmation.";
-        const confirmed = ctx.hasUI
-          ? await ctx.ui.confirm("Hook permission request", reason)
-          : false;
-        if (!confirmed) {
-          return options?.blockToolCall?.(reason) ?? { block: true, reason };
-        }
-      }
-    }
 
-    return undefined;
+      for (const spec of specs) {
+        const raw = await runHook(
+          spec.script,
+          JSON.stringify(makePreToolUseStdin(invocation, cwd)),
+          {
+            cwd,
+            env: options?.env,
+            timeoutMs: spec.timeoutMs,
+            maxOutputBytes: spec.maxOutputBytes,
+          },
+        );
+        const outcome = interpretPreToolUse(raw);
+        if (outcome.notify !== undefined) {
+          ctx.ui.notify(outcome.notify.message, outcome.notify.level);
+        }
+        if (outcome.kind === "block") {
+          const reason =
+            outcome.reason ?? "A PreToolUse hook blocked this tool call.";
+          audit?.addStage(event.toolCallId, {
+            type: "hook",
+            phase: auditPhase,
+            hookId: spec.id,
+            verdict: "deny",
+            reasonCode: "hook-deny",
+            reason,
+          });
+          return finalizeBlock("hook-deny", reason);
+        }
+        if (outcome.kind === "ask") {
+          const reason =
+            outcome.reason ?? "A PreToolUse hook requires confirmation.";
+          audit?.addStage(event.toolCallId, {
+            type: "hook",
+            phase: auditPhase,
+            hookId: spec.id,
+            verdict: "ask",
+            reasonCode: "hook-ask",
+            reason,
+          });
+          const confirmed = ctx.hasUI
+            ? await ctx.ui.confirm("Hook permission request", reason, {
+                signal: ctx.signal,
+              })
+            : false;
+          const status = !ctx.hasUI
+            ? ("not-shown" as const)
+            : signalAborted()
+              ? ("aborted" as const)
+              : confirmed
+                ? ("accepted" as const)
+                : ("rejected" as const);
+          audit?.addStage(event.toolCallId, {
+            type: "confirmation",
+            phase: auditPhase,
+            challengeSource: `hook:${spec.id}`,
+            status,
+            reasonCode: "hook-ask",
+            reason,
+          });
+          if (!confirmed || signalAborted()) {
+            return finalizeBlock("hook-ask", reason);
+          }
+          continue;
+        }
+        const reasonCode = hookContinueReasonCode(raw);
+        const reason =
+          outcome.reason ??
+          (reasonCode === "hook-continue"
+            ? undefined
+            : outcome.notify?.message);
+        audit?.addStage(event.toolCallId, {
+          type: "hook",
+          phase: auditPhase,
+          hookId: spec.id,
+          verdict: "continue",
+          reasonCode,
+          ...(reason === undefined ? {} : { reason }),
+        });
+      }
+
+      return undefined;
+    } catch (error) {
+      const reason = `PreToolUse hook failed: ${String(error)}`;
+      audit?.addStage(event.toolCallId, {
+        type: "error",
+        component: "hook-bridge",
+        phase: auditPhase,
+        verdict: "error",
+        reasonCode: "hook-error",
+        message: String(error),
+      });
+      return finalizeBlock("hook-error", reason);
+    }
   });
 
   pi.on("tool_result", async (event, ctx) => {

--- a/pi/extensions/pi-harness/features/permission-ask-reminder/index.ts
+++ b/pi/extensions/pi-harness/features/permission-ask-reminder/index.ts
@@ -1,0 +1,71 @@
+import type { PiLike } from "../../lib/pi-like";
+
+const PERMISSION_ASK_REMINDER_THRESHOLD = 3;
+const PERMISSION_ASK_REMINDER_CUSTOM_TYPE =
+  "pi-harness-permission-ask-reminder";
+
+export interface PermissionAskReminderIntegration {
+  recordDisplayedConfirmation(): void;
+}
+
+const permissionAskReminderContent = (
+  count: number,
+): string => `<system-reminder>
+You have encountered ${count} Bash permission confirmations in this session.
+Repeated ASK challenges can indicate that command shape is broader or more complex than necessary.
+Before issuing another Bash command, preserve the task intent while making the command easier to evaluate:
+- use a narrow, single-purpose command
+- separate directory navigation from the action when practical
+- avoid unnecessary compound shell syntax, command substitution, or indirect execution
+- prefer an existing checked-in package script when it expresses the intended operation
+Do not weaken or bypass the permission policy, and do not treat prior approval as an automatic ALLOW label.
+If the confirmations were intentional and the command is already minimal, continue without changing its meaning.
+</system-reminder>`;
+
+const reminderMessage = (count: number) => ({
+  role: "custom" as const,
+  customType: PERMISSION_ASK_REMINDER_CUSTOM_TYPE,
+  content: permissionAskReminderContent(count),
+  display: false,
+  timestamp: Date.now(),
+});
+
+const setupPermissionAskReminder = (
+  pi: PiLike,
+): PermissionAskReminderIntegration => {
+  let displayedConfirmations = 0;
+  let pendingCount = 0;
+  let deliveredCount = 0;
+
+  const reset = (): void => {
+    displayedConfirmations = 0;
+    pendingCount = 0;
+    deliveredCount = 0;
+  };
+
+  pi.on("session_start", reset);
+  pi.on("session_shutdown", reset);
+  pi.on("context", (event) => {
+    if (pendingCount === 0 || pendingCount <= deliveredCount) return undefined;
+    deliveredCount = pendingCount;
+    return {
+      messages: [...event.messages, reminderMessage(pendingCount)],
+    };
+  });
+
+  return {
+    recordDisplayedConfirmation() {
+      displayedConfirmations += 1;
+      if (displayedConfirmations % PERMISSION_ASK_REMINDER_THRESHOLD === 0) {
+        pendingCount = displayedConfirmations;
+      }
+    },
+  };
+};
+
+export {
+  PERMISSION_ASK_REMINDER_CUSTOM_TYPE,
+  PERMISSION_ASK_REMINDER_THRESHOLD,
+  permissionAskReminderContent,
+};
+export default setupPermissionAskReminder;

--- a/pi/extensions/pi-harness/features/permission-audit/analysis.ts
+++ b/pi/extensions/pi-harness/features/permission-audit/analysis.ts
@@ -1,0 +1,390 @@
+import {
+  derivePermissionDecision,
+  MAX_PERMISSION_AUDIT_RECORD_BYTES,
+  PERMISSION_AUDIT_SCHEMA,
+  PERMISSION_AUDIT_VERSION,
+  type PermissionAuditStage,
+  type PermissionDecisionRecordV1,
+} from "./model";
+
+export interface PermissionAuditParseDiagnostic {
+  readonly line: number;
+  readonly code: "invalid-json" | "invalid-record" | "truncated-tail";
+}
+
+export interface PermissionAuditParseResult {
+  readonly records: readonly PermissionDecisionRecordV1[];
+  readonly diagnostics: readonly PermissionAuditParseDiagnostic[];
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+const optionalString = (value: unknown): boolean =>
+  value === undefined || typeof value === "string";
+const stringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === "string");
+const nonnegativeSafeInteger = (value: unknown): value is number =>
+  Number.isSafeInteger(value) && Number(value) >= 0;
+
+const validNavigation = (value: unknown): boolean =>
+  isRecord(value) &&
+  ["listed-worktree", "outside-listed-worktrees", "unverified"].includes(
+    String(value.scope),
+  ) &&
+  typeof value.sameRepository === "boolean";
+
+const validProject = (value: unknown): boolean => {
+  if (
+    !isRecord(value) ||
+    !["git", "non-git", "unavailable"].includes(String(value.kind))
+  ) {
+    return false;
+  }
+  if (
+    !optionalString(value.name) ||
+    !optionalString(value.cwd) ||
+    !optionalString(value.activeWorktree) ||
+    !optionalString(value.reason) ||
+    !optionalString(value.fingerprint) ||
+    (value.navigableRoots !== undefined &&
+      !stringArray(value.navigableRoots)) ||
+    (value.worktrees !== undefined && !stringArray(value.worktrees))
+  ) {
+    return false;
+  }
+  return (
+    value.kind !== "git" ||
+    (typeof value.cwd === "string" &&
+      typeof value.activeWorktree === "string" &&
+      stringArray(value.navigableRoots) &&
+      stringArray(value.worktrees))
+  );
+};
+
+const validStage = (value: unknown): value is PermissionAuditStage => {
+  if (
+    !isRecord(value) ||
+    typeof value.type !== "string" ||
+    !optionalString(value.reason)
+  ) {
+    return false;
+  }
+  if (value.type === "confirmation") {
+    return (
+      typeof value.phase === "string" &&
+      typeof value.challengeSource === "string" &&
+      typeof value.reasonCode === "string" &&
+      ["accepted", "rejected", "not-shown", "aborted"].includes(
+        String(value.status),
+      )
+    );
+  }
+  if (value.type === "error") {
+    return (
+      value.verdict === "error" &&
+      typeof value.component === "string" &&
+      typeof value.phase === "string" &&
+      typeof value.reasonCode === "string" &&
+      optionalString(value.message)
+    );
+  }
+  if (value.type === "hook") {
+    return (
+      (value.phase === "preflight" || value.phase === "remaining") &&
+      typeof value.hookId === "string" &&
+      typeof value.reasonCode === "string" &&
+      ["continue", "ask", "deny", "error"].includes(String(value.verdict))
+    );
+  }
+  if (value.type === "judge") {
+    const gates = value.gates;
+    return (
+      typeof value.phase === "string" &&
+      typeof value.reasonCode === "string" &&
+      typeof value.outcome === "string" &&
+      ["allow", "ask", "error"].includes(String(value.verdict)) &&
+      (value.source === undefined ||
+        value.source === "live" ||
+        value.source === "cache") &&
+      optionalString(value.model) &&
+      optionalString(value.expectedDigest) &&
+      optionalString(value.policyVersion) &&
+      (gates === undefined ||
+        (isRecord(gates) &&
+          ["ALLOW", "ASK"].includes(String(gates.safety)) &&
+          ["ALLOW", "ASK"].includes(String(gates.relevance))))
+    );
+  }
+  if (value.type === "scope") {
+    return (
+      typeof value.phase === "string" &&
+      typeof value.reasonCode === "string" &&
+      ["allow", "ask", "deny", "error"].includes(String(value.verdict)) &&
+      (value.project === undefined || validProject(value.project)) &&
+      (value.navigation === undefined || validNavigation(value.navigation))
+    );
+  }
+  if (value.type === "deterministic") {
+    return (
+      typeof value.phase === "string" &&
+      typeof value.basis === "string" &&
+      typeof value.reasonCode === "string" &&
+      ["allow", "ask", "deny", "continue"].includes(String(value.verdict)) &&
+      optionalString(value.ruleSource) &&
+      (value.grantedBySkill === undefined ||
+        typeof value.grantedBySkill === "boolean")
+    );
+  }
+  return false;
+};
+
+const validCommand = (value: unknown): boolean => {
+  if (
+    !isRecord(value) ||
+    !SHA256_PATTERN.test(String(value.sha256)) ||
+    !nonnegativeSafeInteger(value.bytes)
+  ) {
+    return false;
+  }
+  if (value.kind === "command") return typeof value.text === "string";
+  if (value.kind === "malformed") return typeof value.valueType === "string";
+  return value.kind === "omitted" && value.reason === "record-too-large";
+};
+
+const validTask = (value: unknown): boolean => {
+  if (
+    !isRecord(value) ||
+    !["task", "none", "uncorrelated"].includes(String(value.correlation))
+  ) {
+    return false;
+  }
+  if (value.correlation !== "task") return value.task === undefined;
+  return (
+    isRecord(value.task) &&
+    typeof value.task.text === "string" &&
+    typeof value.task.source === "string" &&
+    optionalString(value.task.fingerprint)
+  );
+};
+
+const validRunEvidence = (value: unknown): boolean =>
+  isRecord(value) &&
+  optionalString(value.assistantText) &&
+  typeof value.fingerprint === "string" &&
+  Array.isArray(value.priorToolResults) &&
+  value.priorToolResults.every(
+    (item) =>
+      isRecord(item) &&
+      typeof item.toolName === "string" &&
+      ["ok", "error", "unknown"].includes(String(item.status)),
+  );
+
+export const isPermissionDecisionRecordV1 = (
+  value: unknown,
+): value is PermissionDecisionRecordV1 => {
+  if (!isRecord(value)) return false;
+  const processValue = value.process;
+  const lineage = isRecord(processValue) ? processValue.lineage : undefined;
+  if (
+    value.schema !== PERMISSION_AUDIT_SCHEMA ||
+    value.version !== PERMISSION_AUDIT_VERSION ||
+    typeof value.timestamp !== "string" ||
+    !Number.isFinite(Date.parse(value.timestamp)) ||
+    typeof value.decisionId !== "string" ||
+    !UUID_PATTERN.test(value.decisionId) ||
+    typeof value.writerInstanceId !== "string" ||
+    !UUID_PATTERN.test(value.writerInstanceId) ||
+    !nonnegativeSafeInteger(value.sequence) ||
+    value.sequence < 1 ||
+    typeof value.sessionId !== "string" ||
+    typeof value.toolCallId !== "string" ||
+    !isRecord(processValue) ||
+    !nonnegativeSafeInteger(processValue.pid) ||
+    typeof processValue.isChild !== "boolean" ||
+    !isRecord(lineage) ||
+    typeof lineage.lineageId !== "string" ||
+    !UUID_PATTERN.test(lineage.lineageId) ||
+    (lineage.source !== "generated" && lineage.source !== "harness-env") ||
+    !optionalString(lineage.parentSessionId) ||
+    !optionalString(lineage.childInvocationId) ||
+    !optionalString(lineage.childRunId) ||
+    !validCommand(value.command) ||
+    !validTask(value.task) ||
+    (value.cwd !== undefined && typeof value.cwd !== "string") ||
+    (value.runEvidence !== undefined && !validRunEvidence(value.runEvidence)) ||
+    (value.project !== undefined && !validProject(value.project)) ||
+    (value.leadingNavigation !== undefined &&
+      !validNavigation(value.leadingNavigation)) ||
+    (value.gitCwd !== undefined && !validNavigation(value.gitCwd)) ||
+    !Array.isArray(value.stages) ||
+    !value.stages.every(validStage) ||
+    !["allow", "ask", "deny"].includes(String(value.effectiveDecision)) ||
+    derivePermissionDecision(value.stages) !== value.effectiveDecision ||
+    !["release", "block"].includes(String(value.boundaryDisposition)) ||
+    typeof value.terminalReasonCode !== "string"
+  ) {
+    return false;
+  }
+  return true;
+};
+
+export const parsePermissionAuditJsonl = (
+  text: string,
+): PermissionAuditParseResult => {
+  const records: PermissionDecisionRecordV1[] = [];
+  const diagnostics: PermissionAuditParseDiagnostic[] = [];
+  const endsWithNewline = text.endsWith("\n");
+  const lines = text.split("\n");
+  if (endsWithNewline) lines.pop();
+  for (const [index, line] of lines.entries()) {
+    if (line.trim() === "") continue;
+    if (Buffer.byteLength(line, "utf8") > MAX_PERMISSION_AUDIT_RECORD_BYTES) {
+      diagnostics.push({ line: index + 1, code: "invalid-record" });
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      diagnostics.push({
+        line: index + 1,
+        code:
+          !endsWithNewline && index === lines.length - 1
+            ? "truncated-tail"
+            : "invalid-json",
+      });
+      continue;
+    }
+    if (!isPermissionDecisionRecordV1(parsed)) {
+      diagnostics.push({ line: index + 1, code: "invalid-record" });
+      continue;
+    }
+    records.push(parsed);
+  }
+  return { records, diagnostics };
+};
+
+const increment = (target: Record<string, number>, key: string): void => {
+  target[key] = (target[key] ?? 0) + 1;
+};
+
+const stageRoute = (stage: PermissionAuditStage): string => {
+  if (stage.type === "deterministic")
+    return `${stage.type}:${stage.phase}:${stage.basis}`;
+  if (stage.type === "hook")
+    return `${stage.type}:${stage.phase}:${stage.hookId}`;
+  if (stage.type === "confirmation") {
+    return `${stage.type}:${stage.phase}:${stage.challengeSource}`;
+  }
+  if (stage.type === "error")
+    return `${stage.type}:${stage.component}:${stage.phase}`;
+  return `${stage.type}:${stage.phase}`;
+};
+
+export interface PermissionAuditSummary {
+  readonly total: number;
+  readonly byDecision: Readonly<Record<string, number>>;
+  readonly byDisposition: Readonly<Record<string, number>>;
+  readonly byRoute: Readonly<Record<string, number>>;
+  readonly byReason: Readonly<Record<string, number>>;
+  readonly byJudgeGates: Readonly<Record<string, number>>;
+  readonly byConfirmation: Readonly<Record<string, number>>;
+  readonly byCommand: Readonly<Record<string, number>>;
+  readonly byProcessKind: Readonly<Record<string, number>>;
+}
+
+export const summarizePermissionAudit = (
+  records: readonly PermissionDecisionRecordV1[],
+): PermissionAuditSummary => {
+  const byDecision: Record<string, number> = {};
+  const byDisposition: Record<string, number> = {};
+  const byRoute: Record<string, number> = {};
+  const byReason: Record<string, number> = {};
+  const byJudgeGates: Record<string, number> = {};
+  const byConfirmation: Record<string, number> = {};
+  const byCommand: Record<string, number> = {};
+  const byProcessKind: Record<string, number> = {};
+  for (const record of records) {
+    increment(byDecision, record.effectiveDecision);
+    increment(byDisposition, record.boundaryDisposition);
+    increment(byReason, `terminal:${record.terminalReasonCode}`);
+    increment(byCommand, record.command.sha256);
+    increment(byProcessKind, record.process.isChild ? "child" : "parent");
+    for (const stage of record.stages) {
+      increment(byRoute, stageRoute(stage));
+      increment(byReason, stage.reasonCode);
+      if (stage.type === "judge" && stage.gates !== undefined) {
+        increment(
+          byJudgeGates,
+          `${stage.source ?? "unknown"}:${stage.gates.safety}/${stage.gates.relevance}`,
+        );
+      }
+      if (stage.type === "confirmation") {
+        increment(byConfirmation, stage.status);
+      }
+    }
+  }
+  return {
+    total: records.length,
+    byDecision,
+    byDisposition,
+    byRoute,
+    byReason,
+    byJudgeGates,
+    byConfirmation,
+    byCommand,
+    byProcessKind,
+  };
+};
+
+export interface PermissionQualificationCandidate {
+  readonly schema: "pi-harness/permission-qualification-candidate";
+  readonly version: 1;
+  readonly decisionId: string;
+  readonly observedAt: string;
+  readonly command: string;
+  readonly commandSha256: string;
+  readonly cwd?: string;
+  readonly task: PermissionDecisionRecordV1["task"];
+  readonly runEvidence?: PermissionDecisionRecordV1["runEvidence"];
+  readonly project?: PermissionDecisionRecordV1["project"];
+  readonly leadingNavigation?: PermissionDecisionRecordV1["leadingNavigation"];
+  readonly gitCwd?: PermissionDecisionRecordV1["gitCwd"];
+  readonly observedDecision: PermissionDecisionRecordV1["effectiveDecision"];
+  readonly boundaryDisposition: PermissionDecisionRecordV1["boundaryDisposition"];
+  readonly stages: PermissionDecisionRecordV1["stages"];
+}
+
+export const buildPermissionQualificationCandidates = (
+  records: readonly PermissionDecisionRecordV1[],
+): readonly PermissionQualificationCandidate[] =>
+  records.flatMap((record) => {
+    if (record.command.kind !== "command") return [];
+    return [
+      {
+        schema: "pi-harness/permission-qualification-candidate" as const,
+        version: 1 as const,
+        decisionId: record.decisionId,
+        observedAt: record.timestamp,
+        command: record.command.text,
+        commandSha256: record.command.sha256,
+        ...(record.cwd === undefined ? {} : { cwd: record.cwd }),
+        task: record.task,
+        ...(record.runEvidence === undefined
+          ? {}
+          : { runEvidence: record.runEvidence }),
+        ...(record.project === undefined ? {} : { project: record.project }),
+        ...(record.leadingNavigation === undefined
+          ? {}
+          : { leadingNavigation: record.leadingNavigation }),
+        ...(record.gitCwd === undefined ? {} : { gitCwd: record.gitCwd }),
+        observedDecision: record.effectiveDecision,
+        boundaryDisposition: record.boundaryDisposition,
+        stages: record.stages,
+      },
+    ];
+  });

--- a/pi/extensions/pi-harness/features/permission-audit/index.ts
+++ b/pi/extensions/pi-harness/features/permission-audit/index.ts
@@ -1,0 +1,417 @@
+import { randomUUID } from "node:crypto";
+import type { HarnessConfig } from "../../config";
+import type {
+  CtxLike,
+  PiLike,
+  ToolCallBlockResult,
+  ToolCallEvent,
+} from "../../lib/pi-like";
+import {
+  derivePermissionRunEvidence,
+  type PermissionLeadingNavigation,
+  type PermissionProjectContext,
+  type PermissionTaskTracker,
+} from "../permission-policy/context";
+import {
+  buildPermissionCommand,
+  fitPermissionDecisionRecord,
+  type PermissionAuditStage,
+  type PermissionProjectAuditContext,
+  type PermissionTaskAuditContext,
+} from "./model";
+import {
+  createPermissionAuditWriter,
+  type PermissionAuditWriter,
+} from "./writer";
+
+export const PERMISSION_AUDIT_LINEAGE_ENV = "PI_HARNESS_AUDIT_LINEAGE_ID";
+export const PERMISSION_AUDIT_PARENT_SESSION_ENV =
+  "PI_HARNESS_AUDIT_PARENT_SESSION_ID";
+export const PERMISSION_AUDIT_INVOCATION_ENV = "PI_HARNESS_AUDIT_INVOCATION_ID";
+export const PERMISSION_AUDIT_RUN_ENV = "PI_HARNESS_AUDIT_RUN_ID";
+export const PERMISSION_AUDIT_UNAVAILABLE_REASON =
+  "permission-audit: decision record could not be persisted; command blocked";
+export const PERMISSION_AUDIT_RECORD_TOO_LARGE_REASON =
+  "permission-audit: decision record exceeded 1 MiB; command blocked";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const CORRELATION_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/;
+
+interface PermissionAuditContextUpdate {
+  readonly project?: PermissionProjectContext;
+  readonly leadingNavigation?: PermissionLeadingNavigation;
+  readonly gitCwd?: PermissionLeadingNavigation;
+}
+
+interface PermissionAuditTransaction {
+  readonly sessionId: string;
+  readonly toolCallId: string;
+  readonly command: ReturnType<typeof buildPermissionCommand>;
+  readonly cwd?: string;
+  readonly task: PermissionTaskAuditContext;
+  readonly runEvidence?: ReturnType<typeof derivePermissionRunEvidence>;
+  readonly stages: PermissionAuditStage[];
+  project?: PermissionProjectContext;
+  leadingNavigation?: PermissionLeadingNavigation;
+  gitCwd?: PermissionLeadingNavigation;
+  finalization?: Promise<PermissionAuditFinalizeResult>;
+  context: CtxLike;
+}
+
+type PermissionAuditFinalizeResult =
+  | "persisted"
+  | "record-too-large"
+  | "unavailable";
+
+export interface PermissionAuditIntegration {
+  readonly lineageId: string;
+  addStage(toolCallId: string, stage: PermissionAuditStage): void;
+  updateContext(toolCallId: string, update: PermissionAuditContextUpdate): void;
+  finalizeBlock(toolCallId: string, reasonCode: string): Promise<boolean>;
+  registerTail(
+    pi: PiLike,
+    blockToolCall: (reason: string) => ToolCallBlockResult,
+  ): void;
+  childEnvironment(
+    ctx: CtxLike,
+    childInvocationId: string | undefined,
+    childRunId: string | undefined,
+  ): Record<string, string>;
+}
+
+interface SetupPermissionAuditOptions {
+  readonly taskTracker: PermissionTaskTracker;
+  readonly writer?: PermissionAuditWriter;
+  readonly env?: Record<string, string | undefined>;
+  readonly randomUUID?: () => string;
+  readonly onDisplayedConfirmation?: () => void;
+}
+
+const sessionId = (ctx: CtxLike): string => {
+  try {
+    const value = ctx.sessionManager?.getSessionId?.();
+    return typeof value === "string" && value !== ""
+      ? value
+      : "unknown-session";
+  } catch {
+    return "unknown-session";
+  }
+};
+
+const taskContext = (
+  tracker: PermissionTaskTracker,
+): PermissionTaskAuditContext => {
+  const tracked = tracker.current();
+  return tracked.correlation === "task"
+    ? { correlation: "task", task: tracked.task }
+    : { correlation: tracked.correlation };
+};
+
+const projectContext = (
+  project: PermissionProjectContext | undefined,
+): PermissionProjectAuditContext | undefined => {
+  if (project === undefined) return undefined;
+  if (project.kind === "git") {
+    return {
+      kind: "git",
+      ...(project.name === undefined ? {} : { name: project.name }),
+      cwd: project.cwd,
+      activeWorktree: project.activeWorktree,
+      navigableRoots: project.navigableRoots,
+      worktrees: project.worktrees,
+      fingerprint: project.fingerprint,
+    };
+  }
+  if (project.kind === "non-git") {
+    return {
+      kind: "non-git",
+      cwd: project.cwd,
+      fingerprint: project.fingerprint,
+    };
+  }
+  return {
+    kind: "unavailable",
+    ...(project.cwd === undefined ? {} : { cwd: project.cwd }),
+    ...(project.reason === undefined ? {} : { reason: project.reason }),
+    fingerprint: project.fingerprint,
+  };
+};
+
+const validCorrelationId = (value: string | undefined): string | undefined =>
+  value !== undefined && CORRELATION_ID_PATTERN.test(value) ? value : undefined;
+
+const lineageFrom = (
+  env: Record<string, string | undefined>,
+  createId: () => string,
+) => {
+  const inherited = env[PERMISSION_AUDIT_LINEAGE_ENV];
+  const lineageId =
+    inherited !== undefined && UUID_PATTERN.test(inherited)
+      ? inherited
+      : createId();
+  return {
+    lineageId,
+    source:
+      inherited !== undefined && UUID_PATTERN.test(inherited)
+        ? ("harness-env" as const)
+        : ("generated" as const),
+    parentSessionId: validCorrelationId(
+      env[PERMISSION_AUDIT_PARENT_SESSION_ENV],
+    ),
+    childInvocationId: validCorrelationId(env[PERMISSION_AUDIT_INVOCATION_ENV]),
+    childRunId: validCorrelationId(env[PERMISSION_AUDIT_RUN_ENV]),
+  };
+};
+
+const currentRunEvidence = (
+  ctx: CtxLike,
+  toolCallId: string,
+): ReturnType<typeof derivePermissionRunEvidence> => {
+  try {
+    return derivePermissionRunEvidence(
+      ctx.sessionManager?.getBranch() ?? [],
+      toolCallId,
+    );
+  } catch {
+    return undefined;
+  }
+};
+
+export const setupPermissionAudit = (
+  pi: PiLike,
+  config: HarnessConfig,
+  options: SetupPermissionAuditOptions,
+): PermissionAuditIntegration => {
+  const createId = options.randomUUID ?? randomUUID;
+  let lineage: ReturnType<typeof lineageFrom>;
+  try {
+    lineage = lineageFrom(options.env ?? process.env, createId);
+  } catch {
+    // Keep the permission chain installed even if entropy is unavailable. The
+    // writer will independently fail and the tail will block the command.
+    lineage = {
+      lineageId: "00000000-0000-4000-8000-000000000000",
+      source: "generated",
+      parentSessionId: undefined,
+      childInvocationId: undefined,
+      childRunId: undefined,
+    };
+  }
+  let writer: PermissionAuditWriter;
+  if (options.writer !== undefined) {
+    writer = options.writer;
+  } else {
+    try {
+      writer = createPermissionAuditWriter(config.paths.logDir, {
+        isChild: config.isChild,
+      });
+    } catch (error) {
+      const unavailable =
+        error instanceof Error ? error : new Error(String(error));
+      writer = {
+        writerInstanceId: "unavailable",
+        append: () => Promise.reject(unavailable),
+        close: () => Promise.resolve(),
+      };
+    }
+  }
+  const transactions = new Map<string, PermissionAuditTransaction>();
+  const completedFinalizations = new Map<
+    string,
+    PermissionAuditFinalizeResult
+  >();
+  let unavailableWarningShown = false;
+  let shuttingDown = false;
+
+  const warnUnavailable = (ctx: CtxLike): void => {
+    if (!ctx.hasUI || unavailableWarningShown) return;
+    unavailableWarningShown = true;
+    ctx.ui.notify(
+      "Permission audit log is unavailable; Bash commands are blocked until logging is restored.",
+      "error",
+    );
+  };
+
+  const rememberFinalization = (
+    toolCallId: string,
+    result: PermissionAuditFinalizeResult,
+  ): PermissionAuditFinalizeResult => {
+    completedFinalizations.set(toolCallId, result);
+    if (completedFinalizations.size > 4096) {
+      const oldest = completedFinalizations.keys().next().value;
+      if (oldest !== undefined) completedFinalizations.delete(oldest);
+    }
+    return result;
+  };
+
+  const begin = (event: ToolCallEvent, ctx: CtxLike): void => {
+    if (
+      event.toolName !== "bash" ||
+      transactions.has(event.toolCallId) ||
+      completedFinalizations.has(event.toolCallId)
+    ) {
+      return;
+    }
+    const command = event.input?.command;
+    const runEvidence = currentRunEvidence(ctx, event.toolCallId);
+    transactions.set(event.toolCallId, {
+      sessionId: sessionId(ctx),
+      toolCallId: event.toolCallId,
+      command: buildPermissionCommand(command),
+      ...(ctx.cwd === undefined ? {} : { cwd: ctx.cwd }),
+      task: taskContext(options.taskTracker),
+      ...(runEvidence === undefined ? {} : { runEvidence }),
+      stages: [],
+      context: ctx,
+    });
+  };
+
+  const finalize = async (
+    toolCallId: string,
+    boundaryDisposition: "release" | "block",
+    terminalReasonCode: string,
+  ): Promise<PermissionAuditFinalizeResult> => {
+    const transaction = transactions.get(toolCallId);
+    if (transaction === undefined) {
+      return completedFinalizations.get(toolCallId) ?? "unavailable";
+    }
+    if (transaction.finalization !== undefined) {
+      return transaction.finalization;
+    }
+    const finalization = (async (): Promise<PermissionAuditFinalizeResult> => {
+      try {
+        const project = projectContext(transaction.project);
+        const record = await writer.append((identity) =>
+          fitPermissionDecisionRecord({
+            ...identity,
+            pid: process.pid,
+            isChild: config.isChild,
+            lineage,
+            sessionId: transaction.sessionId,
+            toolCallId: transaction.toolCallId,
+            command: transaction.command,
+            ...(transaction.cwd === undefined ? {} : { cwd: transaction.cwd }),
+            task: transaction.task,
+            ...(transaction.runEvidence === undefined
+              ? {}
+              : { runEvidence: transaction.runEvidence }),
+            ...(project === undefined ? {} : { project }),
+            ...(transaction.leadingNavigation === undefined
+              ? {}
+              : { leadingNavigation: transaction.leadingNavigation }),
+            ...(transaction.gitCwd === undefined
+              ? {}
+              : { gitCwd: transaction.gitCwd }),
+            stages: transaction.stages,
+            boundaryDisposition,
+            terminalReasonCode,
+          }),
+        );
+        transactions.delete(toolCallId);
+        return rememberFinalization(
+          toolCallId,
+          record.terminalReasonCode === "record-too-large"
+            ? "record-too-large"
+            : "persisted",
+        );
+      } catch {
+        transactions.delete(toolCallId);
+        warnUnavailable(transaction.context);
+        return rememberFinalization(toolCallId, "unavailable");
+      }
+    })();
+    transaction.finalization = finalization;
+    return finalization;
+  };
+
+  pi.on("session_start", () => {
+    completedFinalizations.clear();
+    unavailableWarningShown = false;
+  });
+
+  pi.on("tool_call", (event, ctx) => {
+    if (shuttingDown || event.toolName !== "bash") return undefined;
+    begin(event, ctx);
+    return undefined;
+  });
+
+  return {
+    lineageId: lineage.lineageId,
+    addStage(toolCallId, stage) {
+      const transaction = transactions.get(toolCallId);
+      if (transaction === undefined || transaction.finalization !== undefined) {
+        return;
+      }
+      transaction.stages.push(stage);
+      if (stage.type === "confirmation" && stage.status !== "not-shown") {
+        try {
+          options.onDisplayedConfirmation?.();
+        } catch {
+          // Reminder bookkeeping must never alter the permission decision.
+        }
+      }
+    },
+    updateContext(toolCallId, update) {
+      const transaction = transactions.get(toolCallId);
+      if (transaction === undefined || transaction.finalization !== undefined) {
+        return;
+      }
+      if (update.project !== undefined) transaction.project = update.project;
+      if (update.leadingNavigation !== undefined) {
+        transaction.leadingNavigation = update.leadingNavigation;
+      }
+      if (update.gitCwd !== undefined) transaction.gitCwd = update.gitCwd;
+    },
+    async finalizeBlock(toolCallId, reasonCode) {
+      return (
+        (await finalize(toolCallId, "block", reasonCode)) !== "unavailable"
+      );
+    },
+    registerTail(tailPi, blockToolCall) {
+      tailPi.on("tool_call", async (event) => {
+        if (event.toolName !== "bash") return undefined;
+        const result = await finalize(
+          event.toolCallId,
+          "release",
+          "permission-chain-released",
+        );
+        if (result === "persisted") return undefined;
+        return blockToolCall(
+          result === "record-too-large"
+            ? PERMISSION_AUDIT_RECORD_TOO_LARGE_REASON
+            : PERMISSION_AUDIT_UNAVAILABLE_REASON,
+        );
+      });
+      tailPi.on("session_shutdown", async () => {
+        shuttingDown = true;
+        for (const [toolCallId, transaction] of transactions) {
+          if (transaction.finalization !== undefined) continue;
+          transaction.stages.push({
+            type: "error",
+            component: "permission-audit",
+            phase: "session-shutdown",
+            verdict: "error",
+            reasonCode: "session-shutdown",
+          });
+          await finalize(toolCallId, "block", "session-shutdown");
+        }
+        await writer.close().catch(() => {});
+      });
+    },
+    childEnvironment(ctx, childInvocationId, childRunId) {
+      return {
+        [PERMISSION_AUDIT_LINEAGE_ENV]: lineage.lineageId,
+        [PERMISSION_AUDIT_PARENT_SESSION_ENV]: sessionId(ctx),
+        ...(validCorrelationId(childInvocationId) === undefined
+          ? {}
+          : {
+              [PERMISSION_AUDIT_INVOCATION_ENV]: childInvocationId as string,
+            }),
+        ...(validCorrelationId(childRunId) === undefined
+          ? {}
+          : { [PERMISSION_AUDIT_RUN_ENV]: childRunId as string }),
+      };
+    },
+  };
+};

--- a/pi/extensions/pi-harness/features/permission-audit/model.ts
+++ b/pi/extensions/pi-harness/features/permission-audit/model.ts
@@ -1,0 +1,351 @@
+import { createHash, randomUUID } from "node:crypto";
+
+export const PERMISSION_AUDIT_SCHEMA = "pi-harness/bash-permission";
+export const PERMISSION_AUDIT_VERSION = 1;
+export const MAX_PERMISSION_AUDIT_RECORD_BYTES = 1024 * 1024;
+
+export type PermissionAuditDecision = "allow" | "ask" | "deny";
+export type PermissionBoundaryDisposition = "release" | "block";
+export type PermissionStageVerdict =
+  | "allow"
+  | "ask"
+  | "deny"
+  | "continue"
+  | "error";
+
+export interface PermissionCommandValue {
+  readonly kind: "command";
+  readonly text: string;
+  readonly sha256: string;
+  readonly bytes: number;
+}
+
+export interface MalformedPermissionCommandValue {
+  readonly kind: "malformed";
+  readonly valueType: string;
+  readonly sha256: string;
+  readonly bytes: number;
+}
+
+export interface OmittedPermissionCommandValue {
+  readonly kind: "omitted";
+  readonly reason: "record-too-large";
+  readonly sha256: string;
+  readonly bytes: number;
+}
+
+export type PermissionCommandRecord =
+  | PermissionCommandValue
+  | MalformedPermissionCommandValue
+  | OmittedPermissionCommandValue;
+
+export interface PermissionTaskAuditContext {
+  readonly correlation: "task" | "none" | "uncorrelated";
+  readonly task?: {
+    readonly text: string;
+    readonly source: string;
+    readonly fingerprint?: string;
+  };
+}
+
+export interface PermissionRunAuditContext {
+  readonly assistantText?: string;
+  readonly priorToolResults: readonly {
+    readonly toolName: string;
+    readonly status: "ok" | "error" | "unknown";
+  }[];
+  readonly fingerprint: string;
+}
+
+export interface PermissionProjectAuditContext {
+  readonly kind: "git" | "non-git" | "unavailable";
+  readonly name?: string;
+  readonly cwd?: string;
+  readonly activeWorktree?: string;
+  readonly navigableRoots?: readonly string[];
+  readonly worktrees?: readonly string[];
+  readonly reason?: string;
+  readonly fingerprint?: string;
+}
+
+export interface PermissionNavigationAuditContext {
+  readonly scope: "listed-worktree" | "outside-listed-worktrees" | "unverified";
+  readonly sameRepository: boolean;
+}
+
+export interface DeterministicPermissionStage {
+  readonly type: "deterministic";
+  readonly phase: string;
+  readonly verdict:
+    | Exclude<PermissionStageVerdict, "continue" | "error">
+    | "continue";
+  readonly basis: string;
+  readonly reasonCode: string;
+  readonly reason?: string;
+  readonly ruleSource?: string;
+  readonly grantedBySkill?: boolean;
+}
+
+export interface ScopePermissionStage {
+  readonly type: "scope";
+  readonly phase: string;
+  readonly verdict: "allow" | "ask" | "deny" | "error";
+  readonly reasonCode: string;
+  readonly reason?: string;
+  readonly project?: PermissionProjectAuditContext;
+  readonly navigation?: PermissionNavigationAuditContext;
+}
+
+export interface JudgePermissionStage {
+  readonly type: "judge";
+  readonly phase: string;
+  readonly verdict: "allow" | "ask" | "error";
+  readonly reasonCode: string;
+  readonly reason?: string;
+  readonly outcome: string;
+  readonly source?: "live" | "cache";
+  readonly model?: string;
+  readonly expectedDigest?: string;
+  readonly policyVersion?: string;
+  readonly gates?: {
+    readonly safety: "ALLOW" | "ASK";
+    readonly relevance: "ALLOW" | "ASK";
+  };
+}
+
+export interface HookPermissionStage {
+  readonly type: "hook";
+  readonly phase: "preflight" | "remaining";
+  readonly hookId: string;
+  readonly verdict: "continue" | "ask" | "deny" | "error";
+  readonly reasonCode: string;
+  readonly reason?: string;
+}
+
+export type PermissionConfirmationStatus =
+  | "accepted"
+  | "rejected"
+  | "not-shown"
+  | "aborted";
+
+export interface ConfirmationPermissionStage {
+  readonly type: "confirmation";
+  readonly phase: string;
+  readonly challengeSource: string;
+  readonly status: PermissionConfirmationStatus;
+  readonly reasonCode: string;
+  readonly reason?: string;
+}
+
+export interface ErrorPermissionStage {
+  readonly type: "error";
+  readonly component: string;
+  readonly phase: string;
+  readonly verdict: "error";
+  readonly reasonCode: string;
+  readonly message?: string;
+}
+
+export type PermissionAuditStage =
+  | DeterministicPermissionStage
+  | ScopePermissionStage
+  | JudgePermissionStage
+  | HookPermissionStage
+  | ConfirmationPermissionStage
+  | ErrorPermissionStage;
+
+export interface PermissionAuditLineage {
+  readonly lineageId: string;
+  readonly source: "generated" | "harness-env";
+  readonly parentSessionId?: string;
+  readonly childInvocationId?: string;
+  readonly childRunId?: string;
+}
+
+export interface PermissionDecisionRecordV1 {
+  readonly schema: typeof PERMISSION_AUDIT_SCHEMA;
+  readonly version: typeof PERMISSION_AUDIT_VERSION;
+  readonly timestamp: string;
+  readonly decisionId: string;
+  readonly writerInstanceId: string;
+  readonly sequence: number;
+  readonly process: {
+    readonly pid: number;
+    readonly isChild: boolean;
+    readonly lineage: PermissionAuditLineage;
+  };
+  readonly sessionId: string;
+  readonly toolCallId: string;
+  readonly command: PermissionCommandRecord;
+  readonly cwd?: string;
+  readonly task: PermissionTaskAuditContext;
+  readonly runEvidence?: PermissionRunAuditContext;
+  readonly project?: PermissionProjectAuditContext;
+  readonly leadingNavigation?: PermissionNavigationAuditContext;
+  readonly gitCwd?: PermissionNavigationAuditContext;
+  readonly stages: readonly PermissionAuditStage[];
+  readonly effectiveDecision: PermissionAuditDecision;
+  readonly boundaryDisposition: PermissionBoundaryDisposition;
+  readonly terminalReasonCode: string;
+}
+
+export interface PermissionDecisionRecordInput {
+  readonly timestamp?: string;
+  readonly decisionId?: string;
+  readonly writerInstanceId: string;
+  readonly sequence: number;
+  readonly pid: number;
+  readonly isChild: boolean;
+  readonly lineage: PermissionAuditLineage;
+  readonly sessionId: string;
+  readonly toolCallId: string;
+  readonly command: PermissionCommandRecord;
+  readonly cwd?: string;
+  readonly task: PermissionTaskAuditContext;
+  readonly runEvidence?: PermissionRunAuditContext;
+  readonly project?: PermissionProjectAuditContext;
+  readonly leadingNavigation?: PermissionNavigationAuditContext;
+  readonly gitCwd?: PermissionNavigationAuditContext;
+  readonly stages: readonly PermissionAuditStage[];
+  readonly boundaryDisposition: PermissionBoundaryDisposition;
+  readonly terminalReasonCode: string;
+}
+
+const serializedValue = (value: unknown): string => {
+  try {
+    const serialized = JSON.stringify(value);
+    return serialized === undefined ? String(value) : serialized;
+  } catch {
+    return Object.prototype.toString.call(value);
+  }
+};
+
+const sha256 = (value: string): string =>
+  createHash("sha256").update(value).digest("hex");
+
+export const buildPermissionCommand = (
+  value: unknown,
+): PermissionCommandRecord => {
+  if (typeof value === "string") {
+    return {
+      kind: "command",
+      text: value,
+      sha256: sha256(value),
+      bytes: Buffer.byteLength(value, "utf8"),
+    };
+  }
+  const serialized = serializedValue(value);
+  return {
+    kind: "malformed",
+    valueType: value === null ? "null" : typeof value,
+    sha256: sha256(serialized),
+    bytes: Buffer.byteLength(serialized, "utf8"),
+  };
+};
+
+const stageBlocks = (stage: PermissionAuditStage): boolean => {
+  if (stage.type === "confirmation") {
+    return stage.status !== "accepted";
+  }
+  if (stage.type === "error") return true;
+  return stage.verdict === "deny" || stage.verdict === "error";
+};
+
+export const derivePermissionDecision = (
+  stages: readonly PermissionAuditStage[],
+): PermissionAuditDecision => {
+  if (
+    stages.some((stage) => stage.type !== "confirmation" && stageBlocks(stage))
+  ) {
+    return "deny";
+  }
+  if (stages.some((stage) => stage.type === "confirmation")) return "ask";
+  return "allow";
+};
+
+export const buildPermissionDecisionRecord = (
+  input: PermissionDecisionRecordInput,
+): PermissionDecisionRecordV1 => ({
+  schema: PERMISSION_AUDIT_SCHEMA,
+  version: PERMISSION_AUDIT_VERSION,
+  timestamp: input.timestamp ?? new Date().toISOString(),
+  decisionId: input.decisionId ?? randomUUID(),
+  writerInstanceId: input.writerInstanceId,
+  sequence: input.sequence,
+  process: {
+    pid: input.pid,
+    isChild: input.isChild,
+    lineage: input.lineage,
+  },
+  sessionId: input.sessionId,
+  toolCallId: input.toolCallId,
+  command: input.command,
+  ...(input.cwd === undefined ? {} : { cwd: input.cwd }),
+  task: input.task,
+  ...(input.runEvidence === undefined
+    ? {}
+    : { runEvidence: input.runEvidence }),
+  ...(input.project === undefined ? {} : { project: input.project }),
+  ...(input.leadingNavigation === undefined
+    ? {}
+    : { leadingNavigation: input.leadingNavigation }),
+  ...(input.gitCwd === undefined ? {} : { gitCwd: input.gitCwd }),
+  stages: [...input.stages],
+  effectiveDecision: derivePermissionDecision(input.stages),
+  boundaryDisposition: input.boundaryDisposition,
+  terminalReasonCode: input.terminalReasonCode,
+});
+
+export const permissionRecordBytes = (
+  record: PermissionDecisionRecordV1,
+): number => Buffer.byteLength(JSON.stringify(record), "utf8");
+
+const compactIdentifier = (value: string): string => {
+  const bytes = Buffer.byteLength(value, "utf8");
+  return bytes <= 1024 ? value : `sha256:${sha256(value)}:bytes:${bytes}`;
+};
+
+export const buildOversizedPermissionRecord = (
+  input: PermissionDecisionRecordInput,
+): PermissionDecisionRecordV1 => {
+  const command = input.command;
+  const compactCommand: PermissionCommandRecord = {
+    kind: "omitted",
+    reason: "record-too-large",
+    sha256: command.sha256,
+    bytes: command.bytes,
+  };
+  return buildPermissionDecisionRecord({
+    writerInstanceId: input.writerInstanceId,
+    sequence: input.sequence,
+    pid: input.pid,
+    isChild: input.isChild,
+    lineage: input.lineage,
+    sessionId: compactIdentifier(input.sessionId),
+    toolCallId: compactIdentifier(input.toolCallId),
+    command: compactCommand,
+    task: { correlation: input.task.correlation },
+    stages: [
+      {
+        type: "error",
+        component: "permission-audit",
+        phase: "serialize",
+        verdict: "error",
+        reasonCode: "record-too-large",
+      },
+    ],
+    boundaryDisposition: "block",
+    terminalReasonCode: "record-too-large",
+    ...(input.timestamp === undefined ? {} : { timestamp: input.timestamp }),
+    ...(input.decisionId === undefined ? {} : { decisionId: input.decisionId }),
+  });
+};
+
+export const fitPermissionDecisionRecord = (
+  input: PermissionDecisionRecordInput,
+): PermissionDecisionRecordV1 => {
+  const record = buildPermissionDecisionRecord(input);
+  return permissionRecordBytes(record) <= MAX_PERMISSION_AUDIT_RECORD_BYTES
+    ? record
+    : buildOversizedPermissionRecord(input);
+};

--- a/pi/extensions/pi-harness/features/permission-audit/writer.ts
+++ b/pi/extensions/pi-harness/features/permission-audit/writer.ts
@@ -1,0 +1,407 @@
+import { constants } from "node:fs";
+import {
+  lstat,
+  mkdir,
+  open,
+  readdir,
+  rm,
+  type FileHandle,
+  type FileHandle as NodeFileHandle,
+} from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
+import {
+  MAX_PERMISSION_AUDIT_RECORD_BYTES,
+  type PermissionDecisionRecordV1,
+} from "./model";
+
+const DEFAULT_RETENTION_DAYS = 90;
+const WRITER_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const PERMISSION_LOG_PATTERN =
+  /^permission-(\d{4})-(\d{2})-(\d{2})-([0-9a-f-]{36})\.jsonl$/i;
+
+interface FileStatsLike {
+  readonly dev: number | bigint;
+  readonly ino: number | bigint;
+  readonly mode: number;
+  readonly nlink: number;
+  readonly uid: number;
+  isDirectory(): boolean;
+  isFile(): boolean;
+  isSymbolicLink?(): boolean;
+}
+
+export interface PermissionAuditFileHandle {
+  stat(): Promise<FileStatsLike>;
+  chmod(mode: number): Promise<void>;
+  write(
+    buffer: Uint8Array,
+    offset: number,
+    length: number,
+    position: number,
+  ): Promise<{ bytesWritten: number }>;
+  truncate(length: number): Promise<void>;
+  close(): Promise<void>;
+}
+
+export interface PermissionAuditWriterDependencies {
+  readonly mkdir: typeof mkdir;
+  readonly open: (
+    path: string,
+    flags: number,
+    mode?: number,
+  ) => Promise<PermissionAuditFileHandle>;
+  readonly readdir: typeof readdir;
+  readonly lstat: typeof lstat;
+  readonly rm: typeof rm;
+  readonly now: () => Date;
+  readonly randomUUID: () => string;
+  readonly getuid?: () => number;
+  readonly constants: Pick<
+    typeof constants,
+    | "O_RDONLY"
+    | "O_WRONLY"
+    | "O_CREAT"
+    | "O_EXCL"
+    | "O_DIRECTORY"
+    | "O_NOFOLLOW"
+  >;
+}
+
+const defaultDependencies = (): PermissionAuditWriterDependencies => ({
+  mkdir,
+  open: (path, flags, mode) =>
+    open(
+      path,
+      flags,
+      mode,
+    ) as Promise<NodeFileHandle> as Promise<PermissionAuditFileHandle>,
+  readdir,
+  lstat,
+  rm,
+  now: () => new Date(),
+  randomUUID,
+  ...(typeof process.getuid === "function" ? { getuid: process.getuid } : {}),
+  constants,
+});
+
+export interface PermissionAuditAppendIdentity {
+  readonly writerInstanceId: string;
+  readonly sequence: number;
+  readonly timestamp: string;
+}
+
+export type PermissionAuditRecordFactory = (
+  identity: PermissionAuditAppendIdentity,
+) => PermissionDecisionRecordV1;
+
+export interface PermissionAuditWriter {
+  readonly writerInstanceId: string;
+  append(
+    build: PermissionAuditRecordFactory,
+  ): Promise<PermissionDecisionRecordV1>;
+  close(): Promise<void>;
+}
+
+export interface PermissionAuditWriterOptions {
+  readonly isChild: boolean;
+  readonly retentionDays?: number;
+  readonly writerInstanceId?: string;
+  readonly dependencies?: Partial<PermissionAuditWriterDependencies>;
+}
+
+const exactMode = (stats: FileStatsLike): number => stats.mode & 0o777;
+
+const sameIdentity = (left: FileStatsLike, right: FileStatsLike): boolean =>
+  String(left.dev) === String(right.dev) &&
+  String(left.ino) === String(right.ino);
+
+const assertOwner = (
+  stats: FileStatsLike,
+  getuid: (() => number) | undefined,
+  target: string,
+): void => {
+  if (getuid !== undefined && stats.uid !== getuid()) {
+    throw new Error(`${target} is not owned by the current user`);
+  }
+};
+
+const utcDay = (date: Date): string => date.toISOString().slice(0, 10);
+
+const validDatedName = (name: string): { readonly day: string } | undefined => {
+  const match = PERMISSION_LOG_PATTERN.exec(name);
+  if (match === null || !WRITER_ID_PATTERN.test(match[4] ?? "")) {
+    return undefined;
+  }
+  const text = `${match[1]}-${match[2]}-${match[3]}`;
+  const stamp = Date.parse(`${text}T00:00:00.000Z`);
+  if (
+    !Number.isFinite(stamp) ||
+    new Date(stamp).toISOString().slice(0, 10) !== text
+  ) {
+    return undefined;
+  }
+  return { day: text };
+};
+
+const writeFully = async (
+  handle: PermissionAuditFileHandle,
+  data: Uint8Array,
+  start: number,
+): Promise<void> => {
+  let written = 0;
+  while (written < data.byteLength) {
+    const result = await handle.write(
+      data,
+      written,
+      data.byteLength - written,
+      start + written,
+    );
+    if (
+      !Number.isSafeInteger(result.bytesWritten) ||
+      result.bytesWritten <= 0
+    ) {
+      throw new Error("permission audit write made no progress");
+    }
+    written += result.bytesWritten;
+  }
+};
+
+export const createPermissionAuditWriter = (
+  logDir: string,
+  options: PermissionAuditWriterOptions,
+): PermissionAuditWriter => {
+  const defaults = defaultDependencies();
+  const deps: PermissionAuditWriterDependencies = {
+    ...defaults,
+    ...options.dependencies,
+    constants: {
+      ...defaults.constants,
+      ...options.dependencies?.constants,
+    },
+  };
+  const retentionDays = options.retentionDays ?? DEFAULT_RETENTION_DAYS;
+  if (!Number.isInteger(retentionDays) || retentionDays < 1) {
+    throw new Error(
+      "permission audit retentionDays must be a positive integer",
+    );
+  }
+  const writerInstanceId = options.writerInstanceId ?? deps.randomUUID();
+  if (!WRITER_ID_PATTERN.test(writerInstanceId)) {
+    throw new Error("permission audit writer id must be a UUID");
+  }
+  if (
+    typeof deps.constants.O_NOFOLLOW !== "number" ||
+    deps.constants.O_NOFOLLOW === 0 ||
+    typeof deps.constants.O_DIRECTORY !== "number" ||
+    deps.constants.O_DIRECTORY === 0
+  ) {
+    throw new Error("permission audit requires O_NOFOLLOW and O_DIRECTORY");
+  }
+
+  let sequence = 0;
+  let activeDay: string | undefined;
+  let activeHandle: PermissionAuditFileHandle | undefined;
+  let poisoned = false;
+  let closing = false;
+  let closed = false;
+  let retentionDay: string | undefined;
+  let operation: Promise<void> = Promise.resolve();
+
+  const openVerifiedDirectory = async (): Promise<{
+    handle: PermissionAuditFileHandle;
+    stats: FileStatsLike;
+  }> => {
+    const handle = await deps.open(
+      logDir,
+      deps.constants.O_RDONLY |
+        deps.constants.O_DIRECTORY |
+        deps.constants.O_NOFOLLOW,
+    );
+    try {
+      const stats = await handle.stat();
+      if (!stats.isDirectory())
+        throw new Error("permission audit path is not a directory");
+      assertOwner(stats, deps.getuid, "permission audit directory");
+      if (exactMode(stats) !== 0o700) await handle.chmod(0o700);
+      return { handle, stats };
+    } catch (error) {
+      await handle.close().catch(() => {});
+      throw error;
+    }
+  };
+
+  const ensureDirectory = async (): Promise<FileStatsLike> => {
+    await deps.mkdir(logDir, { recursive: true, mode: 0o700 });
+    const verified = await openVerifiedDirectory();
+    await verified.handle.close();
+    return verified.stats;
+  };
+
+  const applyRetention = async (day: string, now: Date): Promise<void> => {
+    if (options.isChild || retentionDay === day) return;
+    retentionDay = day;
+    let names: string[];
+    try {
+      names = await deps.readdir(logDir);
+    } catch {
+      return;
+    }
+    // Filenames carry only a UTC date, not a record timestamp. Keep the whole
+    // cutoff day so a file created late that day never expires early.
+    const cutoffDay = utcDay(
+      new Date(now.getTime() - retentionDays * 24 * 60 * 60 * 1000),
+    );
+    for (const name of names) {
+      const dated = validDatedName(name);
+      if (dated === undefined || dated.day >= cutoffDay) continue;
+      const path = join(logDir, name);
+      try {
+        const stats = (await deps.lstat(path)) as unknown as FileStatsLike;
+        if (
+          !stats.isFile() ||
+          stats.isSymbolicLink?.() === true ||
+          stats.nlink !== 1 ||
+          exactMode(stats) !== 0o600
+        ) {
+          continue;
+        }
+        assertOwner(stats, deps.getuid, "permission audit retention file");
+        await deps.rm(path);
+      } catch {
+        // Retention is best-effort and never changes the current decision.
+      }
+    }
+  };
+
+  const closeActive = async (): Promise<void> => {
+    const handle = activeHandle;
+    activeHandle = undefined;
+    activeDay = undefined;
+    if (handle !== undefined) await handle.close();
+  };
+
+  const openForDay = async (
+    day: string,
+    now: Date,
+  ): Promise<PermissionAuditFileHandle> => {
+    if (activeHandle !== undefined && activeDay === day) return activeHandle;
+    await closeActive();
+    const directoryBefore = await ensureDirectory();
+    await applyRetention(day, now);
+    const path = join(logDir, `permission-${day}-${writerInstanceId}.jsonl`);
+    const handle = await deps.open(
+      path,
+      deps.constants.O_WRONLY |
+        deps.constants.O_CREAT |
+        deps.constants.O_EXCL |
+        deps.constants.O_NOFOLLOW,
+      0o600,
+    );
+    try {
+      const stats = await handle.stat();
+      if (!stats.isFile() || stats.nlink !== 1) {
+        throw new Error("permission audit file is not a private regular file");
+      }
+      assertOwner(stats, deps.getuid, "permission audit file");
+      if (exactMode(stats) !== 0o600) await handle.chmod(0o600);
+      const directoryAfter = await openVerifiedDirectory();
+      try {
+        if (!sameIdentity(directoryBefore, directoryAfter.stats)) {
+          throw new Error("permission audit directory identity changed");
+        }
+      } finally {
+        await directoryAfter.handle.close();
+      }
+      activeDay = day;
+      activeHandle = handle;
+      return handle;
+    } catch (error) {
+      await handle.close().catch(() => {});
+      throw error;
+    }
+  };
+
+  const appendOne = async (
+    build: PermissionAuditRecordFactory,
+  ): Promise<PermissionDecisionRecordV1> => {
+    if (closed) throw new Error("permission audit writer is closed");
+    if (poisoned) throw new Error("permission audit writer is poisoned");
+    const now = deps.now();
+    const day = utcDay(now);
+    const identity = {
+      writerInstanceId,
+      sequence: ++sequence,
+      timestamp: now.toISOString(),
+    };
+    const record = build(identity);
+    if (
+      record.writerInstanceId !== writerInstanceId ||
+      record.sequence !== identity.sequence ||
+      record.timestamp !== identity.timestamp
+    ) {
+      throw new Error("permission audit record identity mismatch");
+    }
+    const line = `${JSON.stringify(record)}\n`;
+    if (
+      Buffer.byteLength(line, "utf8") >
+      MAX_PERMISSION_AUDIT_RECORD_BYTES + 1
+    ) {
+      throw new Error("permission audit record exceeds the size limit");
+    }
+    const handle = await openForDay(day, now);
+    const before = await handle.stat();
+    const offset = Number(
+      (before as FileStatsLike & { size?: number | bigint }).size ?? 0,
+    );
+    if (!Number.isSafeInteger(offset) || offset < 0) {
+      throw new Error("permission audit file size is invalid");
+    }
+    try {
+      await writeFully(handle, Buffer.from(line), offset);
+      return record;
+    } catch (error) {
+      try {
+        await handle.truncate(offset);
+      } catch {
+        poisoned = true;
+        await closeActive().catch(() => {});
+      }
+      throw error;
+    }
+  };
+
+  return {
+    writerInstanceId,
+    append(build) {
+      if (closing || closed) {
+        return Promise.reject(new Error("permission audit writer is closing"));
+      }
+      let result: PermissionDecisionRecordV1 | undefined;
+      const queued = operation.then(async () => {
+        result = await appendOne(build);
+      });
+      operation = queued.catch(() => {});
+      return queued.then(() => {
+        if (result === undefined)
+          throw new Error("permission audit append produced no record");
+        return result;
+      });
+    },
+    async close() {
+      if (closed) return;
+      closing = true;
+      await operation;
+      closed = true;
+      await closeActive();
+    },
+  };
+};
+
+export const permissionAuditLogFileName = (
+  date: Date,
+  writerInstanceId: string,
+): string => `permission-${utcDay(date)}-${writerInstanceId}.jsonl`;
+
+export { DEFAULT_RETENTION_DAYS, PERMISSION_LOG_PATTERN };

--- a/pi/extensions/pi-harness/features/permission-policy/index.ts
+++ b/pi/extensions/pi-harness/features/permission-policy/index.ts
@@ -12,10 +12,11 @@ import {
   type PermissionLeadingNavigation,
   type PermissionProjectContext,
   type PermissionRunEvidence,
+  type PermissionTaskTracker,
 } from "./context";
 import { createPermissionJudge, type JudgeOutcome } from "./judge";
 import {
-  evaluateCommand,
+  evaluateCommandWithAudit,
   gitReadCwdTarget,
   hasProjectSensitiveMutation,
   hasUnverifiedProjectMutationNavigation,
@@ -32,6 +33,11 @@ import {
   type SkillInvocation,
 } from "./skill-allow";
 import { leadingTrustedCdTarget } from "./trusted-cd";
+import {
+  PERMISSION_AUDIT_UNAVAILABLE_REASON,
+  type PermissionAuditIntegration,
+} from "../permission-audit/index";
+import type { AuditedVerdict } from "./rules";
 
 const readPermissionRules = (): string | undefined => {
   try {
@@ -141,6 +147,8 @@ interface SetupPermissionPolicyOptions {
     signal?: AbortSignal,
     leadingCdTarget?: string,
   ) => Promise<PermissionProjectContext>;
+  taskTracker?: PermissionTaskTracker;
+  permissionAudit?: PermissionAuditIntegration;
 }
 
 const setupPermissionPolicy = (
@@ -154,7 +162,8 @@ const setupPermissionPolicy = (
     judgeConfig?.enabled === true
       ? createPermissionJudge(judgeConfig)
       : undefined;
-  const taskTracker = createPermissionTaskTracker();
+  const taskTracker = options.taskTracker ?? createPermissionTaskTracker();
+  const permissionAudit = options.permissionAudit;
   const discoverProject =
     options.discoverProject ??
     ((cwd: string, signal?: AbortSignal, leadingCdTarget?: string) =>
@@ -306,6 +315,37 @@ const setupPermissionPolicy = (
       permissionSignalToken: options.permissionSignalToken,
       writePermissionSignal: options.writePermissionSignal,
     });
+  const recordDeterministic = (
+    toolCallId: string,
+    phase: string,
+    result: AuditedVerdict & { readonly grantedBySkill?: boolean },
+  ): void => {
+    permissionAudit?.addStage(toolCallId, {
+      type: "deterministic",
+      phase,
+      verdict:
+        result.verdict === "default-continue" ? "continue" : result.verdict,
+      basis: result.audit.basis,
+      reasonCode: result.audit.reasonCode,
+      ...(result.verdict === "default-continue" || result.reason === undefined
+        ? {}
+        : { reason: result.reason }),
+      ...(result.audit.ruleSource === undefined
+        ? {}
+        : { ruleSource: result.audit.ruleSource }),
+      ...(result.grantedBySkill === true ? { grantedBySkill: true } : {}),
+    });
+  };
+  const finalizeBlocked = async (
+    toolCallId: string,
+    reasonCode: string,
+    reason: string,
+  ): Promise<PermissionBlockResult> => {
+    if (permissionAudit === undefined) return blocked(reason);
+    return (await permissionAudit.finalizeBlock(toolCallId, reasonCode))
+      ? blocked(reason)
+      : blocked(PERMISSION_AUDIT_UNAVAILABLE_REASON);
+  };
 
   pi.on("before_agent_start", (event) => {
     taskTracker.activate(event.prompt);
@@ -350,7 +390,19 @@ const setupPermissionPolicy = (
       // A bash call whose command is missing or not a string is malformed;
       // the safety floor blocks it instead of letting it through (fail-closed).
       if (typeof command !== "string") {
-        return blocked(MALFORMED_REASON);
+        permissionAudit?.addStage(event.toolCallId, {
+          type: "deterministic",
+          phase: "malformed-input",
+          verdict: "deny",
+          basis: "parse-error",
+          reasonCode: "malformed-input",
+          reason: MALFORMED_REASON,
+        });
+        return finalizeBlocked(
+          event.toolCallId,
+          "malformed-input",
+          MALFORMED_REASON,
+        );
       }
 
       const signal = (
@@ -369,41 +421,84 @@ const setupPermissionPolicy = (
         rules,
         activeSkillBashAllows,
       );
+      recordDeterministic(event.toolCallId, "initial", result);
       if (result.verdict === "allow" && result.grantedBySkill === true) {
         const gitCwd = skillGrantedGitCwd(command);
         if (
           gitCwd === undefined ||
           (gitCwd !== null && ctx.cwd === undefined)
         ) {
-          result = evaluateCommand(command, rules);
+          result = evaluateCommandWithAudit(command, rules);
+          recordDeterministic(event.toolCallId, "skill-fallback", result);
         } else if (gitCwd !== null && ctx.cwd !== undefined) {
           const candidate = resolve(ctx.cwd, gitCwd);
           projectDiscovery = await discoverProject(ctx.cwd, signal, candidate);
+          permissionAudit?.updateContext(event.toolCallId, {
+            project: projectDiscovery,
+            ...(projectDiscovery.leadingNavigation === undefined
+              ? {}
+              : { gitCwd: projectDiscovery.leadingNavigation }),
+          });
           if (
             projectDiscovery.leadingNavigation?.scope !== "listed-worktree" ||
             !projectDiscovery.leadingNavigation.sameRepository
           ) {
-            result = evaluateCommand(command, rules);
+            result = evaluateCommandWithAudit(command, rules);
+            recordDeterministic(event.toolCallId, "skill-fallback", result);
           }
         }
       }
       if (isAborted()) {
-        return blocked("the active pi operation was cancelled");
+        permissionAudit?.addStage(event.toolCallId, {
+          type: "error",
+          component: "permission-policy",
+          phase: "cancelled",
+          verdict: "error",
+          reasonCode: "parent-aborted",
+        });
+        return finalizeBlocked(
+          event.toolCallId,
+          "parent-aborted",
+          "the active pi operation was cancelled",
+        );
       }
       if (result.verdict === "deny") {
-        return blocked(result.reason);
+        return finalizeBlocked(
+          event.toolCallId,
+          result.audit.reasonCode,
+          result.reason,
+        );
       }
       const confirm = async (
         title: string,
         reason: string,
+        reasonCode: string,
+        challengeSource: string,
       ): Promise<{ block: true; reason: string } | undefined> => {
-        if (!ctx.hasUI || isAborted()) return blocked(reason);
-        const confirmed = await ctx.ui.confirm(
-          title,
-          `${reason}\n\n${command}`,
-          { signal },
-        );
-        return confirmed && !isAborted() ? undefined : blocked(reason);
+        const confirmed =
+          ctx.hasUI && !isAborted()
+            ? await ctx.ui.confirm(title, `${reason}\n\n${command}`, {
+                signal,
+              })
+            : false;
+        const status = !ctx.hasUI
+          ? ("not-shown" as const)
+          : isAborted()
+            ? ("aborted" as const)
+            : confirmed
+              ? ("accepted" as const)
+              : ("rejected" as const);
+        permissionAudit?.addStage(event.toolCallId, {
+          type: "confirmation",
+          phase: "permission-policy",
+          challengeSource,
+          status,
+          reasonCode,
+          reason,
+        });
+        return confirmed && !isAborted()
+          ? undefined
+          : finalizeBlocked(event.toolCallId, reasonCode, reason);
       };
 
       if (result.verdict === "ask") {
@@ -411,28 +506,77 @@ const setupPermissionPolicy = (
         if (readCwdTarget !== undefined && ctx.cwd !== undefined) {
           const candidate = resolve(ctx.cwd, readCwdTarget);
           projectDiscovery = await discoverProject(ctx.cwd, signal, candidate);
-          if (isAborted()) {
-            return blocked("the active pi operation was cancelled");
-          }
           gitCwdNavigation = projectDiscovery.leadingNavigation;
+          permissionAudit?.updateContext(event.toolCallId, {
+            project: projectDiscovery,
+            ...(gitCwdNavigation === undefined
+              ? {}
+              : { gitCwd: gitCwdNavigation }),
+          });
+          if (isAborted()) {
+            permissionAudit?.addStage(event.toolCallId, {
+              type: "error",
+              component: "permission-policy",
+              phase: "git-c-discovery",
+              verdict: "error",
+              reasonCode: "parent-aborted",
+            });
+            return finalizeBlocked(
+              event.toolCallId,
+              "parent-aborted",
+              "the active pi operation was cancelled",
+            );
+          }
           if (
             gitCwdNavigation?.scope !== "listed-worktree" ||
             !gitCwdNavigation.sameRepository
           ) {
+            permissionAudit?.addStage(event.toolCallId, {
+              type: "scope",
+              phase: "git-c",
+              verdict: "ask",
+              reasonCode: "git-c-unverified",
+              reason:
+                "git -C の対象を登録済みの同一リポジトリworktree内と確認できませんでした",
+              ...(gitCwdNavigation === undefined
+                ? {}
+                : { navigation: gitCwdNavigation }),
+            });
             return confirm(
               "検証できないGit作業場所を使用しますか？",
               "git -C の対象を登録済みの同一リポジトリworktree内と確認できませんでした",
+              "git-c-unverified",
+              "git-c-scope",
             );
           }
+          permissionAudit?.addStage(event.toolCallId, {
+            type: "scope",
+            phase: "git-c",
+            verdict: "allow",
+            reasonCode: "git-c-listed-worktree",
+            navigation: gitCwdNavigation,
+          });
           trustedGitReadCwdTarget = readCwdTarget;
-          result = evaluateCommand(command, rules, {
+          result = evaluateCommandWithAudit(command, rules, {
             trustedGitCwdTarget: readCwdTarget,
           });
+          recordDeterministic(event.toolCallId, "verified-git-c", result);
         }
       }
-      if (result.verdict === "deny") return blocked(result.reason);
+      if (result.verdict === "deny") {
+        return finalizeBlocked(
+          event.toolCallId,
+          result.audit.reasonCode,
+          result.reason,
+        );
+      }
       if (result.verdict === "ask") {
-        return confirm("危険なコマンドを実行しますか？", result.reason);
+        return confirm(
+          "危険なコマンドを実行しますか？",
+          result.reason,
+          result.audit.reasonCode,
+          "deterministic-policy",
+        );
       }
 
       const leadingCdTarget = leadingTrustedCdTarget(command);
@@ -443,9 +587,20 @@ const setupPermissionPolicy = (
           leadingCdTarget !== undefined,
         );
       if (unverifiedMutationNavigation) {
+        const reason =
+          "プロジェクト変更前の作業場所を検証できないため確認が必要です";
+        permissionAudit?.addStage(event.toolCallId, {
+          type: "scope",
+          phase: "mutation-navigation",
+          verdict: "ask",
+          reasonCode: "mutation-navigation-unverified",
+          reason,
+        });
         return confirm(
           "検証できない移動後のプロジェクト変更を実行しますか？",
-          "プロジェクト変更前の作業場所を検証できないため確認が必要です",
+          reason,
+          "mutation-navigation-unverified",
+          "mutation-navigation",
         );
       }
       // Context-free allows remain cheap, but an allow cannot bypass verified
@@ -469,28 +624,78 @@ const setupPermissionPolicy = (
           ? undefined
           : (projectDiscovery ??
             (await discoverProject(ctx.cwd, signal, leadingCdTarget)));
-      if (isAborted()) {
-        return blocked("the active pi operation was cancelled");
-      }
       const leadingNavigation =
         leadingCdTarget === undefined ? undefined : project?.leadingNavigation;
+      permissionAudit?.updateContext(event.toolCallId, {
+        ...(project === undefined ? {} : { project }),
+        ...(leadingNavigation === undefined ? {} : { leadingNavigation }),
+        ...(gitCwdNavigation === undefined ? {} : { gitCwd: gitCwdNavigation }),
+      });
+      if (isAborted()) {
+        permissionAudit?.addStage(event.toolCallId, {
+          type: "error",
+          component: "permission-policy",
+          phase: "project-discovery",
+          verdict: "error",
+          reasonCode: "parent-aborted",
+        });
+        return finalizeBlocked(
+          event.toolCallId,
+          "parent-aborted",
+          "the active pi operation was cancelled",
+        );
+      }
       if (
         leadingCdTarget !== undefined &&
         (leadingNavigation?.scope !== "listed-worktree" ||
           !leadingNavigation.sameRepository)
       ) {
+        const reason =
+          "登録済みの同一リポジトリworktreeへの移動と確認できませんでした";
+        permissionAudit?.addStage(event.toolCallId, {
+          type: "scope",
+          phase: "leading-navigation",
+          verdict: "ask",
+          reasonCode: "leading-navigation-unverified",
+          reason,
+          ...(leadingNavigation === undefined
+            ? {}
+            : { navigation: leadingNavigation }),
+        });
         return confirm(
           "プロジェクト外へ移動するコマンドを実行しますか？",
-          "登録済みの同一リポジトリworktreeへの移動と確認できませんでした",
+          reason,
+          "leading-navigation-unverified",
+          "leading-navigation",
         );
+      }
+      if (leadingNavigation !== undefined) {
+        permissionAudit?.addStage(event.toolCallId, {
+          type: "scope",
+          phase: "leading-navigation",
+          verdict: "allow",
+          reasonCode: "leading-navigation-listed-worktree",
+          navigation: leadingNavigation,
+        });
       }
       if (
         projectSensitiveMutation &&
         (project === undefined || project.kind === "unavailable")
       ) {
+        const reason =
+          "プロジェクト境界を検証できないため変更コマンドには確認が必要です";
+        permissionAudit?.addStage(event.toolCallId, {
+          type: "scope",
+          phase: "project-mutation",
+          verdict: "ask",
+          reasonCode: "project-mutation-unverified",
+          reason,
+        });
         return confirm(
           "検証できないプロジェクト変更を実行しますか？",
-          "プロジェクト境界を検証できないため変更コマンドには確認が必要です",
+          reason,
+          "project-mutation-unverified",
+          "project-mutation",
         );
       }
       if (result.verdict === "allow") return undefined;
@@ -512,7 +717,7 @@ const setupPermissionPolicy = (
         trustedLeadingCdTarget !== undefined ||
         trustedReadContext !== undefined
       ) {
-        result = evaluateCommand(command, rules, {
+        result = evaluateCommandWithAudit(command, rules, {
           ...(trustedLeadingCdTarget === undefined
             ? {}
             : { trustedLeadingCdTarget }),
@@ -521,9 +726,21 @@ const setupPermissionPolicy = (
             : { trustedGitCwdTarget: trustedGitReadCwdTarget }),
           ...(trustedReadContext === undefined ? {} : { trustedReadContext }),
         });
-        if (result.verdict === "deny") return blocked(result.reason);
+        recordDeterministic(event.toolCallId, "verified-project", result);
+        if (result.verdict === "deny") {
+          return finalizeBlocked(
+            event.toolCallId,
+            result.audit.reasonCode,
+            result.reason,
+          );
+        }
         if (result.verdict === "ask") {
-          return confirm("危険なコマンドを実行しますか？", result.reason);
+          return confirm(
+            "危険なコマンドを実行しますか？",
+            result.reason,
+            result.audit.reasonCode,
+            "deterministic-policy",
+          );
         }
         if (result.verdict === "allow") return undefined;
       }
@@ -543,12 +760,38 @@ const setupPermissionPolicy = (
         ...(leadingNavigation === undefined ? {} : { leadingNavigation }),
         ...(gitCwdNavigation === undefined ? {} : { gitCwd: gitCwdNavigation }),
       });
+      permissionAudit?.addStage(event.toolCallId, {
+        type: "judge",
+        phase: "fallback",
+        verdict:
+          outcome.kind === "allow"
+            ? "allow"
+            : outcome.kind === "ask"
+              ? "ask"
+              : "error",
+        reasonCode: `judge-${outcome.kind}`,
+        ...(outcome.kind === "allow" ? {} : { reason: outcome.reason }),
+        outcome: outcome.kind,
+        ...(outcome.audit === undefined
+          ? {}
+          : {
+              source: outcome.audit.source,
+              gates: outcome.audit.gates,
+              model: outcome.audit.model,
+              expectedDigest: outcome.audit.expectedDigest,
+              policyVersion: outcome.audit.policyVersion,
+            }),
+      });
       if (outcome.kind === "allow") {
         if (!outcome.cached) judgeWarningShown = false;
         return undefined;
       }
       if (outcome.kind === "parent-aborted") {
-        return blocked(outcome.reason);
+        return finalizeBlocked(
+          event.toolCallId,
+          "judge-parent-aborted",
+          outcome.reason,
+        );
       }
       if (outcome.kind === "ask" || outcome.kind === "invalid-response") {
         // A live backend response ends the previous unavailable period even
@@ -566,12 +809,24 @@ const setupPermissionPolicy = (
           "warning",
         );
       }
-      return confirm("ローカル判定器が自動承認しませんでした", outcome.reason);
-    } catch (error) {
-      // Any evaluation failure blocks rather than failing open.
-      return blocked(
-        `permission-policy: 評価中にエラーが発生したためブロックしました (${String(error)})`,
+      return confirm(
+        "ローカル判定器が自動承認しませんでした",
+        outcome.reason,
+        `judge-${outcome.kind}`,
+        "local-judge",
       );
+    } catch (error) {
+      // Any evaluation or audit-integration failure blocks rather than failing open.
+      const reason = `permission-policy: 評価中にエラーが発生したためブロックしました (${String(error)})`;
+      permissionAudit?.addStage(event.toolCallId, {
+        type: "error",
+        component: "permission-policy",
+        phase: "evaluation",
+        verdict: "error",
+        reasonCode: "policy-error",
+        message: String(error),
+      });
+      return finalizeBlocked(event.toolCallId, "policy-error", reason);
     }
   });
 };

--- a/pi/extensions/pi-harness/features/permission-policy/judge.ts
+++ b/pi/extensions/pi-harness/features/permission-policy/judge.ts
@@ -20,7 +20,8 @@ const MAX_RESPONSE_BYTES = 64 * 1024;
 const DEFAULT_CACHE_CAPACITY = 128;
 const DEFAULT_CACHE_TTL_MS = 5 * 60_000;
 const DEFAULT_CIRCUIT_MS = 5_000;
-const POLICY_VERSION = "permission-judge-v6-safety-relevance";
+export const PERMISSION_JUDGE_POLICY_VERSION =
+  "permission-judge-v6-safety-relevance";
 
 const VERDICT_SCHEMA = {
   type: "object",
@@ -57,8 +58,19 @@ Examples below apply only after checking every safety rule; => ALLOW means safet
 - task explicitly says do not inspect the repository; command git status --short => ASK
 When uncertain, set the uncertain gate to ASK.`;
 
+export interface JudgeDecisionAudit {
+  readonly source: "live" | "cache";
+  readonly gates: {
+    readonly safety: "ALLOW" | "ASK";
+    readonly relevance: "ALLOW" | "ASK";
+  };
+  readonly model: string;
+  readonly expectedDigest: string;
+  readonly policyVersion: typeof PERMISSION_JUDGE_POLICY_VERSION;
+}
+
 export type JudgeOutcome =
-  | { kind: "allow"; cached: boolean }
+  | { kind: "allow"; cached: boolean; audit?: JudgeDecisionAudit }
   | {
       kind:
         | "ask"
@@ -68,6 +80,7 @@ export type JudgeOutcome =
         | "parent-aborted"
         | "too-long";
       reason: string;
+      audit?: JudgeDecisionAudit;
     };
 
 export interface JudgeContext {
@@ -187,7 +200,7 @@ const cacheKey = (
   context: JudgeContext,
 ): string =>
   createHash("sha256")
-    .update(POLICY_VERSION)
+    .update(PERMISSION_JUDGE_POLICY_VERSION)
     .update("\0")
     .update(SYSTEM_PROMPT)
     .update("\0")
@@ -591,7 +604,11 @@ export const readLocalOllamaVersion = async (
   }
 };
 
-const parseResponse = (text: string, expectedModel: string): JudgeOutcome => {
+const parseResponse = (
+  text: string,
+  config: PermissionJudgeConfig,
+): JudgeOutcome => {
+  const expectedModel = config.model;
   let value: unknown;
   try {
     value = JSON.parse(text);
@@ -671,10 +688,21 @@ const parseResponse = (text: string, expectedModel: string): JudgeOutcome => {
       reason: "local judge did not return a valid structured decision",
     };
   }
+  const audit: JudgeDecisionAudit = {
+    source: "live",
+    gates: { safety, relevance },
+    model: config.model,
+    expectedDigest: config.expectedDigest,
+    policyVersion: PERMISSION_JUDGE_POLICY_VERSION,
+  };
   if (safety === "ALLOW" && relevance === "ALLOW") {
-    return { kind: "allow", cached: false };
+    return { kind: "allow", cached: false, audit };
   }
-  return { kind: "ask", reason: "local judge requested user confirmation" };
+  return {
+    kind: "ask",
+    reason: "local judge requested user confirmation",
+    audit,
+  };
 };
 
 export const createPermissionJudge = (
@@ -749,7 +777,19 @@ export const createPermissionJudge = (
 
       const key = cacheKey(config, userContent, context);
       const cacheEnabled = taskCorrelation(context) !== "uncorrelated";
-      if (cacheEnabled && cached(key)) return { kind: "allow", cached: true };
+      if (cacheEnabled && cached(key)) {
+        return {
+          kind: "allow",
+          cached: true,
+          audit: {
+            source: "cache",
+            gates: { safety: "ALLOW", relevance: "ALLOW" },
+            model: config.model,
+            expectedDigest: config.expectedDigest,
+            policyVersion: PERMISSION_JUDGE_POLICY_VERSION,
+          },
+        };
+      }
 
       if (config.configurationError !== undefined) {
         return {
@@ -934,7 +974,7 @@ export const createPermissionJudge = (
           };
         }
 
-        const outcome = parseResponse(body, config.model);
+        const outcome = parseResponse(body, config);
         if (parentSignal?.aborted) {
           return {
             kind: "parent-aborted",

--- a/pi/extensions/pi-harness/features/permission-policy/rules.ts
+++ b/pi/extensions/pi-harness/features/permission-policy/rules.ts
@@ -42,6 +42,47 @@ type Verdict =
   | { readonly verdict: "allow"; readonly reason?: string }
   | { readonly verdict: "default-continue" };
 
+export type PermissionVerdictBasis =
+  | "parse-error"
+  | "depth-limit"
+  | "configured-deny"
+  | "structural-deny"
+  | "speculative-deny"
+  | "structural-ask"
+  | "rg-option-glob-ask"
+  | "trusted-leading-cd"
+  | "configured-allow"
+  | "active-skill-allow"
+  | "configured-ask"
+  | "speculative-ask"
+  | "builtin-read-allow"
+  | "default-continue"
+  | "combined-allow"
+  | "combined-default";
+
+export interface PermissionVerdictAudit {
+  readonly basis: PermissionVerdictBasis;
+  readonly reasonCode: string;
+  readonly ruleSource?: string;
+}
+
+export type AuditedVerdict = Verdict & {
+  readonly audit: PermissionVerdictAudit;
+};
+
+const audited = <T extends Verdict>(
+  verdict: T,
+  basis: PermissionVerdictBasis,
+  ruleSource?: string,
+): T & { readonly audit: PermissionVerdictAudit } => ({
+  ...verdict,
+  audit: {
+    basis,
+    reasonCode: basis,
+    ...(ruleSource === undefined ? {} : { ruleSource }),
+  },
+});
+
 interface TrustedReadContext {
   /** Filesystem-verified effective cwd for the command. */
   readonly cwd: string;
@@ -1157,7 +1198,7 @@ const evaluateNormalized = (
   trustedLeadingCdTarget: string | undefined,
   trustedGitCwdTarget: string | undefined,
   trustedReadContext: TrustedReadContext | undefined,
-): Verdict => {
+): AuditedVerdict => {
   if (normalized.words.length === 0) {
     // A parenthesized group can leave redirects in a wordless outer segment.
     // Apply every segment-wide floor before returning so a sensitive input
@@ -1168,20 +1209,31 @@ const evaluateNormalized = (
       trustedGitCwdTarget,
     );
     return structuralAsk === undefined
-      ? { verdict: "default-continue" }
-      : { verdict: "ask", reason: structuralAsk };
+      ? audited({ verdict: "default-continue" }, "default-continue")
+      : audited({ verdict: "ask", reason: structuralAsk }, "structural-ask");
   }
   const command = normalized.words.join(" ");
   const potential = speculativeFloor(normalized);
 
   const denied = rules.deny.find((rule) => rule.pattern.test(command));
-  if (denied !== undefined) return { verdict: "deny", reason: denied.reason };
+  if (denied !== undefined) {
+    return audited(
+      { verdict: "deny", reason: denied.reason },
+      "configured-deny",
+      denied.source,
+    );
+  }
 
   const structural = structuralBitDeny(normalized);
-  if (structural !== undefined) return { verdict: "deny", reason: structural };
+  if (structural !== undefined) {
+    return audited({ verdict: "deny", reason: structural }, "structural-deny");
+  }
 
   if (potential === "deny") {
-    return { verdict: "ask", reason: POTENTIALLY_SENSITIVE_REASON };
+    return audited(
+      { verdict: "ask", reason: POTENTIALLY_SENSITIVE_REASON },
+      "speculative-deny",
+    );
   }
 
   const structuralAsk = structuralKnownAsk(
@@ -1190,13 +1242,16 @@ const evaluateNormalized = (
     trustedGitCwdTarget,
   );
   if (structuralAsk !== undefined) {
-    return { verdict: "ask", reason: structuralAsk };
+    return audited({ verdict: "ask", reason: structuralAsk }, "structural-ask");
   }
   if (hasRgOptionLikeGlobExpansion(normalized, trustedReadContext)) {
-    return {
-      verdict: "ask",
-      reason: "rg のglob展開が実行オプションとして解釈される可能性があります",
-    };
+    return audited(
+      {
+        verdict: "ask",
+        reason: "rg のglob展開が実行オプションとして解釈される可能性があります",
+      },
+      "rg-option-glob-ask",
+    );
   }
 
   // A same-repository leading cd is neutral only for explicit-allow
@@ -1206,7 +1261,7 @@ const evaluateNormalized = (
     trustedLeadingCdTarget !== undefined &&
     literalTrustedCdTarget(segment) === trustedLeadingCdTarget
   ) {
-    return { verdict: "allow" };
+    return audited({ verdict: "allow" }, "trusted-leading-cd");
   }
 
   // Git reads may invoke configured helpers, and rg requires no-config plus
@@ -1225,23 +1280,30 @@ const evaluateNormalized = (
       ? undefined
       : rules.allow.find((rule) => rule.pattern.test(allowCandidate));
   if (allowed !== undefined) {
-    return allowed.reason === undefined
-      ? { verdict: "allow" }
-      : { verdict: "allow", reason: allowed.reason };
+    const verdict =
+      allowed.reason === undefined
+        ? ({ verdict: "allow" } as const)
+        : ({ verdict: "allow", reason: allowed.reason } as const);
+    return audited(verdict, "configured-allow", allowed.source);
   }
 
   const asked = rules.ask.find((rule) => rule.pattern.test(command));
-  if (asked !== undefined) return { verdict: "ask", reason: asked.reason };
+  if (asked !== undefined) {
+    return audited({ verdict: "ask", reason: asked.reason }, "configured-ask");
+  }
 
   if (potential === "ask") {
-    return { verdict: "ask", reason: POTENTIALLY_SENSITIVE_REASON };
+    return audited(
+      { verdict: "ask", reason: POTENTIALLY_SENSITIVE_REASON },
+      "speculative-ask",
+    );
   }
 
   if (structuralKnownAllow(segment, normalized, trustedReadContext)) {
-    return { verdict: "allow" };
+    return audited({ verdict: "allow" }, "builtin-read-allow");
   }
 
-  return { verdict: "default-continue" };
+  return audited({ verdict: "default-continue" }, "default-continue");
 };
 
 const VERDICT_RANK: Readonly<Record<Verdict["verdict"], number>> = {
@@ -1254,8 +1316,13 @@ const VERDICT_RANK: Readonly<Record<Verdict["verdict"], number>> = {
 // Precedence deny > ask > allow > default-continue. `allow` only wins when
 // EVERY unit is explicitly allowed; a mix of allow + continue proceeds as the
 // default (both proceed, so the block outcome is identical either way).
-const combineVerdicts = (verdicts: readonly Verdict[]): Verdict => {
-  let best: Verdict = { verdict: "default-continue" };
+const combineVerdicts = (
+  verdicts: readonly AuditedVerdict[],
+): AuditedVerdict => {
+  let best: AuditedVerdict = audited(
+    { verdict: "default-continue" },
+    "default-continue",
+  );
   let allAllow = verdicts.length > 0;
   for (const verdict of verdicts) {
     if (verdict.verdict !== "allow") allAllow = false;
@@ -1264,7 +1331,10 @@ const combineVerdicts = (verdicts: readonly Verdict[]): Verdict => {
     }
   }
   if (best.verdict === "allow" && !allAllow) {
-    return { verdict: "default-continue" };
+    return audited({ verdict: "default-continue" }, "combined-default");
+  }
+  if (allAllow && verdicts.length > 1) {
+    return audited(best, "combined-allow");
   }
   return best;
 };
@@ -1274,13 +1344,21 @@ const evaluateCommandInner = (
   rules: LoadedRules,
   depth: number,
   options: EvaluationOptions,
-): Verdict => {
+): AuditedVerdict => {
   if (depth > MAX_SUBSTITUTION_DEPTH) {
-    return { verdict: "deny", reason: UNPARSEABLE_REASON };
+    return audited(
+      { verdict: "deny", reason: UNPARSEABLE_REASON },
+      "depth-limit",
+    );
   }
   const scanned = scanCommand(command);
-  if (!scanned.ok) return { verdict: "deny", reason: UNPARSEABLE_REASON };
-  const verdicts: Verdict[] = [];
+  if (!scanned.ok) {
+    return audited(
+      { verdict: "deny", reason: UNPARSEABLE_REASON },
+      "parse-error",
+    );
+  }
+  const verdicts: AuditedVerdict[] = [];
   for (const [index, segment] of scanned.segments.entries()) {
     const normalized = normalizeSegment(segment);
     verdicts.push(
@@ -1424,14 +1502,28 @@ const hasUnverifiedProjectMutationNavigation = (
 ): boolean =>
   hasUnverifiedProjectMutationNavigationInner(command, 0, allowLeadingCd);
 
+const evaluateCommandWithAudit = (
+  command: string,
+  rules: LoadedRules,
+  options: EvaluationOptions = {},
+): AuditedVerdict => evaluateCommandInner(command, rules, 0, options);
+
 const evaluateCommand = (
   command: string,
   rules: LoadedRules,
   options: EvaluationOptions = {},
-): Verdict => evaluateCommandInner(command, rules, 0, options);
+): Verdict => {
+  const { audit: _audit, ...verdict } = evaluateCommandWithAudit(
+    command,
+    rules,
+    options,
+  );
+  return verdict;
+};
 
 export {
   evaluateCommand,
+  evaluateCommandWithAudit,
   gitReadCwdTarget,
   hasProjectSensitiveMutation,
   hasUnverifiedProjectMutationNavigation,

--- a/pi/extensions/pi-harness/features/permission-policy/skill-allow.ts
+++ b/pi/extensions/pi-harness/features/permission-policy/skill-allow.ts
@@ -2,11 +2,11 @@ import { readFileSync, statSync } from "node:fs";
 import { dirname, isAbsolute } from "node:path";
 import type { BeforeAgentStartEvent } from "../../lib/pi-like";
 import {
-  evaluateCommand,
+  evaluateCommandWithAudit,
   type AllowRule,
+  type AuditedVerdict,
   isSkillOverridableAsk,
   type LoadedRules,
-  type Verdict,
 } from "./rules";
 import { normalizeSegment, scanCommand } from "./scan";
 
@@ -263,7 +263,9 @@ const resolveActiveSkillBashAllows = (
     : createActiveSkillBashAllowResolver(event)(event.prompt, invocation);
 };
 
-type SkillAwareVerdict = Verdict & { readonly grantedBySkill?: boolean };
+type SkillAwareVerdict = AuditedVerdict & {
+  readonly grantedBySkill?: boolean;
+};
 
 const matchingConcreteSkillAllow = (
   command: string,
@@ -288,7 +290,7 @@ const evaluateCommandWithSkillAllows = (
   rules: LoadedRules,
   skillAllows: readonly AllowRule[],
 ): SkillAwareVerdict => {
-  const base = evaluateCommand(command, rules);
+  const base = evaluateCommandWithAudit(command, rules);
   const matchingSkill = matchingConcreteSkillAllow(command, skillAllows);
   // An authenticated active-skill grant is itself explicit user approval for a
   // plain push or a verified git -C location. Force, destructive Git, secrets,
@@ -303,13 +305,20 @@ const evaluateCommandWithSkillAllows = (
       ...(matchingSkill.reason === undefined
         ? {}
         : { reason: matchingSkill.reason }),
+      audit: {
+        basis: "active-skill-allow",
+        reasonCode: "active-skill-allow",
+        ...(matchingSkill.source === undefined
+          ? {}
+          : { ruleSource: matchingSkill.source }),
+      },
       grantedBySkill: true,
     };
   }
   if (base.verdict !== "default-continue" || skillAllows.length === 0) {
     return base;
   }
-  const withSkill = evaluateCommand(command, {
+  const withSkill = evaluateCommandWithAudit(command, {
     ...rules,
     allow: [...rules.allow, ...skillAllows],
   });

--- a/pi/extensions/pi-harness/features/subagent/index.ts
+++ b/pi/extensions/pi-harness/features/subagent/index.ts
@@ -2,6 +2,7 @@ import type { CtxLike, PiLike } from "../../lib/pi-like";
 import type { HarnessConfig } from "../../config";
 import { replacePrevious } from "../../lib/placeholder";
 import type { ChildRunsIntegration } from "../child-runs/index";
+import type { PermissionAuditIntegration } from "../permission-audit/index";
 import type { ChildObservation } from "../child-runs/model";
 import { renderChildRunsResult } from "../child-runs/presentation";
 import { findAgent, loadAgents } from "./loader";
@@ -34,6 +35,7 @@ interface SetupSubagentOptions {
   spawnFn?: SpawnFunction;
   termGraceMs?: number;
   childRuns?: ChildRunsIntegration;
+  permissionAudit?: PermissionAuditIntegration;
 }
 
 interface SubagentDetails {
@@ -396,6 +398,11 @@ const setupSubagent = (
               onUpdate: emitUpdate,
               observe: observeFor(runId),
               termGraceMs: options.termGraceMs,
+              auditEnv: options.permissionAudit?.childEnvironment(
+                ctx,
+                invocationId,
+                runId,
+              ),
             },
           );
           finishSpawnResult(runId, result);

--- a/pi/extensions/pi-harness/features/subagent/spawn.ts
+++ b/pi/extensions/pi-harness/features/subagent/spawn.ts
@@ -87,6 +87,8 @@ type SpawnFunction = (
 interface SpawnAgentOptions {
   cwd: string;
   signal?: AbortSignal;
+  /** Harness-owned, non-secret correlation fields for child audit records. */
+  auditEnv?: Readonly<Record<string, string>>;
   spawnFn?: SpawnFunction;
   onUpdate?: (text: string) => void;
   observe?: (observation: ChildObservation) => void;
@@ -272,6 +274,7 @@ const spawnAgent = async (
             env: sanitizeChildEnv(
               process.env,
               {
+                ...options.auditEnv,
                 PI_HARNESS_CHILD: "1",
                 [CHILD_PERMISSION_SIGNAL_ENV]: permissionSignalToken,
               },

--- a/pi/extensions/pi-harness/features/workflow/index.ts
+++ b/pi/extensions/pi-harness/features/workflow/index.ts
@@ -16,6 +16,7 @@ import { realpath, stat } from "node:fs/promises";
 import type { HarnessConfig } from "../../config";
 import { MAX_NOTIFICATION_RESULT_BYTES } from "../child-runs/background";
 import type { ChildRunsIntegration } from "../child-runs/index";
+import type { PermissionAuditIntegration } from "../permission-audit/index";
 import type { ChildObservation } from "../child-runs/model";
 import { renderChildRunsResult } from "../child-runs/presentation";
 import type { CtxLike, PiLike } from "../../lib/pi-like";
@@ -59,6 +60,7 @@ interface SetupWorkflowOptions {
     rootCwd: string,
   ) => Promise<CwdBoundaryResult>;
   childRuns?: ChildRunsIntegration;
+  permissionAudit?: PermissionAuditIntegration;
 }
 
 interface SpawnFailure {
@@ -521,6 +523,11 @@ const setupWorkflow = (
                     onUpdate: emitUpdate,
                     observe: observeFor(runId),
                     termGraceMs: options.termGraceMs,
+                    auditEnv: options.permissionAudit?.childEnvironment(
+                      ctx,
+                      invocationId,
+                      runId,
+                    ),
                   },
                 );
                 if (runId !== undefined) {

--- a/pi/extensions/pi-harness/index.ts
+++ b/pi/extensions/pi-harness/index.ts
@@ -15,6 +15,8 @@ import { delimiter } from "node:path";
 import type { PiLike } from "./lib/pi-like";
 import { loadConfig, type HarnessConfig } from "./config";
 import setupPermissionPolicy from "./features/permission-policy/index";
+import { createPermissionTaskTracker } from "./features/permission-policy/context";
+import { setupPermissionAudit } from "./features/permission-audit/index";
 import {
   createPermissionBlocker,
   type PermissionBlockerOptions,
@@ -22,6 +24,7 @@ import {
 import setupHookBridge from "./features/hook-bridge/index";
 import setupGitHubCliReminder from "./features/github-cli-reminder/index";
 import setupProgressReminder from "./features/progress-reminder/index";
+import setupPermissionAskReminder from "./features/permission-ask-reminder/index";
 import {
   buildRegistry,
   partitionBridgeRegistry,
@@ -60,6 +63,16 @@ const setupHarness = (
   // This preserves the parent observer's failure classification even when a
   // bridge hook rejects before (or after) the mandatory policy handler.
   const blockToolCall = createPermissionBlocker(config.isChild, options);
+  const permissionTaskTracker = createPermissionTaskTracker();
+  const permissionAskReminder = config.isChild
+    ? undefined
+    : setupPermissionAskReminder(pi);
+  // The audit starter must be the first Bash tool_call observer. Every later
+  // permission handler enriches this transaction or block-finalizes it.
+  const permissionAudit = setupPermissionAudit(pi, config, {
+    taskTracker: permissionTaskTracker,
+    onDisplayedConfirmation: permissionAskReminder?.recordDisplayedConfirmation,
+  });
   const bridgeRegistry = config.features["hook-bridge"]
     ? partitionBridgeRegistry(buildRegistry(config.paths))
     : undefined;
@@ -92,20 +105,35 @@ const setupHarness = (
       registry: bridgeRegistry.permissionPreflight,
       env: { PATH: PERMISSION_PREFLIGHT_PATH },
       blockToolCall,
+      permissionAudit,
+      auditPhase: "preflight",
     });
   }
 
   // Safety floor before every path that can continue to tool execution.
-  setupPermissionPolicy(pi, config, { blockToolCall });
+  setupPermissionPolicy(pi, config, {
+    blockToolCall,
+    taskTracker: permissionTaskTracker,
+    permissionAudit,
+  });
 
   if (bridgeRegistry?.remaining.length) {
     setupHookBridge(pi, config, {
       registry: bridgeRegistry.remaining,
       blockToolCall,
+      permissionAudit,
+      auditPhase: "remaining",
     });
   }
-  if (config.features.subagent) setupSubagent(pi, config, { childRuns });
-  if (config.features.workflow) setupWorkflow(pi, config, { childRuns });
+  // This is the last pi-harness Bash permission handler. "release" here means
+  // only that pi-harness passed the call to any later third-party handlers.
+  permissionAudit.registerTail(pi, blockToolCall);
+  if (config.features.subagent) {
+    setupSubagent(pi, config, { childRuns, permissionAudit });
+  }
+  if (config.features.workflow) {
+    setupWorkflow(pi, config, { childRuns, permissionAudit });
+  }
   if (config.features["bit-task"]) setupBitTask(pi, config);
   if (config.features.statusline) setupStatusline(pi, config);
   if (config.features["provider-log"]) setupProviderLog(pi, config);

--- a/pi/extensions/pi-harness/lib/pi-like.ts
+++ b/pi/extensions/pi-harness/lib/pi-like.ts
@@ -222,6 +222,8 @@ export interface UiLike {
 export interface SessionManagerLike {
   /** Active branch in root-to-leaf order, synchronized through tool_call. */
   getBranch(): unknown[];
+  /** Stable Pi session identifier, including in-memory/no-session runtimes. */
+  getSessionId?(): string;
 }
 
 export interface CtxLike {
@@ -231,6 +233,7 @@ export interface CtxLike {
   cwd?: string;
   model?: ModelLike;
   sessionManager?: SessionManagerLike;
+  signal?: AbortSignal;
   getContextUsage?(): ContextUsageLike | undefined;
 }
 

--- a/tests/hooks/pi-harness/bridge-integration.test.ts
+++ b/tests/hooks/pi-harness/bridge-integration.test.ts
@@ -10,6 +10,14 @@ import {
   setupHarness,
 } from "../../../pi/extensions/pi-harness/index";
 import setupHookBridge from "../../../pi/extensions/pi-harness/features/hook-bridge/index";
+import { parsePermissionAuditJsonl } from "../../../pi/extensions/pi-harness/features/permission-audit/analysis";
+import {
+  setupPermissionAudit,
+  type PermissionAuditIntegration,
+} from "../../../pi/extensions/pi-harness/features/permission-audit/index";
+import type { PermissionAuditStage } from "../../../pi/extensions/pi-harness/features/permission-audit/model";
+import { createPermissionTaskTracker } from "../../../pi/extensions/pi-harness/features/permission-policy/context";
+import setupPermissionPolicy from "../../../pi/extensions/pi-harness/features/permission-policy/index";
 import type { BridgeHookSpec } from "../../../pi/extensions/pi-harness/features/hook-bridge/registry";
 import {
   CHILD_PERMISSION_SIGNAL_ENV,
@@ -118,6 +126,123 @@ describe("pi-harness hook bridge", () => {
     });
     const nonInteractive = await nonInteractivePi.emitToolCall(event);
     expect(nonInteractive?.reason).toBe("confirm hook action");
+  });
+
+  test("a later policy denial outranks an accepted hook ASK", async () => {
+    const directory = await makeTempDirectory("pi-hook-ask-then-deny");
+    const script = join(directory, "ask.sh");
+    await fs.writeFile(
+      script,
+      [
+        "#!/bin/bash",
+        "cat >/dev/null",
+        `printf '%s' '{"hookSpecificOutput":{"permissionDecision":"ask","permissionDecisionReason":"confirm first"}}'`,
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    const config = makeConfig(directory);
+    const pi = createFakePi({ cwd: directory });
+    const taskTracker = createPermissionTaskTracker();
+    const audit = setupPermissionAudit(pi, config, { taskTracker });
+    const blocker = (reason: string) => ({ block: true as const, reason });
+    setupHookBridge(pi, config, {
+      registry: [
+        makeSpec("ask-first", "tool_call", script, { matcher: /^Bash$/ }),
+      ],
+      permissionAudit: audit,
+      auditPhase: "preflight",
+      blockToolCall: blocker,
+    });
+    setupPermissionPolicy(pi, config, {
+      taskTracker,
+      permissionAudit: audit,
+      blockToolCall: blocker,
+    });
+    audit.registerTail(pi, blocker);
+    pi.queueConfirm(true);
+
+    expect(
+      await pi.emitToolCall({
+        type: "tool_call",
+        toolName: "bash",
+        toolCallId: "ask-then-deny",
+        input: { command: "bit relay serve" },
+      }),
+    ).toMatchObject({ block: true });
+    await pi.emitSessionShutdown();
+
+    const [file] = await fs.readdir(config.paths.logDir);
+    const parsed = parsePermissionAuditJsonl(
+      await fs.readFile(join(config.paths.logDir, file ?? ""), "utf8"),
+    );
+    expect(parsed.records[0]).toMatchObject({
+      effectiveDecision: "deny",
+      boundaryDisposition: "block",
+      stages: [
+        { type: "hook", verdict: "ask" },
+        { type: "confirmation", status: "accepted" },
+        { type: "deterministic", verdict: "deny" },
+      ],
+    });
+  });
+
+  test("records degraded hook continues with stable reason codes", async () => {
+    const directory = await makeTempDirectory("pi-hook-degraded");
+    const timeoutScript = join(directory, "timeout.sh");
+    const nonzeroScript = join(directory, "nonzero.sh");
+    const malformedScript = join(directory, "malformed.sh");
+    await fs.writeFile(
+      timeoutScript,
+      "#!/bin/bash\ncat >/dev/null\nsleep 1\n",
+      { mode: 0o755 },
+    );
+    await fs.writeFile(nonzeroScript, "#!/bin/bash\ncat >/dev/null\nexit 1\n", {
+      mode: 0o755,
+    });
+    await fs.writeFile(
+      malformedScript,
+      "#!/bin/bash\ncat >/dev/null\nprintf not-json\n",
+      { mode: 0o755 },
+    );
+    const stages: PermissionAuditStage[] = [];
+    const permissionAudit: PermissionAuditIntegration = {
+      lineageId: "123e4567-e89b-42d3-a456-426614174000",
+      addStage: (_toolCallId, stage) => stages.push(stage),
+      updateContext() {},
+      finalizeBlock: async () => true,
+      registerTail() {},
+      childEnvironment: () => ({}),
+    };
+    const timeoutSpec = makeSpec("timeout", "tool_call", timeoutScript, {
+      matcher: /^Bash$/,
+    });
+    const pi = createFakePi({ cwd: directory });
+    setupHookBridge(pi, makeConfig(directory), {
+      permissionAudit,
+      registry: [
+        { ...timeoutSpec, timeoutMs: 10 },
+        makeSpec("nonzero", "tool_call", nonzeroScript, {
+          matcher: /^Bash$/,
+        }),
+        makeSpec("malformed", "tool_call", malformedScript, {
+          matcher: /^Bash$/,
+        }),
+      ],
+    });
+
+    expect(
+      await pi.emitToolCall({
+        type: "tool_call",
+        toolName: "bash",
+        toolCallId: "degraded-hooks",
+        input: { command: "pwd" },
+      }),
+    ).toBeUndefined();
+    expect(
+      stages.map((stage) =>
+        stage.type === "hook" ? stage.reasonCode : stage.type,
+      ),
+    ).toEqual(["hook-timeout", "hook-nonzero-exit", "hook-malformed-output"]);
   });
 
   test("npm_script_preference blocks before later permission handlers", async () => {
@@ -237,6 +362,39 @@ describe("pi-harness hook bridge", () => {
     expect(permissionSignals).toEqual([
       `${formatChildPermissionSignal(permissionSignalToken)}\n`,
       `${formatChildPermissionSignal(permissionSignalToken)}\n`,
+    ]);
+
+    await pi.emitSessionShutdown();
+    const auditFiles = (await fs.readdir(config.paths.logDir)).filter((name) =>
+      name.startsWith("permission-"),
+    );
+    expect(auditFiles).toHaveLength(1);
+    const audit = parsePermissionAuditJsonl(
+      await fs.readFile(join(config.paths.logDir, auditFiles[0] ?? ""), "utf8"),
+    );
+    expect(audit.records).toHaveLength(2);
+    expect(audit.records[0]?.stages).toEqual([
+      expect.objectContaining({
+        type: "hook",
+        phase: "preflight",
+        hookId: "npm-script-preference",
+        verdict: "deny",
+      }),
+    ]);
+    expect(audit.records[1]?.stages).toEqual([
+      expect.objectContaining({
+        type: "hook",
+        phase: "preflight",
+        verdict: "continue",
+      }),
+      expect.objectContaining({
+        type: "deterministic",
+        verdict: "ask",
+      }),
+      expect.objectContaining({
+        type: "confirmation",
+        status: "not-shown",
+      }),
     ]);
   });
 

--- a/tests/pi-harness/agent-loader.test.ts
+++ b/tests/pi-harness/agent-loader.test.ts
@@ -7,6 +7,8 @@ import {
   type HarnessConfig,
 } from "../../pi/extensions/pi-harness/config";
 import setupPermissionPolicy from "../../pi/extensions/pi-harness/features/permission-policy";
+import { ChildRunRegistry } from "../../pi/extensions/pi-harness/features/child-runs/registry";
+import type { PermissionAuditIntegration } from "../../pi/extensions/pi-harness/features/permission-audit/index";
 import setupSubagent from "../../pi/extensions/pi-harness/features/subagent/index";
 import {
   CHILD_PERMISSION_SIGNAL_ENV,
@@ -324,11 +326,13 @@ describe("pi-harness subagent", () => {
     );
 
     let recordedArgs: string[] = [];
-    let recordedChildEnv: string | undefined;
+    let recordedEnv: NodeJS.ProcessEnv = {};
     let recordedPrompt = "";
+    let capturedInvocationId: string | undefined;
+    let capturedRunId: string | undefined;
     const spawnFn: SpawnFunction = (_command, args, options) => {
       recordedArgs = [...args];
-      recordedChildEnv = options.env.PI_HARNESS_CHILD;
+      recordedEnv = options.env;
       const promptFlag = args.indexOf("--append-system-prompt");
       recordedPrompt = readFileSync(args[promptFlag + 1] ?? "", "utf8");
       const controller = createFakeProcess();
@@ -338,8 +342,32 @@ describe("pi-harness subagent", () => {
       });
       return controller.process;
     };
-    const pi = createFakePi({ cwd: home });
-    setupSubagent(pi, makeConfig(home), { spawnFn });
+    const pi = createFakePi({ cwd: home, sessionId: "parent-session" });
+    const registry = new ChildRunRegistry();
+    const childRuns = { registry, ensureVisible() {} };
+    const permissionAudit = {
+      childEnvironment(
+        _ctx: CtxLike,
+        invocationId: string | undefined,
+        runId: string | undefined,
+      ) {
+        capturedInvocationId = invocationId;
+        capturedRunId = runId;
+        return {
+          PI_HARNESS_AUDIT_LINEAGE_ID: "123e4567-e89b-42d3-a456-426614174000",
+          PI_HARNESS_AUDIT_PARENT_SESSION_ID: "parent-session",
+          ...(invocationId === undefined
+            ? {}
+            : { PI_HARNESS_AUDIT_INVOCATION_ID: invocationId }),
+          ...(runId === undefined ? {} : { PI_HARNESS_AUDIT_RUN_ID: runId }),
+        };
+      },
+    } as unknown as PermissionAuditIntegration;
+    setupSubagent(pi, makeConfig(home), {
+      spawnFn,
+      childRuns,
+      permissionAudit,
+    });
 
     await executeTool(
       pi.tools[0],
@@ -352,8 +380,24 @@ describe("pi-harness subagent", () => {
     expect(recordedArgs).toContain("--append-system-prompt");
     expect(recordedArgs).toContain("openai-codex/gpt-5.4-mini");
     expect(recordedArgs).toContain("read,grep");
-    expect(recordedChildEnv).toBe("1");
+    expect(recordedEnv.PI_HARNESS_CHILD).toBe("1");
+    expect(recordedEnv.PI_HARNESS_AUDIT_LINEAGE_ID).toBe(
+      "123e4567-e89b-42d3-a456-426614174000",
+    );
+    expect(recordedEnv.PI_HARNESS_AUDIT_PARENT_SESSION_ID).toBe(
+      "parent-session",
+    );
+    if (capturedInvocationId === undefined || capturedRunId === undefined) {
+      throw new Error("expected child correlation ids");
+    }
+    expect(recordedEnv.PI_HARNESS_AUDIT_INVOCATION_ID).toBe(
+      capturedInvocationId,
+    );
+    expect(recordedEnv.PI_HARNESS_AUDIT_RUN_ID).toBe(capturedRunId);
+    expect(capturedInvocationId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(capturedRunId).toMatch(/^[0-9a-f-]{36}$/);
     expect(recordedPrompt).toBe("Review carefully.");
+    registry.dispose();
   });
 
   test("runs at most four parallel child processes", async () => {

--- a/tests/pi-harness/fake-pi.ts
+++ b/tests/pi-harness/fake-pi.ts
@@ -154,6 +154,7 @@ export function createFakePi(
     gitBranch?: string | null;
     model?: ModelLike;
     contextUsage?: ContextUsageLike;
+    sessionId?: string;
   } = {},
 ): FakePi {
   const store: HandlerStore = {
@@ -212,6 +213,7 @@ export function createFakePi(
     model: options.model,
     sessionManager: {
       getBranch: () => [...sessionBranch],
+      getSessionId: () => options.sessionId ?? "fake-session",
     },
     getContextUsage: () => contextUsage,
     ui: {

--- a/tests/pi-harness/permission-ask-reminder.test.ts
+++ b/tests/pi-harness/permission-ask-reminder.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { HarnessConfig } from "../../pi/extensions/pi-harness/config";
+import setupPermissionAskReminder, {
+  PERMISSION_ASK_REMINDER_CUSTOM_TYPE,
+  PERMISSION_ASK_REMINDER_THRESHOLD,
+} from "../../pi/extensions/pi-harness/features/permission-ask-reminder/index";
+import { setupHarness } from "../../pi/extensions/pi-harness/index";
+import { resolvePaths } from "../../pi/extensions/pi-harness/lib/paths";
+import { createFakePi } from "./fake-pi";
+
+const config = async (): Promise<HarnessConfig> => ({
+  isChild: false,
+  features: {
+    "hook-bridge": false,
+    subagent: false,
+    workflow: false,
+    "bit-task": false,
+    statusline: false,
+    "provider-log": false,
+    "asuku-notify": false,
+    "ask-user-question": false,
+  },
+  trust: { trustedRoots: [] },
+  paths: resolvePaths(await mkdtemp(join(tmpdir(), "pi-ask-reminder-"))),
+});
+
+const reminders = (messages: readonly unknown[]) =>
+  messages.filter(
+    (message) =>
+      typeof message === "object" &&
+      message !== null &&
+      "customType" in message &&
+      message.customType === PERMISSION_ASK_REMINDER_CUSTOM_TYPE,
+  );
+
+describe("permission ASK reminder", () => {
+  test("injects one hidden reminder after every three displayed confirmations", async () => {
+    const pi = createFakePi();
+    const reminder = setupPermissionAskReminder(pi);
+
+    for (let index = 1; index < PERMISSION_ASK_REMINDER_THRESHOLD; index += 1) {
+      reminder.recordDisplayedConfirmation();
+    }
+    expect(await pi.emitContext([])).toEqual([]);
+
+    reminder.recordDisplayedConfirmation();
+    const first = reminders(await pi.emitContext([]));
+    expect(first).toHaveLength(1);
+    expect(first[0]).toMatchObject({
+      role: "custom",
+      customType: PERMISSION_ASK_REMINDER_CUSTOM_TYPE,
+      display: false,
+    });
+    expect(JSON.stringify(first[0])).toContain(
+      "3 Bash permission confirmations",
+    );
+    expect(JSON.stringify(first[0])).toContain("Do not weaken or bypass");
+    expect(reminders(await pi.emitContext([]))).toEqual([]);
+
+    for (let index = 0; index < PERMISSION_ASK_REMINDER_THRESHOLD; index += 1) {
+      reminder.recordDisplayedConfirmation();
+    }
+    expect(JSON.stringify(reminders(await pi.emitContext([]))[0])).toContain(
+      "6 Bash permission confirmations",
+    );
+
+    await pi.emitSessionStart({ type: "session_start", reason: "resume" });
+    reminder.recordDisplayedConfirmation();
+    reminder.recordDisplayedConfirmation();
+    expect(await pi.emitContext([])).toEqual([]);
+  });
+
+  test("counts accepted policy challenges but excludes UI-less not-shown outcomes", async () => {
+    const value = await config();
+    const pi = createFakePi({ cwd: value.paths.home });
+    setupHarness(pi, value);
+
+    for (let index = 0; index < PERMISSION_ASK_REMINDER_THRESHOLD; index += 1) {
+      pi.queueConfirm(true);
+      expect(
+        await pi.emitToolCall({
+          type: "tool_call",
+          toolName: "bash",
+          toolCallId: `displayed-${index}`,
+          input: { command: "git push origin main" },
+        }),
+      ).toBeUndefined();
+    }
+    expect(reminders(await pi.emitContext([]))).toHaveLength(1);
+    await pi.emitSessionShutdown();
+
+    const headlessValue = await config();
+    const headless = createFakePi({
+      cwd: headlessValue.paths.home,
+      hasUI: false,
+    });
+    setupHarness(headless, headlessValue);
+
+    for (let index = 0; index < PERMISSION_ASK_REMINDER_THRESHOLD; index += 1) {
+      expect(
+        await headless.emitToolCall({
+          type: "tool_call",
+          toolName: "bash",
+          toolCallId: `not-shown-${index}`,
+          input: { command: "git push origin main" },
+        }),
+      ).toMatchObject({ block: true });
+    }
+    expect(await headless.emitContext([])).toEqual([]);
+    await headless.emitSessionShutdown();
+  });
+});

--- a/tests/pi-harness/permission-audit.test.ts
+++ b/tests/pi-harness/permission-audit.test.ts
@@ -1,0 +1,1037 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import {
+  buildPermissionQualificationCandidates,
+  parsePermissionAuditJsonl,
+  summarizePermissionAudit,
+} from "../../pi/extensions/pi-harness/features/permission-audit/analysis";
+import {
+  buildPermissionCommand,
+  buildPermissionDecisionRecord,
+  fitPermissionDecisionRecord,
+  MAX_PERMISSION_AUDIT_RECORD_BYTES,
+  type PermissionAuditStage,
+  type PermissionDecisionRecordInput,
+} from "../../pi/extensions/pi-harness/features/permission-audit/model";
+import {
+  createPermissionAuditWriter,
+  permissionAuditLogFileName,
+  type PermissionAuditFileHandle,
+  type PermissionAuditWriter,
+} from "../../pi/extensions/pi-harness/features/permission-audit/writer";
+import type { HarnessConfig } from "../../pi/extensions/pi-harness/config";
+import {
+  PERMISSION_AUDIT_INVOCATION_ENV,
+  PERMISSION_AUDIT_LINEAGE_ENV,
+  PERMISSION_AUDIT_PARENT_SESSION_ENV,
+  PERMISSION_AUDIT_RUN_ENV,
+  setupPermissionAudit,
+} from "../../pi/extensions/pi-harness/features/permission-audit/index";
+import setupPermissionPolicy from "../../pi/extensions/pi-harness/features/permission-policy/index";
+import { createPermissionTaskTracker } from "../../pi/extensions/pi-harness/features/permission-policy/context";
+import { CHILD_PERMISSION_SIGNAL_ENV } from "../../pi/extensions/pi-harness/features/permission-policy/block";
+import { sanitizeChildEnv } from "../../pi/extensions/pi-harness/lib/child-env";
+import { resolvePaths } from "../../pi/extensions/pi-harness/lib/paths";
+import { createFakePi } from "./fake-pi";
+import { cleanupTestDirectory, setupTestDirectory } from "../test-helpers";
+
+const roots: string[] = [];
+const WRITER_ID = "123e4567-e89b-42d3-a456-426614174000";
+const OTHER_WRITER_ID = "223e4567-e89b-42d3-a456-426614174000";
+const NOW = new Date("2026-07-23T12:00:00.000Z");
+
+const tempRoot = async (prefix: string): Promise<string> => {
+  const root = await setupTestDirectory(prefix);
+  roots.push(root);
+  return root;
+};
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map(cleanupTestDirectory));
+});
+
+const baseInput = (
+  stages: readonly PermissionAuditStage[],
+  overrides: Partial<PermissionDecisionRecordInput> = {},
+): PermissionDecisionRecordInput => ({
+  timestamp: NOW.toISOString(),
+  decisionId: "323e4567-e89b-42d3-a456-426614174000",
+  writerInstanceId: WRITER_ID,
+  sequence: 1,
+  pid: 123,
+  isChild: false,
+  lineage: { lineageId: WRITER_ID, source: "generated" },
+  sessionId: "session-1",
+  toolCallId: "tool-1",
+  command: buildPermissionCommand("git status --short"),
+  cwd: "/workspace/acme",
+  task: {
+    correlation: "task",
+    task: {
+      text: "Inspect the repository",
+      source: "interactive",
+      fingerprint: "task-fingerprint",
+    },
+  },
+  runEvidence: {
+    assistantText: "I will inspect status.",
+    priorToolResults: [],
+    fingerprint: "run-fingerprint",
+  },
+  stages,
+  boundaryDisposition: "release",
+  terminalReasonCode: "permission-chain-released",
+  ...overrides,
+});
+
+const allowedStage: PermissionAuditStage = {
+  type: "deterministic",
+  phase: "initial",
+  verdict: "allow",
+  basis: "configured-allow",
+  reasonCode: "configured-allow",
+  ruleSource: "Bash(git status:*)",
+};
+
+describe("permission audit record model", () => {
+  test("derives terminal decisions from challenges rather than intermediate ASK", () => {
+    const intermediateAsk: PermissionAuditStage = {
+      type: "deterministic",
+      phase: "initial",
+      verdict: "ask",
+      basis: "git-c-unverified",
+      reasonCode: "git-c-unverified",
+    };
+    const verified: PermissionAuditStage = {
+      type: "scope",
+      phase: "git-c",
+      verdict: "allow",
+      reasonCode: "git-c-listed-worktree",
+    };
+    expect(
+      buildPermissionDecisionRecord(baseInput([intermediateAsk, verified]))
+        .effectiveDecision,
+    ).toBe("allow");
+
+    const accepted: PermissionAuditStage = {
+      type: "confirmation",
+      phase: "judge",
+      challengeSource: "local-judge",
+      status: "accepted",
+      reasonCode: "judge-ask",
+    };
+    expect(
+      buildPermissionDecisionRecord(baseInput([intermediateAsk, accepted]))
+        .effectiveDecision,
+    ).toBe("ask");
+
+    const denied: PermissionAuditStage = {
+      type: "deterministic",
+      phase: "initial",
+      verdict: "deny",
+      basis: "configured-deny",
+      reasonCode: "configured-deny",
+    };
+    expect(
+      buildPermissionDecisionRecord(
+        baseInput([denied], { boundaryDisposition: "block" }),
+      ).effectiveDecision,
+    ).toBe("deny");
+    expect(
+      buildPermissionDecisionRecord(
+        baseInput([accepted, denied], { boundaryDisposition: "block" }),
+      ).effectiveDecision,
+    ).toBe("deny");
+  });
+
+  test("retains full corpus canaries and emits a bounded oversized marker", () => {
+    const canary = "secret-token-CANARY";
+    const record = buildPermissionDecisionRecord(
+      baseInput([allowedStage], {
+        command: buildPermissionCommand(`printf %s ${canary}`),
+        task: {
+          correlation: "task",
+          task: { text: `task ${canary}`, source: "rpc" },
+        },
+        runEvidence: {
+          assistantText: `assistant ${canary}`,
+          priorToolResults: [],
+          fingerprint: "canary-run",
+        },
+      }),
+    );
+    expect(JSON.stringify(record)).toContain(canary);
+
+    const oversized = fitPermissionDecisionRecord(
+      baseInput([allowedStage], {
+        command: buildPermissionCommand(
+          "x".repeat(MAX_PERMISSION_AUDIT_RECORD_BYTES),
+        ),
+      }),
+    );
+    expect(oversized.command.kind).toBe("omitted");
+    expect(oversized.boundaryDisposition).toBe("block");
+    expect(oversized.terminalReasonCode).toBe("record-too-large");
+    expect(Buffer.byteLength(JSON.stringify(oversized))).toBeLessThan(
+      MAX_PERMISSION_AUDIT_RECORD_BYTES,
+    );
+
+    const oversizedIdentifiers = fitPermissionDecisionRecord(
+      baseInput([allowedStage], {
+        sessionId: "s".repeat(MAX_PERMISSION_AUDIT_RECORD_BYTES),
+        toolCallId: "t".repeat(MAX_PERMISSION_AUDIT_RECORD_BYTES),
+      }),
+    );
+    expect(oversizedIdentifiers).toMatchObject({
+      command: { kind: "omitted", reason: "record-too-large" },
+      boundaryDisposition: "block",
+      terminalReasonCode: "record-too-large",
+    });
+    expect(oversizedIdentifiers.sessionId).toMatch(/^sha256:/);
+    expect(oversizedIdentifiers.toolCallId).toMatch(/^sha256:/);
+    expect(
+      Buffer.byteLength(JSON.stringify(oversizedIdentifiers)),
+    ).toBeLessThan(MAX_PERMISSION_AUDIT_RECORD_BYTES);
+  });
+});
+
+describe("permission audit analysis", () => {
+  test("parses records, diagnoses a truncated tail, aggregates, and emits unlabeled candidates", () => {
+    const judge: PermissionAuditStage = {
+      type: "judge",
+      phase: "fallback",
+      verdict: "ask",
+      reasonCode: "judge-ask",
+      outcome: "ask",
+      source: "live",
+      gates: { safety: "ALLOW", relevance: "ASK" },
+    };
+    const confirmation: PermissionAuditStage = {
+      type: "confirmation",
+      phase: "fallback",
+      challengeSource: "local-judge",
+      status: "accepted",
+      reasonCode: "judge-ask",
+    };
+    const record = buildPermissionDecisionRecord(
+      baseInput([judge, confirmation]),
+    );
+    const parsed = parsePermissionAuditJsonl(
+      `${JSON.stringify(record)}\n{"schema":"pi-harness/bash-permission"`,
+    );
+    expect(parsed.records).toEqual([record]);
+    expect(parsed.diagnostics).toEqual([{ line: 2, code: "truncated-tail" }]);
+
+    const summary = summarizePermissionAudit(parsed.records);
+    expect(summary.byDecision.ask).toBe(1);
+    expect(summary.byJudgeGates["live:ALLOW/ASK"]).toBe(1);
+    expect(summary.byConfirmation.accepted).toBe(1);
+    expect(summary.byProcessKind.parent).toBe(1);
+
+    const [candidate] = buildPermissionQualificationCandidates(parsed.records);
+    expect(candidate?.command).toBe("git status --short");
+    expect(candidate).not.toHaveProperty("expected");
+  });
+
+  test("rejects unrelated and malformed nested V1 records", () => {
+    const result = parsePermissionAuditJsonl('{"kind":"provider-request"}\n');
+    expect(result.records).toEqual([]);
+    expect(result.diagnostics).toEqual([{ line: 1, code: "invalid-record" }]);
+
+    const record = buildPermissionDecisionRecord(baseInput([allowedStage]));
+    const malformed = [
+      { ...record, command: { kind: "malformed", sha256: "bad", bytes: -1 } },
+      { ...record, task: { correlation: "task" } },
+      {
+        ...record,
+        process: {
+          ...record.process,
+          lineage: { lineageId: WRITER_ID, source: "forged" },
+        },
+      },
+      {
+        ...record,
+        stages: [
+          {
+            type: "judge",
+            phase: "fallback",
+            verdict: "allow",
+            reasonCode: "judge-allow",
+            outcome: "allow",
+            gates: { safety: "YES", relevance: "ALLOW" },
+          },
+        ],
+      },
+    ];
+    const parsed = parsePermissionAuditJsonl(
+      `${malformed.map((value) => JSON.stringify(value)).join("\n")}\n`,
+    );
+    expect(parsed.records).toEqual([]);
+    expect(parsed.diagnostics).toEqual(
+      malformed.map((_, index) => ({
+        line: index + 1,
+        code: "invalid-record",
+      })),
+    );
+  });
+});
+
+describe("permission audit writer", () => {
+  test("writes one private per-writer JSONL file and enforces directory mode", async () => {
+    const root = await tempRoot("pi-permission-audit-writer");
+    const logDir = join(root, "logs");
+    const writer = createPermissionAuditWriter(logDir, {
+      isChild: false,
+      writerInstanceId: WRITER_ID,
+      dependencies: { now: () => NOW },
+    });
+    const record = await writer.append((identity) =>
+      fitPermissionDecisionRecord(
+        baseInput([allowedStage], {
+          ...identity,
+          writerInstanceId: identity.writerInstanceId,
+        }),
+      ),
+    );
+    await writer.close();
+
+    const path = join(logDir, permissionAuditLogFileName(NOW, WRITER_ID));
+    expect(JSON.parse((await fs.readFile(path, "utf8")).trim())).toEqual(
+      record,
+    );
+    expect((await fs.stat(logDir)).mode & 0o777).toBe(0o700);
+    expect((await fs.stat(path)).mode & 0o777).toBe(0o600);
+  });
+
+  test("drains an already queued append before close", async () => {
+    const root = await tempRoot("pi-permission-audit-close-drain");
+    const logDir = join(root, "logs");
+    const writer = createPermissionAuditWriter(logDir, {
+      isChild: false,
+      writerInstanceId: WRITER_ID,
+      dependencies: { now: () => NOW },
+    });
+    const pending = writer.append((identity) =>
+      fitPermissionDecisionRecord(baseInput([allowedStage], identity)),
+    );
+    const closing = writer.close();
+    await expect(pending).resolves.toMatchObject({ toolCallId: "tool-1" });
+    await expect(closing).resolves.toBeUndefined();
+  });
+
+  test("refuses a symlinked log directory", async () => {
+    const root = await tempRoot("pi-permission-audit-symlink");
+    const target = join(root, "target");
+    const logDir = join(root, "logs");
+    await fs.mkdir(target);
+    await fs.symlink(target, logDir);
+    const writer = createPermissionAuditWriter(logDir, {
+      isChild: false,
+      writerInstanceId: WRITER_ID,
+      dependencies: { now: () => NOW },
+    });
+    await expect(
+      writer.append((identity) =>
+        fitPermissionDecisionRecord(baseInput([allowedStage], identity)),
+      ),
+    ).rejects.toThrow();
+    await writer.close();
+    expect(await fs.readdir(target)).toEqual([]);
+  });
+
+  test("rolls back a partial failed line and can append the next record", async () => {
+    const root = await tempRoot("pi-permission-audit-partial");
+    const logDir = join(root, "logs");
+    let injected = false;
+    const writer = createPermissionAuditWriter(logDir, {
+      isChild: false,
+      writerInstanceId: WRITER_ID,
+      dependencies: {
+        now: () => NOW,
+        async open(path, flags, mode) {
+          const handle = await fs.open(path, flags, mode);
+          if (!path.endsWith(".jsonl")) return handle;
+          const wrapped: PermissionAuditFileHandle = {
+            stat: () => handle.stat(),
+            chmod: (value) => handle.chmod(value),
+            truncate: (value) => handle.truncate(value),
+            close: () => handle.close(),
+            async write(buffer, offset, length, position) {
+              if (!injected) {
+                injected = true;
+                await handle.write(
+                  buffer,
+                  offset,
+                  Math.max(1, Math.floor(length / 2)),
+                  position,
+                );
+                throw new Error("injected partial write");
+              }
+              return handle.write(buffer, offset, length, position);
+            },
+          };
+          return wrapped;
+        },
+      },
+    });
+    await expect(
+      writer.append((identity) =>
+        fitPermissionDecisionRecord(baseInput([allowedStage], identity)),
+      ),
+    ).rejects.toThrow("injected partial write");
+    const second = await writer.append((identity) =>
+      fitPermissionDecisionRecord(
+        baseInput([allowedStage], { ...identity, toolCallId: "tool-2" }),
+      ),
+    );
+    await writer.close();
+
+    const path = join(logDir, permissionAuditLogFileName(NOW, WRITER_ID));
+    const lines = (await fs.readFile(path, "utf8")).trim().split("\n");
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0] ?? "")).toEqual(second);
+    expect(second.sequence).toBe(2);
+  });
+
+  test("poisons the writer when partial-write rollback fails", async () => {
+    const root = await tempRoot("pi-permission-audit-poison");
+    const logDir = join(root, "logs");
+    let writes = 0;
+    let truncates = 0;
+    let closes = 0;
+    const writer = createPermissionAuditWriter(logDir, {
+      isChild: false,
+      writerInstanceId: WRITER_ID,
+      dependencies: {
+        now: () => NOW,
+        async open(path, flags, mode) {
+          const handle = await fs.open(path, flags, mode);
+          if (!path.endsWith(".jsonl")) return handle;
+          return {
+            stat: () => handle.stat(),
+            chmod: (value) => handle.chmod(value),
+            async truncate() {
+              truncates += 1;
+              throw new Error("injected truncate failure");
+            },
+            async close() {
+              closes += 1;
+              await handle.close();
+            },
+            async write(buffer, offset, _length, position) {
+              writes += 1;
+              await handle.write(buffer, offset, 1, position);
+              throw new Error("injected write failure");
+            },
+          };
+        },
+      },
+    });
+    await expect(
+      writer.append((identity) =>
+        fitPermissionDecisionRecord(baseInput([allowedStage], identity)),
+      ),
+    ).rejects.toThrow("injected write failure");
+    await expect(
+      writer.append((identity) =>
+        fitPermissionDecisionRecord(baseInput([allowedStage], identity)),
+      ),
+    ).rejects.toThrow("poisoned");
+    await writer.close();
+    await writer.close();
+    expect({ writes, truncates, closes }).toEqual({
+      writes: 1,
+      truncates: 1,
+      closes: 1,
+    });
+  });
+
+  test("removes only safe expired files and leaves hostile entries", async () => {
+    const root = await tempRoot("pi-permission-audit-retention");
+    const logDir = join(root, "logs");
+    await fs.mkdir(logDir, { mode: 0o700 });
+    const expired = join(
+      logDir,
+      `permission-2026-01-01-${OTHER_WRITER_ID}.jsonl`,
+    );
+    const loose = join(
+      logDir,
+      "permission-2026-01-02-323e4567-e89b-42d3-a456-426614174000.jsonl",
+    );
+    const cutoffDay = join(
+      logDir,
+      "permission-2026-04-24-623e4567-e89b-42d3-a456-426614174000.jsonl",
+    );
+    const justExpired = join(
+      logDir,
+      "permission-2026-04-23-923e4567-e89b-42d3-a456-426614174000.jsonl",
+    );
+    const ownerMismatch = join(
+      logDir,
+      "permission-2026-01-05-723e4567-e89b-42d3-a456-426614174000.jsonl",
+    );
+    const malformedName = join(
+      logDir,
+      "permission-2026-02-31-823e4567-e89b-42d3-a456-426614174000.jsonl",
+    );
+    const victim = join(root, "victim");
+    const symlink = join(
+      logDir,
+      "permission-2026-01-03-423e4567-e89b-42d3-a456-426614174000.jsonl",
+    );
+    const hardlinkSource = join(root, "hardlink-source");
+    const hardlink = join(
+      logDir,
+      "permission-2026-01-04-523e4567-e89b-42d3-a456-426614174000.jsonl",
+    );
+    await fs.writeFile(expired, "{}\n", { mode: 0o600 });
+    await fs.writeFile(loose, "{}\n", { mode: 0o644 });
+    await fs.writeFile(cutoffDay, "{}\n", { mode: 0o600 });
+    await fs.writeFile(justExpired, "{}\n", { mode: 0o600 });
+    await fs.writeFile(ownerMismatch, "{}\n", { mode: 0o600 });
+    await fs.writeFile(malformedName, "{}\n", { mode: 0o600 });
+    await fs.writeFile(victim, "victim");
+    await fs.symlink(victim, symlink);
+    await fs.writeFile(hardlinkSource, "{}\n", { mode: 0o600 });
+    await fs.link(hardlinkSource, hardlink);
+
+    const uid = process.getuid?.();
+    const lstatWithOwnerMismatch = (async (
+      path: Parameters<typeof fs.lstat>[0],
+    ) => {
+      const stats = await fs.lstat(path);
+      if (uid === undefined || String(path) !== ownerMismatch) return stats;
+      return new Proxy(stats, {
+        get(target, property, receiver) {
+          if (property === "uid") return uid + 1;
+          const value = Reflect.get(target, property, receiver);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+    }) as typeof fs.lstat;
+    const writer = createPermissionAuditWriter(logDir, {
+      isChild: false,
+      writerInstanceId: WRITER_ID,
+      dependencies: {
+        now: () => NOW,
+        ...(uid === undefined
+          ? {}
+          : { getuid: () => uid, lstat: lstatWithOwnerMismatch }),
+      },
+    });
+    await writer.append((identity) =>
+      fitPermissionDecisionRecord(baseInput([allowedStage], identity)),
+    );
+    await writer.close();
+
+    await expect(fs.access(expired)).rejects.toThrow();
+    await expect(fs.access(justExpired)).rejects.toThrow();
+    await fs.access(loose);
+    await fs.access(cutoffDay);
+    if (uid === undefined) {
+      await expect(fs.access(ownerMismatch)).rejects.toThrow();
+    } else {
+      await fs.access(ownerMismatch);
+    }
+    await fs.access(malformedName);
+    await fs.access(symlink);
+    await fs.access(hardlink);
+    expect(await fs.readFile(victim, "utf8")).toBe("victim");
+  });
+
+  test("suppresses retention in children and rotates at the UTC day boundary", async () => {
+    const root = await tempRoot("pi-permission-audit-child-retention");
+    const logDir = join(root, "logs");
+    await fs.mkdir(logDir, { mode: 0o700 });
+    const expired = join(
+      logDir,
+      `permission-2026-01-01-${OTHER_WRITER_ID}.jsonl`,
+    );
+    await fs.writeFile(expired, "{}\n", { mode: 0o600 });
+    let now = NOW;
+    const writer = createPermissionAuditWriter(logDir, {
+      isChild: true,
+      writerInstanceId: WRITER_ID,
+      dependencies: { now: () => now },
+    });
+    await writer.append((identity) =>
+      fitPermissionDecisionRecord(baseInput([allowedStage], identity)),
+    );
+    now = new Date("2026-07-24T00:00:00.000Z");
+    await writer.append((identity) =>
+      fitPermissionDecisionRecord(
+        baseInput([allowedStage], { ...identity, toolCallId: "tool-2" }),
+      ),
+    );
+    await writer.close();
+
+    await fs.access(expired);
+    expect(
+      (await fs.readdir(logDir)).filter((name) => name.includes(WRITER_ID)),
+    ).toHaveLength(2);
+  });
+});
+
+const harnessConfig = (home: string): HarnessConfig => ({
+  isChild: false,
+  features: {
+    "hook-bridge": false,
+    subagent: false,
+    workflow: false,
+    "bit-task": false,
+    statusline: false,
+    "provider-log": false,
+    "asuku-notify": false,
+    "ask-user-question": false,
+  },
+  trust: { trustedRoots: [] },
+  paths: resolvePaths(home),
+});
+
+const activateTask = async (
+  pi: ReturnType<typeof createFakePi>,
+): Promise<void> => {
+  await pi.emitInput({
+    type: "input",
+    text: "Inspect and update the repository",
+    source: "interactive",
+  });
+  await pi.emitBeforeAgentStart({
+    type: "before_agent_start",
+    prompt: "Inspect and update the repository",
+    systemPrompt: "base",
+  });
+};
+
+describe("permission audit policy lifecycle", () => {
+  test("writes exactly one terminal record for allow, accepted ASK, and deny", async () => {
+    const home = await tempRoot("pi-permission-audit-policy");
+    const config = harnessConfig(home);
+    const pi = createFakePi({ cwd: home, sessionId: "audit-session" });
+    const taskTracker = createPermissionTaskTracker();
+    const audit = setupPermissionAudit(pi, config, { taskTracker });
+    const blocker = (reason: string) => ({ block: true as const, reason });
+    setupPermissionPolicy(pi, config, {
+      taskTracker,
+      permissionAudit: audit,
+      blockToolCall: blocker,
+    });
+    audit.registerTail(pi, blocker);
+    await activateTask(pi);
+
+    expect(
+      await pi.emitToolCall({
+        type: "tool_call",
+        toolName: "bash",
+        toolCallId: "allow-1",
+        input: { command: "bun test" },
+      }),
+    ).toBeUndefined();
+
+    pi.queueConfirm(true);
+    expect(
+      await pi.emitToolCall({
+        type: "tool_call",
+        toolName: "bash",
+        toolCallId: "ask-1",
+        input: { command: "git push origin main" },
+      }),
+    ).toBeUndefined();
+
+    expect(
+      await pi.emitToolCall({
+        type: "tool_call",
+        toolName: "bash",
+        toolCallId: "deny-1",
+        input: { command: "bit relay serve" },
+      }),
+    ).toMatchObject({ block: true });
+    await pi.emitSessionShutdown();
+
+    const files = (await fs.readdir(config.paths.logDir)).filter((name) =>
+      name.startsWith("permission-"),
+    );
+    expect(files).toHaveLength(1);
+    const parsed = parsePermissionAuditJsonl(
+      await fs.readFile(join(config.paths.logDir, files[0] ?? ""), "utf8"),
+    );
+    expect(parsed.diagnostics).toEqual([]);
+    expect(parsed.records).toHaveLength(3);
+    expect(
+      parsed.records.map((record) => ({
+        id: record.toolCallId,
+        decision: record.effectiveDecision,
+        disposition: record.boundaryDisposition,
+      })),
+    ).toEqual([
+      { id: "allow-1", decision: "allow", disposition: "release" },
+      { id: "ask-1", decision: "ask", disposition: "release" },
+      { id: "deny-1", decision: "deny", disposition: "block" },
+    ]);
+    expect(parsed.records[0]?.task.task?.text).toBe(
+      "Inspect and update the repository",
+    );
+    expect(parsed.records[1]?.stages).toContainEqual(
+      expect.objectContaining({
+        type: "confirmation",
+        status: "accepted",
+      }),
+    );
+  });
+
+  test("records rejected ASK at the challenge site without reaching tail release", async () => {
+    const home = await tempRoot("pi-permission-audit-reject");
+    const config = harnessConfig(home);
+    const pi = createFakePi({ cwd: home });
+    const taskTracker = createPermissionTaskTracker();
+    const audit = setupPermissionAudit(pi, config, { taskTracker });
+    const blocker = (reason: string) => ({ block: true as const, reason });
+    setupPermissionPolicy(pi, config, {
+      taskTracker,
+      permissionAudit: audit,
+      blockToolCall: blocker,
+    });
+    audit.registerTail(pi, blocker);
+    await activateTask(pi);
+    pi.queueConfirm(false);
+
+    expect(
+      await pi.emitToolCall({
+        type: "tool_call",
+        toolName: "bash",
+        toolCallId: "ask-rejected",
+        input: { command: "git push origin main" },
+      }),
+    ).toMatchObject({ block: true });
+    await pi.emitSessionShutdown();
+
+    const [file] = await fs.readdir(config.paths.logDir);
+    const parsed = parsePermissionAuditJsonl(
+      await fs.readFile(join(config.paths.logDir, file ?? ""), "utf8"),
+    );
+    expect(parsed.records).toHaveLength(1);
+    expect(parsed.records[0]).toMatchObject({
+      toolCallId: "ask-rejected",
+      effectiveDecision: "ask",
+      boundaryDisposition: "block",
+    });
+    expect(parsed.records[0]?.stages).toContainEqual(
+      expect.objectContaining({ type: "confirmation", status: "rejected" }),
+    );
+  });
+
+  test("propagates real parent-child audit env without recording the permission token", async () => {
+    const home = await tempRoot("pi-permission-audit-child-lineage");
+    const parentConfig = harnessConfig(home);
+    const parentPi = createFakePi({ cwd: home, sessionId: "parent-session" });
+    const parentAudit = setupPermissionAudit(parentPi, parentConfig, {
+      taskTracker: createPermissionTaskTracker(),
+      env: {},
+      randomUUID: () => WRITER_ID,
+    });
+    const auditOverrides = parentAudit.childEnvironment(
+      parentPi.ctx,
+      "invocation-1",
+      "run-1",
+    );
+    expect(
+      parentAudit.childEnvironment(parentPi.ctx, "invalid id", "also invalid"),
+    ).toEqual({
+      [PERMISSION_AUDIT_LINEAGE_ENV]: WRITER_ID,
+      [PERMISSION_AUDIT_PARENT_SESSION_ENV]: "parent-session",
+    });
+    const permissionToken = "permission-signal-secret";
+    const childEnv = sanitizeChildEnv(
+      { NODE_OPTIONS: "--require attacker", AMBIENT: "kept" },
+      {
+        ...auditOverrides,
+        [CHILD_PERMISSION_SIGNAL_ENV]: permissionToken,
+      },
+      { cwd: home },
+    );
+    expect(childEnv.NODE_OPTIONS).toBeUndefined();
+    expect(childEnv[CHILD_PERMISSION_SIGNAL_ENV]).toBe(permissionToken);
+
+    const config = { ...parentConfig, isChild: true };
+    const pi = createFakePi({ cwd: home, sessionId: "child-session" });
+    const taskTracker = createPermissionTaskTracker();
+    const audit = setupPermissionAudit(pi, config, {
+      taskTracker,
+      env: childEnv,
+    });
+    const blocker = (reason: string) => ({ block: true as const, reason });
+    audit.registerTail(pi, blocker);
+
+    expect(
+      await pi.emitToolCall({
+        type: "tool_call",
+        toolName: "bash",
+        toolCallId: "child-allow",
+        input: { command: "printf child" },
+      }),
+    ).toBeUndefined();
+    await pi.emitSessionShutdown();
+
+    const [file] = await fs.readdir(config.paths.logDir);
+    const parsed = parsePermissionAuditJsonl(
+      await fs.readFile(join(config.paths.logDir, file ?? ""), "utf8"),
+    );
+    expect(parsed.records[0]).toMatchObject({
+      sessionId: "child-session",
+      process: {
+        isChild: true,
+        lineage: {
+          lineageId: WRITER_ID,
+          source: "harness-env",
+          parentSessionId: "parent-session",
+          childInvocationId: "invocation-1",
+          childRunId: "run-1",
+        },
+      },
+    });
+    expect(JSON.stringify(parsed.records[0])).not.toContain(
+      CHILD_PERMISSION_SIGNAL_ENV,
+    );
+    expect(JSON.stringify(parsed.records[0])).not.toContain(permissionToken);
+  });
+
+  test("regenerates invalid inherited lineage and omits invalid correlation IDs", async () => {
+    const home = await tempRoot("pi-permission-audit-invalid-lineage");
+    const config = { ...harnessConfig(home), isChild: true };
+    const pi = createFakePi({ cwd: home, sessionId: "child-session" });
+    const audit = setupPermissionAudit(pi, config, {
+      taskTracker: createPermissionTaskTracker(),
+      env: {
+        [PERMISSION_AUDIT_LINEAGE_ENV]: "not-a-uuid",
+        [PERMISSION_AUDIT_PARENT_SESSION_ENV]: "invalid parent id",
+        [PERMISSION_AUDIT_INVOCATION_ENV]: "invalid invocation id",
+        [PERMISSION_AUDIT_RUN_ENV]: "invalid run id",
+      },
+      randomUUID: () => OTHER_WRITER_ID,
+    });
+    audit.registerTail(pi, (reason) => ({ block: true as const, reason }));
+
+    expect(
+      await pi.emitToolCall({
+        type: "tool_call",
+        toolName: "bash",
+        toolCallId: "invalid-lineage",
+        input: { command: "printf child" },
+      }),
+    ).toBeUndefined();
+    await pi.emitSessionShutdown();
+
+    const [file] = await fs.readdir(config.paths.logDir);
+    const parsed = parsePermissionAuditJsonl(
+      await fs.readFile(join(config.paths.logDir, file ?? ""), "utf8"),
+    );
+    expect(parsed.records[0]?.process.lineage).toEqual({
+      lineageId: OTHER_WRITER_ID,
+      source: "generated",
+    });
+  });
+
+  test("blocks an oversized record with a persisted compact marker, not a sink warning", async () => {
+    const home = await tempRoot("pi-permission-audit-oversized");
+    const config = harnessConfig(home);
+    const pi = createFakePi({ cwd: home });
+    const taskTracker = createPermissionTaskTracker();
+    const audit = setupPermissionAudit(pi, config, { taskTracker });
+    const blocker = (reason: string) => ({ block: true as const, reason });
+    audit.registerTail(pi, blocker);
+
+    expect(
+      await pi.emitToolCall({
+        type: "tool_call",
+        toolName: "bash",
+        toolCallId: "oversized-record",
+        input: { command: "x".repeat(MAX_PERMISSION_AUDIT_RECORD_BYTES) },
+      }),
+    ).toEqual({
+      block: true,
+      reason:
+        "permission-audit: decision record exceeded 1 MiB; command blocked",
+    });
+    await pi.emitSessionShutdown();
+
+    expect(pi.notifications).toEqual([]);
+    const [file] = await fs.readdir(config.paths.logDir);
+    const parsed = parsePermissionAuditJsonl(
+      await fs.readFile(join(config.paths.logDir, file ?? ""), "utf8"),
+    );
+    expect(parsed.records[0]).toMatchObject({
+      toolCallId: "oversized-record",
+      command: { kind: "omitted", reason: "record-too-large" },
+      boundaryDisposition: "block",
+      terminalReasonCode: "record-too-large",
+    });
+  });
+
+  test("waits for persistence before later handlers and reuses duplicate finalization", async () => {
+    const home = await tempRoot("pi-permission-audit-release-order");
+    const config = harnessConfig(home);
+    const pi = createFakePi({ cwd: home });
+    const taskTracker = createPermissionTaskTracker();
+    let releaseAppend: (() => void) | undefined;
+    let appendStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      appendStarted = resolve;
+    });
+    const gate = new Promise<void>((resolve) => {
+      releaseAppend = resolve;
+    });
+    let appends = 0;
+    const writer: PermissionAuditWriter = {
+      writerInstanceId: WRITER_ID,
+      async append(build) {
+        appends += 1;
+        const record = build({
+          writerInstanceId: WRITER_ID,
+          sequence: appends,
+          timestamp: NOW.toISOString(),
+        });
+        appendStarted?.();
+        await gate;
+        return record;
+      },
+      close: async () => {},
+    };
+    const audit = setupPermissionAudit(pi, config, { taskTracker, writer });
+    const blocker = (reason: string) => ({ block: true as const, reason });
+    audit.registerTail(pi, blocker);
+    let laterHandlerCalls = 0;
+    pi.on("tool_call", () => {
+      laterHandlerCalls += 1;
+      return undefined;
+    });
+
+    const pending = pi.emitToolCall({
+      type: "tool_call",
+      toolName: "bash",
+      toolCallId: "ordered-release",
+      input: { command: "bun test" },
+    });
+    await started;
+    expect(laterHandlerCalls).toBe(0);
+    const concurrentDuplicate = audit.finalizeBlock(
+      "ordered-release",
+      "concurrent-duplicate",
+    );
+    releaseAppend?.();
+    await expect(pending).resolves.toBeUndefined();
+    await expect(concurrentDuplicate).resolves.toBe(true);
+    expect(laterHandlerCalls).toBe(1);
+    await expect(
+      audit.finalizeBlock("ordered-release", "late-duplicate"),
+    ).resolves.toBe(true);
+    expect(appends).toBe(1);
+
+    await expect(
+      pi.emitToolCall({
+        type: "tool_call",
+        toolName: "bash",
+        toolCallId: "ordered-release",
+        input: { command: "bun test" },
+      }),
+    ).resolves.toBeUndefined();
+    expect(appends).toBe(1);
+    expect(laterHandlerCalls).toBe(2);
+  });
+
+  test("finalizes pending shutdown transactions before closing the writer", async () => {
+    const home = await tempRoot("pi-permission-audit-shutdown");
+    const config = harnessConfig(home);
+    const pi = createFakePi({ cwd: home });
+    const taskTracker = createPermissionTaskTracker();
+    const events: string[] = [];
+    let written: ReturnType<typeof buildPermissionDecisionRecord> | undefined;
+    const writer: PermissionAuditWriter = {
+      writerInstanceId: WRITER_ID,
+      async append(build) {
+        events.push("append");
+        written = build({
+          writerInstanceId: WRITER_ID,
+          sequence: 1,
+          timestamp: NOW.toISOString(),
+        });
+        return written;
+      },
+      async close() {
+        events.push("close");
+      },
+    };
+    const audit = setupPermissionAudit(pi, config, { taskTracker, writer });
+    await pi.emitToolCall({
+      type: "tool_call",
+      toolName: "bash",
+      toolCallId: "pending-shutdown",
+      input: { command: "bun test" },
+    });
+    audit.registerTail(pi, (reason) => ({ block: true as const, reason }));
+    await pi.emitSessionShutdown();
+
+    expect(events).toEqual(["append", "close"]);
+    expect(written).toMatchObject({
+      boundaryDisposition: "block",
+      terminalReasonCode: "session-shutdown",
+      stages: [
+        {
+          type: "error",
+          component: "permission-audit",
+          phase: "session-shutdown",
+          verdict: "error",
+          reasonCode: "session-shutdown",
+        },
+      ],
+    });
+  });
+
+  test("blocks release and emits one generic warning when the sink fails", async () => {
+    const home = await tempRoot("pi-permission-audit-unavailable");
+    const config = harnessConfig(home);
+    const pi = createFakePi({ cwd: home });
+    const taskTracker = createPermissionTaskTracker();
+    const failingWriter: PermissionAuditWriter = {
+      writerInstanceId: WRITER_ID,
+      append: async () => {
+        throw new Error("secret sink failure");
+      },
+      close: async () => {},
+    };
+    const audit = setupPermissionAudit(pi, config, {
+      taskTracker,
+      writer: failingWriter,
+    });
+    const blocker = (reason: string) => ({ block: true as const, reason });
+    audit.registerTail(pi, blocker);
+
+    expect(
+      await pi.emitToolCall({
+        type: "tool_call",
+        toolName: "bash",
+        toolCallId: "audit-failed",
+        input: { command: "printf secret-token" },
+      }),
+    ).toEqual({
+      block: true,
+      reason:
+        "permission-audit: decision record could not be persisted; command blocked",
+    });
+    expect(
+      await pi.emitToolCall({
+        type: "tool_call",
+        toolName: "bash",
+        toolCallId: "audit-failed-again",
+        input: { command: "printf another-secret" },
+      }),
+    ).toMatchObject({ block: true });
+    expect(pi.notifications).toEqual([
+      {
+        message:
+          "Permission audit log is unavailable; Bash commands are blocked until logging is restored.",
+        level: "error",
+      },
+    ]);
+  });
+});

--- a/tests/pi-harness/permission-judge.test.ts
+++ b/tests/pi-harness/permission-judge.test.ts
@@ -225,7 +225,16 @@ describe("local Ollama permission judge", () => {
         runEvidence: runEvidence(),
         project: gitProject(),
       }),
-    ).toEqual({ kind: "allow", cached: false });
+    ).toMatchObject({
+      kind: "allow",
+      cached: false,
+      audit: {
+        source: "live",
+        gates: { safety: "ALLOW", relevance: "ALLOW" },
+        model: DEFAULT_PERMISSION_JUDGE_CONFIG.model,
+        policyVersion: "permission-judge-v6-safety-relevance",
+      },
+    });
     expect(upstream.received.map((request) => request.path)).toEqual([
       "/api/status",
       "/api/tags",
@@ -315,7 +324,14 @@ describe("local Ollama permission judge", () => {
       },
     });
 
-    expect(outcome).toEqual({ kind: "allow", cached: false });
+    expect(outcome).toMatchObject({
+      kind: "allow",
+      cached: false,
+      audit: {
+        source: "live",
+        gates: { safety: "ALLOW", relevance: "ALLOW" },
+      },
+    });
     expect(chatRequests(upstream)).toHaveLength(1);
   });
 
@@ -753,7 +769,11 @@ describe("local Ollama permission judge", () => {
     );
     expect(
       await createPermissionJudge(configFor(lossyUpstream)).judge("git status"),
-    ).toEqual({ kind: "allow", cached: false });
+    ).toMatchObject({
+      kind: "allow",
+      cached: false,
+      audit: { source: "live" },
+    });
 
     const upstream = await startRaw((socket) => {
       socket.end(
@@ -810,9 +830,13 @@ describe("local Ollama permission judge", () => {
     ]);
 
     expect(exitCode, stderr).toBe(0);
-    expect(JSON.parse(stdout.trim())).toEqual({
+    expect(JSON.parse(stdout.trim())).toMatchObject({
       version: "0.test.0",
-      outcome: { kind: "allow", cached: false },
+      outcome: {
+        kind: "allow",
+        cached: false,
+        audit: { source: "live" },
+      },
     });
     expect(target.received.map((request) => request.path)).toContain(
       "/api/version",
@@ -934,7 +958,11 @@ describe("local Ollama permission judge", () => {
         cwd: "/a",
         project: unavailableProject,
       }),
-    ).toEqual({ kind: "allow", cached: true });
+    ).toMatchObject({
+      kind: "allow",
+      cached: true,
+      audit: { source: "cache" },
+    });
     const secondCwd = await judge.judge("git status", {
       cwd: "/b",
       project: unavailableProject,
@@ -961,7 +989,11 @@ describe("local Ollama permission judge", () => {
         runEvidence: runEvidence("complete-run-a"),
         project: gitProject("complete-project-a"),
       }),
-    ).toEqual({ kind: "allow", cached: true });
+    ).toMatchObject({
+      kind: "allow",
+      cached: true,
+      audit: { source: "cache" },
+    });
 
     await judge.judge(command, {
       cwd: "/private/project",
@@ -1004,9 +1036,10 @@ describe("local Ollama permission judge", () => {
       project: gitProject("complete-project-a"),
     };
     expect((await judge.judge("make check", noTaskContext)).kind).toBe("allow");
-    expect(await judge.judge("make check", noTaskContext)).toEqual({
+    expect(await judge.judge("make check", noTaskContext)).toMatchObject({
       kind: "allow",
       cached: true,
+      audit: { source: "cache" },
     });
     expect(chatRequests(upstream)).toHaveLength(3);
   });

--- a/tests/pi-harness/workflow.test.ts
+++ b/tests/pi-harness/workflow.test.ts
@@ -8,6 +8,7 @@ import {
   formatChildPermissionSignal,
 } from "../../pi/extensions/pi-harness/features/permission-policy/block";
 import { ChildRunRegistry } from "../../pi/extensions/pi-harness/features/child-runs/registry";
+import type { PermissionAuditIntegration } from "../../pi/extensions/pi-harness/features/permission-audit/index";
 import setupWorkflow from "../../pi/extensions/pi-harness/features/workflow/index";
 import type {
   SpawnFunction,
@@ -277,8 +278,35 @@ describe("pi-harness workflow", () => {
         ? { text: "finding-one" }
         : { text: "finding-two" },
     );
-    const pi = createFakePi({ cwd: home });
-    setupWorkflow(pi, makeConfig(home), { spawnFn });
+    const pi = createFakePi({ cwd: home, sessionId: "workflow-parent" });
+    const registry = new ChildRunRegistry();
+    const childRuns = { registry, ensureVisible() {} };
+    const childCorrelations: Array<{
+      invocationId?: string;
+      runId?: string;
+    }> = [];
+    const permissionAudit = {
+      childEnvironment(
+        _ctx: CtxLike,
+        invocationId: string | undefined,
+        runId: string | undefined,
+      ) {
+        childCorrelations.push({ invocationId, runId });
+        return {
+          PI_HARNESS_AUDIT_LINEAGE_ID: "123e4567-e89b-42d3-a456-426614174000",
+          PI_HARNESS_AUDIT_PARENT_SESSION_ID: "workflow-parent",
+          ...(invocationId === undefined
+            ? {}
+            : { PI_HARNESS_AUDIT_INVOCATION_ID: invocationId }),
+          ...(runId === undefined ? {} : { PI_HARNESS_AUDIT_RUN_ID: runId }),
+        };
+      },
+    } as unknown as PermissionAuditIntegration;
+    setupWorkflow(pi, makeConfig(home), {
+      spawnFn,
+      childRuns,
+      permissionAudit,
+    });
 
     const result = await executeTool(
       findWorkflowTool(pi.tools),
@@ -302,6 +330,18 @@ describe("pi-harness workflow", () => {
     for (const record of records) {
       expect(record.command).toBe("pi");
       expect(record.options.env.PI_HARNESS_CHILD).toBe("1");
+      expect(record.options.env.PI_HARNESS_AUDIT_LINEAGE_ID).toBe(
+        "123e4567-e89b-42d3-a456-426614174000",
+      );
+      expect(record.options.env.PI_HARNESS_AUDIT_PARENT_SESSION_ID).toBe(
+        "workflow-parent",
+      );
+      expect(record.options.env.PI_HARNESS_AUDIT_INVOCATION_ID).toMatch(
+        /^[0-9a-f-]{36}$/,
+      );
+      expect(record.options.env.PI_HARNESS_AUDIT_RUN_ID).toMatch(
+        /^[0-9a-f-]{36}$/,
+      );
       expect(record.options.cwd).toBe(canonicalHome);
     }
     expect(text).toContain("2/2");
@@ -309,6 +349,12 @@ describe("pi-harness workflow", () => {
     expect(text).toContain("finding-two");
     expect(details.succeeded).toBe(2);
     expect(details.total).toBe(2);
+    expect(childCorrelations).toHaveLength(2);
+    expect(
+      new Set(childCorrelations.map((entry) => entry.invocationId)).size,
+    ).toBe(1);
+    expect(new Set(childCorrelations.map((entry) => entry.runId)).size).toBe(2);
+    registry.dispose();
   });
 
   test("enforces a read-only child tool profile", async () => {


### PR DESCRIPTION
## Summary

- add an always-on, fail-closed JSONL audit for the complete pi-harness Bash permission chain
- record stable deterministic, scope, judge/cache, hook, confirmation, and terminal provenance
- add private per-writer storage, safe 90-day retention, partial-write recovery, bounded oversized markers, and parent/child lineage
- provide strict parsing, aggregation, and unlabeled qualification-candidate helpers
- remind the parent agent after every three displayed Bash confirmations to narrow command shape without weakening policy or promoting approvals to ALLOW

## Safety properties

- permission records live under `~/.pi/agent/pi-harness/logs` with `0700` directory and `0600` files
- an ALLOW or accepted ASK is not released until its terminal audit record is appended
- append/serialization failures block Bash and emit only one generic warning
- parent and child processes use separate writer files; permission signal tokens are never recorded
- observed decisions remain telemetry and are not automatically treated as corpus labels

## Testing

- focused permission audit, hook integration, and ASK reminder: 34 passed
- isolated full suite: 1493 passed, 2 gated skips (`PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false bun test`)
- TypeScript, pi import/rule/schema checks, pi compatibility, and diff checks pass
- lint reports 0 errors (existing warnings remain)

A standard full-suite run encountered one environment-only pnpm fixture failure because the ambient token helper prevented pnpm 11 dependency auto-install; disabling that unrelated auto-install behavior made the complete suite pass.