### PR TITLE
feat(pi): accelerate built-in tools with Hearth

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "dotfiles",
       "dependencies": {
         "@clack/prompts": "0.11.0",
+        "@hearthdev/napi": "0.1.0",
         "c12": "3.2.0",
         "consola": "3.4.2",
         "defu": "6.1.4",
@@ -173,6 +174,16 @@
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.9", "", { "os": "win32", "cpu": "x64" }, "sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ=="],
 
     "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
+
+    "@hearthdev/napi": ["@hearthdev/napi@0.1.0", "", { "optionalDependencies": { "@hearthdev/napi-darwin-arm64": "0.1.0", "@hearthdev/napi-darwin-x64": "0.1.0", "@hearthdev/napi-linux-arm64-gnu": "0.1.0", "@hearthdev/napi-linux-x64-gnu": "0.1.0" } }, "sha512-obrufSxvnEBrn7SM72qW3xdMg6pqT/sC586k0JpNpIkX/oPIVJWIuToYQnQinwE8ca/QHZM9K9WhXBz/M+G3nQ=="],
+
+    "@hearthdev/napi-darwin-arm64": ["@hearthdev/napi-darwin-arm64@0.1.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-3vg3ykiPVCNnL54+Pnnmy0j4X9qPsQQuJzZ5ba3K362KYXCyhD8u9knEQKlqJNNGL/BQT2C0y/MH4ODdJvCaow=="],
+
+    "@hearthdev/napi-darwin-x64": ["@hearthdev/napi-darwin-x64@0.1.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-rVSQ7rT//l8vhrFHnCc/jaN7bdqlsx6ZgW34p6tdPNNoAYoNt9MPzyvmP5Q+eezH99mccNpjyPjg1blWQQBQbQ=="],
+
+    "@hearthdev/napi-linux-arm64-gnu": ["@hearthdev/napi-linux-arm64-gnu@0.1.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-FUDNTOjubtnEaWL4FJfWdciGO0YWqrAnzzXMduIm8g7JFb0JRu92Rg67/RdPW+5rtovbne8KpUgqIreuxUkEiw=="],
+
+    "@hearthdev/napi-linux-x64-gnu": ["@hearthdev/napi-linux-x64-gnu@0.1.0", "", { "os": "linux", "cpu": "x64" }, "sha512-aS6smaXHMsSk+ZCi25YWNyXPPwjplqWBCLAGQVluR+7dLFdYUwGMkeMM9g707DURhXyD9gUE6eofOrbmBK2eTA=="],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 

--- a/dotfiles.config.ts
+++ b/dotfiles.config.ts
@@ -154,6 +154,11 @@ export default defineConfig({
       type: "directory",
     },
     {
+      source: "./pi/extensions/hearth-tools",
+      target: "~/.pi/agent/extensions/hearth-tools",
+      type: "directory",
+    },
+    {
       source: "./pi/extensions/codex-web",
       target: "~/.pi/agent/extensions/codex-web",
       type: "directory",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "bun run src/index.ts",
     "build": "bun build src/index.ts --outdir=dist --target=bun",
+    "benchmark:hearth-tools": "bun scripts/benchmark-hearth-tools.ts",
     "test": "bun test",
     "lint": "oxlint",
     "lint:sh": "if command -v shellcheck >/dev/null 2>&1; then shellcheck -x bin/svgshow config/zellij/copy-capture.sh config/zellij/translate-popup.sh claude/.claude/statusline.sh claude/.claude/hooks/lib/statusline_checks_lib.sh claude/.claude/hooks/lib/statusline_checks_run.sh claude/.claude/hooks/session_start/statusline_checks.sh claude/.claude/hooks/stop/statusline_checks.sh claude/.claude/hooks/post_tool_use/coding_cycle.sh claude/.claude/hooks/task-completed/bit-issue-update.sh && find codex/hooks -type f -name '*.sh' -exec shellcheck -x {} +; else echo 'shellcheck not installed; skipping shell lint. Install with: mise use -g github:koalaman/shellcheck'; fi",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@clack/prompts": "0.11.0",
+    "@hearthdev/napi": "0.1.0",
     "c12": "3.2.0",
     "consola": "3.4.2",
     "defu": "6.1.4",

--- a/pi/README.md
+++ b/pi/README.md
@@ -157,9 +157,11 @@ uses the verified read-only route described above.
 `pi/extensions/hearth-tools` pins `@hearthdev/napi` exactly to `0.1.0` and
 constructs one in-process `HearthEngine` per pi process. Parent pi and every
 subagent/workflow child have separate resident caches and warm-shell pools;
-`/reload` reuses the process Engine. BTW keeps extension/package discovery off
-but receives a custom Hearth-backed `read`; its active tools remain `read` and
-`ls`.
+`/reload` reuses the process Engine when every Engine option is unchanged. A
+config, cwd, or inherited shell change during reload fails with a bounded
+restart-required diagnostic instead of silently retaining old settings. BTW
+keeps extension/package discovery off but receives a custom Hearth-backed
+`read`; its active tools remain `read` and `ls`.
 
 The checked-in maximum-speed defaults are:
 
@@ -173,15 +175,22 @@ The checked-in maximum-speed defaults are:
 ```
 
 Override these fields, plus optional `maxCachedFiles`, in
-`~/.pi/agent/hearth-tools.local.json`. Invalid config, a missing/incompatible
-native addon, or a competing override for one of the five names terminates pi
-at startup with exit code 1; there is no built-in fallback. Registration
-restores the prior active names, so replacing `grep` does not enable it.
+`~/.pi/agent/hearth-tools.local.json`; unknown keys are rejected. Invalid
+config, a missing/incompatible native addon, or an effective competing override
+for one of the five names terminates pi at startup with exit code 1; there is no
+built-in fallback. Registration restores the prior active names, so replacing
+`grep` does not enable it. Pi 0.80.7 exposes only the first effective tool per
+name: a later inert losing registration cannot be enumerated, but it also cannot
+execute. Hearth checks effective ownership before registration, immediately
+after registration, and before each agent turn.
 
-`trustCache` is a single-writer optimization. Hearth write/edit operations are
-cache-coherent. Tool Bash and user Bash (`!`/`!!`) clear all caches after every
-outcome, including nonzero, timeout, abort, and indeterminate. External editor
-or process changes still require `/hearth-clear-cache`, a restart, or
+`trustCache` is a single-writer optimization. File-backed tools share an Engine
+gate; tool Bash and user Bash (`!`/`!!`) take it exclusively and clear all
+caches before another file operation can start, after every outcome including
+nonzero, timeout, abort, and indeterminate. Cache invalidation also runs after
+write/edit result hooks and after managed subagent/workflow completion, covering
+formatters and child writers before the next parent turn. External editors and
+unmanaged processes still require `/hearth-clear-cache`, a restart, or
 `trustCache: false`. An `indeterminate` command is never retried automatically;
 inspect the workspace first.
 

--- a/pi/README.md
+++ b/pi/README.md
@@ -220,6 +220,19 @@ tail truncation, and full-output files. Hearth 0.1.0 streams valid UTF-8 text,
 so invalid binary bytes are replacement-decoded and are not byte-identical in
 full-output files.
 
+### Benchmarking
+
+Run `bun run benchmark:hearth-tools` to compare warm-cache performance in one
+Bun process. The benchmark covers both pi's end-to-end `read`/`grep` tool
+contracts and raw `fs.readFile`/`rg --json` backends against Hearth, over this
+repository and a deterministic synthetic corpus. End-to-end Hearth samples use
+the same shared access gate as the production extension. The benchmark validates
+equivalent outputs before timing, warms each implementation equally, alternates
+AB/BA execution order, and reports median, mean, and p95 latency. The primary speedup
+is baseline median divided by Hearth median; corpus generation and equivalence
+checks are outside timed regions. Use `--json` for machine-readable output and
+`--help` for iteration and corpus-size controls.
+
 ## Codex web tools
 
 `extensions/codex-web` registers `web_search` and `web_fetch` for the current

--- a/pi/README.md
+++ b/pi/README.md
@@ -206,12 +206,14 @@ more important than shell reuse.
 
 Grep translates cwd-relative positive and negative ripgrep globs to Hearth,
 preserves root anchors, ignores valid globs for an explicit file operand like
-ripgrep, and still validates malformed globs first. Negative globs and positive
-globs containing `/` use separator-aware post-filtering because Hearth 0.1.0
-has no native exclusion glob and lets `*` cross separators in path globs.
-Negative matching also filters matching ancestor directories like ripgrep's
-walker. The adapter bounds native candidates and fails closed with a refinement
-error rather than returning an incomplete result if that bound is exhausted.
+ripgrep, and still validates malformed classes, ranges, alternates, and escapes
+through Hearth's strict native glob parser. Negative globs, rooted positive
+globs, directory-only globs ending in `/`, and positive globs containing `/`
+use separator-aware post-filtering because Hearth 0.1.0 has no native exclusion
+glob and lets `*` cross separators in path globs. Negative matching also filters
+matching ancestor directories like ripgrep's walker. The adapter bounds native
+candidates and fails closed with a refinement error rather than returning an
+incomplete result if that bound is exhausted.
 
 Bash streams once into pi's existing accumulator, preserving progress updates,
 tail truncation, and full-output files. Hearth 0.1.0 streams valid UTF-8 text,

--- a/pi/README.md
+++ b/pi/README.md
@@ -182,31 +182,36 @@ built-in fallback. Registration restores the prior active names, so replacing
 `grep` does not enable it. Pi 0.80.7 exposes only the first effective tool per
 name: a later inert losing registration cannot be enumerated, but it also cannot
 execute. Hearth checks effective ownership before registration, immediately
-after registration, and before each agent turn.
+after registration, before each agent turn, and again at the tool-call boundary.
 
 `trustCache` is a single-writer optimization. File-backed tools share an Engine
 gate; tool Bash and user Bash (`!`/`!!`) take it exclusively and clear all
 caches before another file operation can start, after every outcome including
 nonzero, timeout, abort, and indeterminate. Cache invalidation also runs after
-write/edit result hooks. Every managed subagent/workflow acquires an exclusive
-parent-Engine lease before child work begins, clears caches after settlement,
-and only then releases parent file tools. Concurrent managed children share one
-writer epoch so fan-out remains parallel. Abort, branch navigation, reload, and
-shutdown paths use the same lease even when completion notification is
-suppressed; after a bounded drain timeout, the lease remains held until the late
-child actually settles. This covers formatters and child writers independently
-of parent-message delivery. External editors and unmanaged processes still
-require `/hearth-clear-cache`, a restart, or `trustCache: false`. An `indeterminate` command is never retried
+write/edit and worktree create/remove result hooks. Every managed
+subagent/workflow acquires an exclusive parent-Engine lease before child work
+begins, clears caches after settlement, and only then releases parent file
+tools. Its background acceptance result does not queue a redundant clear behind
+the live lease. Concurrent managed children share one writer epoch so fan-out
+remains parallel. Abort, branch navigation, reload, and shutdown paths use the
+same lease even when completion notification is suppressed; after a bounded
+drain timeout, the lease remains held until the late child actually settles,
+and branch navigation is cancelled until that old-branch record archives. This
+covers formatters and child writers independently of parent-message delivery.
+External editors and unmanaged processes still require `/hearth-clear-cache`,
+a restart, or `trustCache: false`. An `indeterminate` command is never retried
 automatically. In particular, a command that terminates its pooled warm shell
 may be indeterminate; set `warmShell: false` when exact signal-exit reporting is
 more important than shell reuse.
 
 Grep translates cwd-relative positive and negative ripgrep globs to Hearth,
-preserves root anchors, and ignores globs for an explicit file operand like
-ripgrep. Negative directory globs require post-filtering because Hearth 0.1.0
-has no native exclusion glob; the adapter bounds native candidates and fails
-closed with a refinement error rather than returning an incomplete result if
-that bound is exhausted.
+preserves root anchors, ignores valid globs for an explicit file operand like
+ripgrep, and still validates malformed globs first. Negative globs and positive
+globs containing `/` use separator-aware post-filtering because Hearth 0.1.0
+has no native exclusion glob and lets `*` cross separators in path globs.
+Negative matching also filters matching ancestor directories like ripgrep's
+walker. The adapter bounds native candidates and fails closed with a refinement
+error rather than returning an incomplete result if that bound is exhausted.
 
 Bash streams once into pi's existing accumulator, preserving progress updates,
 tail truncation, and full-output files. Hearth 0.1.0 streams valid UTF-8 text,

--- a/pi/README.md
+++ b/pi/README.md
@@ -188,11 +188,20 @@ after registration, and before each agent turn.
 gate; tool Bash and user Bash (`!`/`!!`) take it exclusively and clear all
 caches before another file operation can start, after every outcome including
 nonzero, timeout, abort, and indeterminate. Cache invalidation also runs after
-write/edit result hooks and after managed subagent/workflow completion, covering
-formatters and child writers before the next parent turn. External editors and
-unmanaged processes still require `/hearth-clear-cache`, a restart, or
-`trustCache: false`. An `indeterminate` command is never retried automatically;
-inspect the workspace first.
+write/edit result hooks and through an awaitable settlement handshake for every
+managed subagent/workflow, including abort, branch navigation, reload, and
+shutdown paths where completion notification is suppressed. This covers
+formatters and child writers independently of parent-message delivery. External
+editors and unmanaged processes still require `/hearth-clear-cache`, a restart,
+or `trustCache: false`. An `indeterminate` command is never retried
+automatically. In particular, a command that terminates its pooled warm shell
+may be indeterminate; set `warmShell: false` when exact signal-exit reporting is
+more important than shell reuse.
+
+Grep translates root-relative positive and negative globs to Hearth. Negative
+globs require post-filtering because Hearth 0.1.0 has no native exclusion glob;
+the adapter bounds native candidates and fails closed with a refinement error
+rather than returning an incomplete result if that bound is exhausted.
 
 Bash streams once into pi's existing accumulator, preserving progress updates,
 tail truncation, and full-output files. Hearth 0.1.0 streams valid UTF-8 text,

--- a/pi/README.md
+++ b/pi/README.md
@@ -188,20 +188,25 @@ after registration, and before each agent turn.
 gate; tool Bash and user Bash (`!`/`!!`) take it exclusively and clear all
 caches before another file operation can start, after every outcome including
 nonzero, timeout, abort, and indeterminate. Cache invalidation also runs after
-write/edit result hooks and through an awaitable settlement handshake for every
-managed subagent/workflow, including abort, branch navigation, reload, and
-shutdown paths where completion notification is suppressed. This covers
-formatters and child writers independently of parent-message delivery. External
-editors and unmanaged processes still require `/hearth-clear-cache`, a restart,
-or `trustCache: false`. An `indeterminate` command is never retried
+write/edit result hooks. Every managed subagent/workflow acquires an exclusive
+parent-Engine lease before child work begins, clears caches after settlement,
+and only then releases parent file tools. Concurrent managed children share one
+writer epoch so fan-out remains parallel. Abort, branch navigation, reload, and
+shutdown paths use the same lease even when completion notification is
+suppressed; after a bounded drain timeout, the lease remains held until the late
+child actually settles. This covers formatters and child writers independently
+of parent-message delivery. External editors and unmanaged processes still
+require `/hearth-clear-cache`, a restart, or `trustCache: false`. An `indeterminate` command is never retried
 automatically. In particular, a command that terminates its pooled warm shell
 may be indeterminate; set `warmShell: false` when exact signal-exit reporting is
 more important than shell reuse.
 
-Grep translates root-relative positive and negative globs to Hearth. Negative
-globs require post-filtering because Hearth 0.1.0 has no native exclusion glob;
-the adapter bounds native candidates and fails closed with a refinement error
-rather than returning an incomplete result if that bound is exhausted.
+Grep translates cwd-relative positive and negative ripgrep globs to Hearth,
+preserves root anchors, and ignores globs for an explicit file operand like
+ripgrep. Negative directory globs require post-filtering because Hearth 0.1.0
+has no native exclusion glob; the adapter bounds native candidates and fails
+closed with a refinement error rather than returning an incomplete result if
+that bound is exhausted.
 
 Bash streams once into pi's existing accumulator, preserving progress updates,
 tail truncation, and full-output files. Hearth 0.1.0 streams valid UTF-8 text,

--- a/pi/README.md
+++ b/pi/README.md
@@ -11,12 +11,13 @@ child-process behavior): `tests/fixtures/pi-harness/raw/`.
 
 ## Layout
 
-| Repo path                  | Deployed to                         | Mechanism                                     |
-| -------------------------- | ----------------------------------- | --------------------------------------------- |
-| `pi/extensions/pi-harness` | `~/.pi/agent/extensions/pi-harness` | dotfiles directory symlink                    |
-| `pi/extensions/codex-web`  | `~/.pi/agent/extensions/codex-web`  | dotfiles directory symlink                    |
-| `claude/.claude/skills`    | `~/.agents/skills`                  | existing shared mapping                       |
-| `pi/skills`                | `~/.pi/agent/skills`                | selective symlink (6 forks + 1 pi-only skill) |
+| Repo path                    | Deployed to                           | Mechanism                                     |
+| ---------------------------- | ------------------------------------- | --------------------------------------------- |
+| `pi/extensions/pi-harness`   | `~/.pi/agent/extensions/pi-harness`   | dotfiles directory symlink                    |
+| `pi/extensions/hearth-tools` | `~/.pi/agent/extensions/hearth-tools` | dotfiles directory symlink                    |
+| `pi/extensions/codex-web`    | `~/.pi/agent/extensions/codex-web`    | dotfiles directory symlink                    |
+| `claude/.claude/skills`      | `~/.agents/skills`                    | existing shared mapping                       |
+| `pi/skills`                  | `~/.pi/agent/skills`                  | selective symlink (6 forks + 1 pi-only skill) |
 
 ## Install
 
@@ -56,9 +57,12 @@ rejection may short-circuit first, then permission-policy remains the mandatory
 safety floor before every path that can execute a command, followed by the
 remaining hook-bridge features. The preflight uses `/bin/bash` with a fixed
 root-owned system `PATH`, never the repository-influenced inherited path. The
-narrowly scoped `codex-web` extension is
-separate because it owns provider credentials
-and network traffic rather than harness lifecycle compatibility. Harness
+`hearth-tools` extension is separate so native-addon preflight cannot partially
+initialize the permission/audit extension. It replaces pi's `read`, `write`,
+`edit`, `bash`, and `grep` execution while preserving their public schemas and
+built-in renderers. The narrowly scoped `codex-web` extension is separate
+because it owns provider credentials and network traffic rather than harness
+lifecycle compatibility. Harness
 feature toggles live in `~/.pi/agent/pi-harness.local.json` (machine-local):
 
 ```json
@@ -147,6 +151,44 @@ on the judge route, and child profiles never inherit grants. A skill's mutating
 worktree that shares the active cwd's canonical Git common directory. A
 helper-capable `git -C` read never bypasses the judge through a skill grant; it
 uses the verified read-only route described above.
+
+## Hearth-backed built-in tools
+
+`pi/extensions/hearth-tools` pins `@hearthdev/napi` exactly to `0.1.0` and
+constructs one in-process `HearthEngine` per pi process. Parent pi and every
+subagent/workflow child have separate resident caches and warm-shell pools;
+`/reload` reuses the process Engine. BTW keeps extension/package discovery off
+but receives a custom Hearth-backed `read`; its active tools remain `read` and
+`ls`.
+
+The checked-in maximum-speed defaults are:
+
+```json
+{
+  "trustCache": true,
+  "warmShell": true,
+  "enableOptimizer": true,
+  "bashTimeoutMs": 2147483647
+}
+```
+
+Override these fields, plus optional `maxCachedFiles`, in
+`~/.pi/agent/hearth-tools.local.json`. Invalid config, a missing/incompatible
+native addon, or a competing override for one of the five names terminates pi
+at startup with exit code 1; there is no built-in fallback. Registration
+restores the prior active names, so replacing `grep` does not enable it.
+
+`trustCache` is a single-writer optimization. Hearth write/edit operations are
+cache-coherent. Tool Bash and user Bash (`!`/`!!`) clear all caches after every
+outcome, including nonzero, timeout, abort, and indeterminate. External editor
+or process changes still require `/hearth-clear-cache`, a restart, or
+`trustCache: false`. An `indeterminate` command is never retried automatically;
+inspect the workspace first.
+
+Bash streams once into pi's existing accumulator, preserving progress updates,
+tail truncation, and full-output files. Hearth 0.1.0 streams valid UTF-8 text,
+so invalid binary bytes are replacement-decoded and are not byte-identical in
+full-output files.
 
 ## Codex web tools
 

--- a/pi/extensions/hearth-tools/adapters.ts
+++ b/pi/extensions/hearth-tools/adapters.ts
@@ -31,6 +31,9 @@ import {
 } from "./engine";
 
 const DEFAULT_GREP_LIMIT = 100;
+const NEGATIVE_GLOB_SCAN_MIN = 1_000;
+const NEGATIVE_GLOB_SCAN_MAX = 100_000;
+const NEGATIVE_GLOB_SCAN_MULTIPLIER = 100;
 const MAX_TIMEOUT_MS = 2_147_483_647;
 
 const absolutePath = (cwd: string, input: string): string => {
@@ -288,7 +291,8 @@ const excludeNegativeGlob = (
   glob: string | undefined,
 ): FileMatches[] => {
   if (glob === undefined || !glob.startsWith("!")) return files;
-  const matcher = new Bun.Glob(glob.slice(1));
+  const pattern = normalizedGlobPath(glob.slice(1)).replace(/^\/+/, "");
+  const matcher = new Bun.Glob(pattern);
   return files.filter((file) => {
     const relativePath = normalizedGlobPath(relative(root, file.path));
     return !(
@@ -297,6 +301,12 @@ const excludeNegativeGlob = (
     );
   });
 };
+
+const negativeGlobScanLimit = (limit: number): number =>
+  Math.min(
+    NEGATIVE_GLOB_SCAN_MAX,
+    Math.max(NEGATIVE_GLOB_SCAN_MIN, limit * NEGATIVE_GLOB_SCAN_MULTIPLIER),
+  );
 
 const limitFileMatches = (
   files: FileMatches[],
@@ -354,7 +364,9 @@ export const createHearthGrepDefinition = (
               fixedStrings: input.literal ?? false,
               beforeContext: context,
               afterContext: context,
-              ...(negativeGlob ? {} : { maxTotalCount: limit }),
+              maxTotalCount: negativeGlob
+                ? negativeGlobScanLimit(limit)
+                : limit,
               hidden: true,
               respectGitignore: true,
             },
@@ -371,6 +383,11 @@ export const createHearthGrepDefinition = (
           (total, file) => total + file.matchCount,
           0,
         );
+        if (negativeGlob && result.limitReached && totalMatches < limit) {
+          throw new Error(
+            "Negative glob candidate scan limit reached before enough included matches; refine pattern or path",
+          );
+        }
         if (totalMatches === 0) {
           return {
             content: [{ type: "text" as const, text: "No matches found" }],
@@ -387,14 +404,24 @@ export const createHearthGrepDefinition = (
           const shownPath = result.rootIsDir
             ? relative(result.root, file.path).replaceAll("\\", "/")
             : basename(file.path);
-          for (const line of file.lines) {
-            const truncated = truncateLine(line.text.replaceAll("\r", ""));
-            linesTruncated ||= truncated.wasTruncated;
-            lines.push(
-              line.isMatch
-                ? `${shownPath}:${line.lineNumber}: ${truncated.text}`
-                : `${shownPath}-${line.lineNumber}- ${truncated.text}`,
-            );
+          const matches = file.lines.filter((line) => line.isMatch);
+          for (const match of matches) {
+            const block =
+              context === 0
+                ? [match]
+                : file.lines.filter(
+                    (line) =>
+                      Math.abs(line.lineNumber - match.lineNumber) <= context,
+                  );
+            for (const line of block) {
+              const truncated = truncateLine(line.text.replaceAll("\r", ""));
+              linesTruncated ||= truncated.wasTruncated;
+              lines.push(
+                line.lineNumber === match.lineNumber
+                  ? `${shownPath}:${line.lineNumber}: ${truncated.text}`
+                  : `${shownPath}-${line.lineNumber}- ${truncated.text}`,
+              );
+            }
           }
         }
         const truncation = truncateHead(lines.join("\n"), {

--- a/pi/extensions/hearth-tools/adapters.ts
+++ b/pi/extensions/hearth-tools/adapters.ts
@@ -31,9 +31,9 @@ import {
 } from "./engine";
 
 const DEFAULT_GREP_LIMIT = 100;
-const NEGATIVE_GLOB_SCAN_MIN = 1_000;
-const NEGATIVE_GLOB_SCAN_MAX = 100_000;
-const NEGATIVE_GLOB_SCAN_MULTIPLIER = 100;
+const GLOB_SCAN_MIN = 1_000;
+const GLOB_SCAN_MAX = 100_000;
+const GLOB_SCAN_MULTIPLIER = 100;
 const MAX_TIMEOUT_MS = 2_147_483_647;
 
 const absolutePath = (cwd: string, input: string): string => {
@@ -273,41 +273,106 @@ export const createHearthEditDefinition = (
 const normalizedGlobPath = (value: string): string =>
   value.replaceAll("\\", "/");
 
-const hearthGlobs = (cwd: string, glob: string | undefined): string[] => {
-  if (glob === undefined || glob.startsWith("!")) return [];
-  const normalized = normalizedGlobPath(glob);
-  if (!normalized.includes("/")) return [normalized];
-  return [normalizedGlobPath(resolve(cwd, normalized.replace(/^\/+/, "")))];
+interface GrepGlob {
+  original: string;
+  negative: boolean;
+  rooted: boolean;
+  pattern: string;
+  hasSlash: boolean;
+  matcher: Bun.Glob;
+}
+
+const validateGrepGlob = (original: string, pattern: string): void => {
+  let inClass = false;
+  let classHasMember = false;
+  for (let index = 0; index < pattern.length; index += 1) {
+    const character = pattern[index];
+    if (!inClass) {
+      if (character === "[") {
+        inClass = true;
+        classHasMember = false;
+      }
+      continue;
+    }
+    if (!classHasMember && (character === "!" || character === "^")) {
+      continue;
+    }
+    if (character === "]" && classHasMember) {
+      inClass = false;
+      continue;
+    }
+    classHasMember = true;
+  }
+  if (inClass) {
+    throw new Error(
+      `rg: error parsing glob '${original}': unclosed character class`,
+    );
+  }
 };
 
-const excludeNegativeGlob = (
-  files: FileMatches[],
-  cwd: string,
-  glob: string | undefined,
-  rootIsDirectory: boolean,
-): FileMatches[] => {
-  if (glob === undefined || !glob.startsWith("!") || !rootIsDirectory) {
-    return files;
-  }
-  const rawPattern = normalizedGlobPath(glob.slice(1));
+const parseGrepGlob = (glob: string | undefined): GrepGlob | undefined => {
+  if (glob === undefined) return undefined;
+  const negative = glob.startsWith("!");
+  const rawPattern = normalizedGlobPath(negative ? glob.slice(1) : glob);
   const rooted = rawPattern.startsWith("/");
   const pattern = rawPattern.replace(/^\/+/, "");
-  const matcher = new Bun.Glob(pattern);
+  validateGrepGlob(glob, pattern);
+  return {
+    original: glob,
+    negative,
+    rooted,
+    pattern,
+    hasSlash: pattern.includes("/"),
+    matcher: new Bun.Glob(pattern),
+  };
+};
+
+const hearthGlobs = (glob: GrepGlob | undefined): string[] => {
+  if (glob === undefined || glob.negative || glob.hasSlash) return [];
+  return [glob.pattern];
+};
+
+const ancestorPaths = (path: string): string[] => {
+  const segments = path.split("/");
+  return segments
+    .slice(0, -1)
+    .map((_segment, index) => segments.slice(0, index + 1).join("/"));
+};
+
+const matchesNegativeGlob = (path: string, glob: GrepGlob): boolean => {
+  if (!glob.rooted && !glob.hasSlash) {
+    return path.split("/").some((segment) => glob.matcher.match(segment));
+  }
+  return [...ancestorPaths(path), path].some((candidate) =>
+    glob.matcher.match(candidate),
+  );
+};
+
+const filterPostProcessedGlob = (
+  files: FileMatches[],
+  cwd: string,
+  glob: GrepGlob | undefined,
+  rootIsDirectory: boolean,
+): FileMatches[] => {
+  if (
+    glob === undefined ||
+    !rootIsDirectory ||
+    (!glob.negative && !glob.hasSlash)
+  ) {
+    return files;
+  }
   return files.filter((file) => {
     const relativePath = normalizedGlobPath(relative(cwd, file.path));
-    const pathMatches = matcher.match(relativePath);
-    const basenameMatches =
-      !rooted &&
-      !pattern.includes("/") &&
-      matcher.match(normalizedGlobPath(basename(file.path)));
-    return !(pathMatches || basenameMatches);
+    return glob.negative
+      ? !matchesNegativeGlob(relativePath, glob)
+      : glob.matcher.match(relativePath);
   });
 };
 
-const negativeGlobScanLimit = (limit: number): number =>
+const postFilterGlobScanLimit = (limit: number): number =>
   Math.min(
-    NEGATIVE_GLOB_SCAN_MAX,
-    Math.max(NEGATIVE_GLOB_SCAN_MIN, limit * NEGATIVE_GLOB_SCAN_MULTIPLIER),
+    GLOB_SCAN_MAX,
+    Math.max(GLOB_SCAN_MIN, limit * GLOB_SCAN_MULTIPLIER),
   );
 
 const limitFileMatches = (
@@ -354,20 +419,22 @@ export const createHearthGrepDefinition = (
         const searchPath = absolutePath(cwd, input.path || ".");
         const limit = Math.max(1, input.limit ?? DEFAULT_GREP_LIMIT);
         const context = input.context && input.context > 0 ? input.context : 0;
-        const negativeGlob = input.glob?.startsWith("!") === true;
+        const glob = parseGrepGlob(input.glob);
+        const postFilterGlob =
+          glob !== undefined && (glob.negative || glob.hasSlash);
         const result = await engine
           .grepAsync(
             {
               pattern: input.pattern,
               path: searchPath,
               mode: "content" as GrepMode,
-              globs: hearthGlobs(cwd, input.glob),
+              globs: hearthGlobs(glob),
               caseInsensitive: input.ignoreCase ?? false,
               fixedStrings: input.literal ?? false,
               beforeContext: context,
               afterContext: context,
-              maxTotalCount: negativeGlob
-                ? negativeGlobScanLimit(limit)
+              maxTotalCount: postFilterGlob
+                ? postFilterGlobScanLimit(limit)
                 : limit,
               hidden: true,
               respectGitignore: true,
@@ -376,19 +443,20 @@ export const createHearthGrepDefinition = (
           )
           .catch((error) => mapCancelled(error, "Operation aborted"));
 
-        const filtered = excludeNegativeGlob(
+        const filtered = filterPostProcessedGlob(
           result.files,
           cwd,
-          input.glob,
+          glob,
           result.rootIsDir,
         );
         const totalMatches = filtered.reduce(
           (total, file) => total + file.matchCount,
           0,
         );
-        if (negativeGlob && result.limitReached && totalMatches < limit) {
+        if (postFilterGlob && result.limitReached && totalMatches < limit) {
+          const kind = glob?.negative ? "Negative" : "Positive";
           throw new Error(
-            "Negative glob candidate scan limit reached before enough included matches; refine pattern or path",
+            `${kind} glob candidate scan limit reached before enough included matches; refine pattern or path`,
           );
         }
         if (totalMatches === 0) {
@@ -398,7 +466,7 @@ export const createHearthGrepDefinition = (
           };
         }
 
-        const files = negativeGlob
+        const files = postFilterGlob
           ? limitFileMatches(filtered, limit, context)
           : filtered;
         let linesTruncated = false;
@@ -452,7 +520,7 @@ export const createHearthGrepDefinition = (
         const truncation = truncateHead(lines.join("\n"), {
           maxLines: Number.MAX_SAFE_INTEGER,
         });
-        const limitReached = negativeGlob
+        const limitReached = postFilterGlob
           ? totalMatches >= limit
           : result.limitReached;
         const matchLimitReached = limitReached ? limit : undefined;

--- a/pi/extensions/hearth-tools/adapters.ts
+++ b/pi/extensions/hearth-tools/adapters.ts
@@ -277,50 +277,25 @@ interface GrepGlob {
   original: string;
   negative: boolean;
   rooted: boolean;
+  directoryOnly: boolean;
   pattern: string;
   hasSlash: boolean;
   matcher: Bun.Glob;
 }
 
-const validateGrepGlob = (original: string, pattern: string): void => {
-  let inClass = false;
-  let classHasMember = false;
-  for (let index = 0; index < pattern.length; index += 1) {
-    const character = pattern[index];
-    if (!inClass) {
-      if (character === "[") {
-        inClass = true;
-        classHasMember = false;
-      }
-      continue;
-    }
-    if (!classHasMember && (character === "!" || character === "^")) {
-      continue;
-    }
-    if (character === "]" && classHasMember) {
-      inClass = false;
-      continue;
-    }
-    classHasMember = true;
-  }
-  if (inClass) {
-    throw new Error(
-      `rg: error parsing glob '${original}': unclosed character class`,
-    );
-  }
-};
-
 const parseGrepGlob = (glob: string | undefined): GrepGlob | undefined => {
   if (glob === undefined) return undefined;
   const negative = glob.startsWith("!");
-  const rawPattern = normalizedGlobPath(negative ? glob.slice(1) : glob);
+  const rawPattern = negative ? glob.slice(1) : glob;
   const rooted = rawPattern.startsWith("/");
-  const pattern = rawPattern.replace(/^\/+/, "");
-  validateGrepGlob(glob, pattern);
+  const directoryOnly = rawPattern.endsWith("/");
+  const withoutRoot = rawPattern.replace(/^\/+/, "");
+  const pattern = directoryOnly ? withoutRoot.slice(0, -1) : withoutRoot;
   return {
     original: glob,
     negative,
     rooted,
+    directoryOnly,
     pattern,
     hasSlash: pattern.includes("/"),
     matcher: new Bun.Glob(pattern),
@@ -328,8 +303,19 @@ const parseGrepGlob = (glob: string | undefined): GrepGlob | undefined => {
 };
 
 const hearthGlobs = (glob: GrepGlob | undefined): string[] => {
-  if (glob === undefined || glob.negative || glob.hasSlash) return [];
-  return [glob.pattern];
+  if (glob === undefined) return [];
+  if (
+    glob.negative ||
+    glob.rooted ||
+    glob.directoryOnly ||
+    glob.hasSlash
+  ) {
+    // Hearth's native globset is the same strict parser family as ripgrep.
+    // `**` keeps the candidate walk unfiltered while the second entry validates
+    // malformed classes, ranges, alternates, and escapes before JS post-filtering.
+    return ["**", glob.original];
+  }
+  return [glob.original];
 };
 
 const ancestorPaths = (path: string): string[] => {
@@ -340,12 +326,14 @@ const ancestorPaths = (path: string): string[] => {
 };
 
 const matchesNegativeGlob = (path: string, glob: GrepGlob): boolean => {
+  const ancestors = ancestorPaths(path);
   if (!glob.rooted && !glob.hasSlash) {
-    return path.split("/").some((segment) => glob.matcher.match(segment));
+    const segments = path.split("/");
+    const candidates = glob.directoryOnly ? segments.slice(0, -1) : segments;
+    return candidates.some((segment) => glob.matcher.match(segment));
   }
-  return [...ancestorPaths(path), path].some((candidate) =>
-    glob.matcher.match(candidate),
-  );
+  const candidates = glob.directoryOnly ? ancestors : [...ancestors, path];
+  return candidates.some((candidate) => glob.matcher.match(candidate));
 };
 
 const filterPostProcessedGlob = (
@@ -357,15 +345,18 @@ const filterPostProcessedGlob = (
   if (
     glob === undefined ||
     !rootIsDirectory ||
-    (!glob.negative && !glob.hasSlash)
+    (!glob.negative &&
+      !glob.rooted &&
+      !glob.directoryOnly &&
+      !glob.hasSlash)
   ) {
     return files;
   }
   return files.filter((file) => {
     const relativePath = normalizedGlobPath(relative(cwd, file.path));
-    return glob.negative
-      ? !matchesNegativeGlob(relativePath, glob)
-      : glob.matcher.match(relativePath);
+    if (glob.negative) return !matchesNegativeGlob(relativePath, glob);
+    if (glob.directoryOnly) return false;
+    return glob.matcher.match(relativePath);
   });
 };
 
@@ -421,7 +412,11 @@ export const createHearthGrepDefinition = (
         const context = input.context && input.context > 0 ? input.context : 0;
         const glob = parseGrepGlob(input.glob);
         const postFilterGlob =
-          glob !== undefined && (glob.negative || glob.hasSlash);
+          glob !== undefined &&
+          (glob.negative ||
+            glob.rooted ||
+            glob.directoryOnly ||
+            glob.hasSlash);
         const result = await engine
           .grepAsync(
             {

--- a/pi/extensions/hearth-tools/adapters.ts
+++ b/pi/extensions/hearth-tools/adapters.ts
@@ -24,28 +24,108 @@ import { access, open } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { MAX_TIMEOUT_MS } from "./constants";
 import {
   IMMEDIATE_HEARTH_ACCESS_GATE,
   type HearthAccessGate,
   type PiToolSettings,
 } from "./engine";
 
+const FILE_REFERENCE_PREFIX = "@";
+const HOME_DIRECTORY_TOKEN = "~";
+const HOME_DIRECTORY_PREFIX = "~/";
+const FILE_URL_PREFIX = "file://";
+const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;
+const FILE_START_OFFSET = 0;
+
 const DEFAULT_GREP_LIMIT = 100;
+const MIN_GREP_LIMIT = 1;
+const FIRST_LINE_NUMBER = 1;
+const NO_CONTEXT_LINES = 0;
+const GREP_LIMIT_REFINEMENT_MULTIPLIER = 2;
+const GREP_MAX_LINE_LENGTH = 500;
 const GLOB_SCAN_MIN = 1_000;
 const GLOB_SCAN_MAX = 100_000;
 const GLOB_SCAN_MULTIPLIER = 100;
-const MAX_TIMEOUT_MS = 2_147_483_647;
+const MILLISECONDS_PER_SECOND = 1_000;
+const HEARTH_SIGNAL_EXIT_CODE = -1;
+
+// Mirrors pi 0.80.7's bounded image sniffer and supported MIME contract.
+const IMAGE_TYPE_SNIFF_BYTES = 4_100;
+const ASCII_ENCODING = "ascii";
+const IMAGE_MIME = {
+  jpeg: "image/jpeg",
+  png: "image/png",
+  gif: "image/gif",
+  webp: "image/webp",
+  bmp: "image/bmp",
+} as const;
+
+const JPEG_SIGNATURE = Buffer.from([0xff, 0xd8, 0xff]);
+const JPEG_MARKER_OFFSET = JPEG_SIGNATURE.length;
+const JPEG_LS_MARKER = 0xf7;
+
+const PNG_SIGNATURE = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+const PNG_CHUNK_LENGTH_BYTES = 4;
+const PNG_CHUNK_TYPE_BYTES = 4;
+const PNG_CHUNK_CRC_BYTES = 4;
+const PNG_CHUNK_HEADER_BYTES = PNG_CHUNK_LENGTH_BYTES + PNG_CHUNK_TYPE_BYTES;
+const PNG_CHUNK_OVERHEAD_BYTES = PNG_CHUNK_HEADER_BYTES + PNG_CHUNK_CRC_BYTES;
+const PNG_CHUNK_TYPE_OFFSET = PNG_CHUNK_LENGTH_BYTES;
+const PNG_IHDR_DATA_LENGTH = 13;
+const PNG_IHDR_DATA_LENGTH_OFFSET = PNG_SIGNATURE.length;
+const PNG_IHDR_TYPE_OFFSET =
+  PNG_IHDR_DATA_LENGTH_OFFSET + PNG_CHUNK_LENGTH_BYTES;
+const PNG_MIN_HEADER_BYTES = PNG_IHDR_TYPE_OFFSET + PNG_CHUNK_TYPE_BYTES;
+const PNG_ANIMATION_CONTROL_CHUNK = Buffer.from("acTL", ASCII_ENCODING);
+const PNG_IMAGE_DATA_CHUNK = Buffer.from("IDAT", ASCII_ENCODING);
+const PNG_HEADER_CHUNK = Buffer.from("IHDR", ASCII_ENCODING);
+
+const GIF_SIGNATURE = Buffer.from("GIF", ASCII_ENCODING);
+const RIFF_SIGNATURE = Buffer.from("RIFF", ASCII_ENCODING);
+const RIFF_SIZE_FIELD_BYTES = 4;
+const WEBP_SIGNATURE = Buffer.from("WEBP", ASCII_ENCODING);
+const WEBP_FORMAT_OFFSET = RIFF_SIGNATURE.length + RIFF_SIZE_FIELD_BYTES;
+
+const BMP_SIGNATURE = Buffer.from("BM", ASCII_ENCODING);
+const BMP_FILE_HEADER_BYTES = 14;
+const BMP_CORE_DIB_HEADER_BYTES = 12;
+const BMP_INFO_DIB_HEADER_MIN_BYTES = 40;
+const BMP_INFO_DIB_HEADER_MAX_BYTES = 124;
+const BMP_MIN_HEADER_BYTES = BMP_FILE_HEADER_BYTES + BMP_CORE_DIB_HEADER_BYTES;
+const BMP_FILE_SIZE_OFFSET = 2;
+const BMP_PIXEL_DATA_OFFSET = 10;
+const BMP_DIB_HEADER_SIZE_OFFSET = 14;
+const BMP_CORE_PLANES_OFFSET = 22;
+const BMP_CORE_BITS_PER_PIXEL_OFFSET = 24;
+const BMP_INFO_PLANES_OFFSET = 26;
+const BMP_INFO_BITS_PER_PIXEL_OFFSET = 28;
+const BMP_FIELD_BYTES = 2;
+const BMP_INFO_MIN_FILE_BYTES =
+  BMP_INFO_BITS_PER_PIXEL_OFFSET + BMP_FIELD_BYTES;
+const BMP_UNKNOWN_FILE_SIZE = 0;
+const BMP_REQUIRED_COLOR_PLANES = 1;
+const BMP_SUPPORTED_BITS_PER_PIXEL: ReadonlySet<number> = new Set([
+  1, 4, 8, 16, 24, 32,
+]);
 
 const absolutePath = (cwd: string, input: string): string => {
-  let normalized = input.replace(
-    /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g,
-    " ",
-  );
-  if (normalized.startsWith("@")) normalized = normalized.slice(1);
-  if (normalized === "~") normalized = homedir();
-  else if (normalized.startsWith("~/"))
-    normalized = join(homedir(), normalized.slice(2));
-  if (normalized.startsWith("file://")) normalized = fileURLToPath(normalized);
+  let normalized = input.replace(UNICODE_SPACES, " ");
+  if (normalized.startsWith(FILE_REFERENCE_PREFIX)) {
+    normalized = normalized.slice(FILE_REFERENCE_PREFIX.length);
+  }
+  if (normalized === HOME_DIRECTORY_TOKEN) normalized = homedir();
+  else if (normalized.startsWith(HOME_DIRECTORY_PREFIX)) {
+    normalized = join(
+      homedir(),
+      normalized.slice(HOME_DIRECTORY_PREFIX.length),
+    );
+  }
+  if (normalized.startsWith(FILE_URL_PREFIX)) {
+    normalized = fileURLToPath(normalized);
+  }
   return isAbsolute(normalized)
     ? resolve(normalized)
     : resolve(cwd, normalized);
@@ -59,45 +139,61 @@ const mapCancelled = (error: unknown, message: string): never => {
   throw error;
 };
 
-const PNG_SIGNATURE = Buffer.from([
-  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
-]);
-
-const asciiAt = (buffer: Buffer, offset: number, text: string): boolean =>
-  buffer.length >= offset + text.length &&
-  [...text].every(
-    (character, index) => buffer[offset + index] === character.charCodeAt(0),
-  );
+const signatureAt = (
+  buffer: Buffer,
+  offset: number,
+  signature: Buffer,
+): boolean =>
+  buffer.length >= offset + signature.length &&
+  buffer.subarray(offset, offset + signature.length).equals(signature);
 
 const validBmp = (buffer: Buffer): boolean => {
-  if (buffer.length < 26) return false;
-  const size = buffer.readUInt32LE(2);
-  const pixels = buffer.readUInt32LE(10);
-  const dib = buffer.readUInt32LE(14);
+  if (buffer.length < BMP_MIN_HEADER_BYTES) return false;
+  const size = buffer.readUInt32LE(BMP_FILE_SIZE_OFFSET);
+  const pixels = buffer.readUInt32LE(BMP_PIXEL_DATA_OFFSET);
+  const dib = buffer.readUInt32LE(BMP_DIB_HEADER_SIZE_OFFSET);
   if (
-    (size !== 0 && size < 26) ||
-    pixels < 14 + dib ||
-    (size !== 0 && pixels >= size)
+    (size !== BMP_UNKNOWN_FILE_SIZE && size < BMP_MIN_HEADER_BYTES) ||
+    pixels < BMP_FILE_HEADER_BYTES + dib ||
+    (size !== BMP_UNKNOWN_FILE_SIZE && pixels >= size)
   ) {
     return false;
   }
-  if (dib !== 12 && buffer.length < 30) return false;
-  const planes = buffer.readUInt16LE(dib === 12 ? 22 : 26);
-  const bits = buffer.readUInt16LE(dib === 12 ? 24 : 28);
+  if (
+    dib !== BMP_CORE_DIB_HEADER_BYTES &&
+    buffer.length < BMP_INFO_MIN_FILE_BYTES
+  ) {
+    return false;
+  }
+  const coreHeader = dib === BMP_CORE_DIB_HEADER_BYTES;
+  const planes = buffer.readUInt16LE(
+    coreHeader ? BMP_CORE_PLANES_OFFSET : BMP_INFO_PLANES_OFFSET,
+  );
+  const bits = buffer.readUInt16LE(
+    coreHeader
+      ? BMP_CORE_BITS_PER_PIXEL_OFFSET
+      : BMP_INFO_BITS_PER_PIXEL_OFFSET,
+  );
+  const supportedHeader =
+    coreHeader ||
+    (dib >= BMP_INFO_DIB_HEADER_MIN_BYTES &&
+      dib <= BMP_INFO_DIB_HEADER_MAX_BYTES);
   return (
-    (dib === 12 || (dib >= 40 && dib <= 124)) &&
-    planes === 1 &&
-    [1, 4, 8, 16, 24, 32].includes(bits)
+    supportedHeader &&
+    planes === BMP_REQUIRED_COLOR_PLANES &&
+    BMP_SUPPORTED_BITS_PER_PIXEL.has(bits)
   );
 };
 
 const animatedPng = (buffer: Buffer): boolean => {
   let offset = PNG_SIGNATURE.length;
-  while (offset + 8 <= buffer.length) {
+  while (offset + PNG_CHUNK_HEADER_BYTES <= buffer.length) {
     const length = buffer.readUInt32BE(offset);
-    if (asciiAt(buffer, offset + 4, "acTL")) return true;
-    if (asciiAt(buffer, offset + 4, "IDAT")) return false;
-    const next = offset + 12 + length;
+    const typeOffset = offset + PNG_CHUNK_TYPE_OFFSET;
+    if (signatureAt(buffer, typeOffset, PNG_ANIMATION_CONTROL_CHUNK))
+      return true;
+    if (signatureAt(buffer, typeOffset, PNG_IMAGE_DATA_CHUNK)) return false;
+    const next = offset + PNG_CHUNK_OVERHEAD_BYTES + length;
     if (next <= offset || next > buffer.length) return false;
     offset = next;
   }
@@ -107,24 +203,39 @@ const animatedPng = (buffer: Buffer): boolean => {
 const imageMime = async (path: string): Promise<string | null> => {
   const handle = await open(path, "r");
   try {
-    const bytes = Buffer.alloc(4_100);
-    const { bytesRead } = await handle.read(bytes, 0, bytes.length, 0);
-    const data = bytes.subarray(0, bytesRead);
-    if (data[0] === 0xff && data[1] === 0xd8 && data[2] === 0xff) {
-      return data[3] === 0xf7 ? null : "image/jpeg";
+    const bytes = Buffer.alloc(IMAGE_TYPE_SNIFF_BYTES);
+    const { bytesRead } = await handle.read(
+      bytes,
+      FILE_START_OFFSET,
+      bytes.length,
+      FILE_START_OFFSET,
+    );
+    const data = bytes.subarray(FILE_START_OFFSET, bytesRead);
+    if (signatureAt(data, FILE_START_OFFSET, JPEG_SIGNATURE)) {
+      return data[JPEG_MARKER_OFFSET] === JPEG_LS_MARKER
+        ? null
+        : IMAGE_MIME.jpeg;
     }
     if (
-      data.subarray(0, 8).equals(PNG_SIGNATURE) &&
-      data.length >= 16 &&
-      data.readUInt32BE(8) === 13 &&
-      asciiAt(data, 12, "IHDR")
+      signatureAt(data, FILE_START_OFFSET, PNG_SIGNATURE) &&
+      data.length >= PNG_MIN_HEADER_BYTES &&
+      data.readUInt32BE(PNG_IHDR_DATA_LENGTH_OFFSET) === PNG_IHDR_DATA_LENGTH &&
+      signatureAt(data, PNG_IHDR_TYPE_OFFSET, PNG_HEADER_CHUNK)
     ) {
-      return animatedPng(data) ? null : "image/png";
+      return animatedPng(data) ? null : IMAGE_MIME.png;
     }
-    if (asciiAt(data, 0, "GIF")) return "image/gif";
-    if (asciiAt(data, 0, "RIFF") && asciiAt(data, 8, "WEBP"))
-      return "image/webp";
-    if (asciiAt(data, 0, "BM") && validBmp(data)) return "image/bmp";
+    if (signatureAt(data, FILE_START_OFFSET, GIF_SIGNATURE)) {
+      return IMAGE_MIME.gif;
+    }
+    if (
+      signatureAt(data, FILE_START_OFFSET, RIFF_SIGNATURE) &&
+      signatureAt(data, WEBP_FORMAT_OFFSET, WEBP_SIGNATURE)
+    ) {
+      return IMAGE_MIME.webp;
+    }
+    if (signatureAt(data, FILE_START_OFFSET, BMP_SIGNATURE) && validBmp(data)) {
+      return IMAGE_MIME.bmp;
+    }
     return null;
   } finally {
     await handle.close();
@@ -400,8 +511,14 @@ export const createHearthGrepDefinition = (
     execute(_id, input, signal) {
       return gate.shared(async () => {
         const searchPath = absolutePath(cwd, input.path || ".");
-        const limit = Math.max(1, input.limit ?? DEFAULT_GREP_LIMIT);
-        const context = input.context && input.context > 0 ? input.context : 0;
+        const limit = Math.max(
+          MIN_GREP_LIMIT,
+          input.limit ?? DEFAULT_GREP_LIMIT,
+        );
+        const context =
+          input.context && input.context > NO_CONTEXT_LINES
+            ? input.context
+            : NO_CONTEXT_LINES;
         const glob = parseGrepGlob(input.glob);
         const postFilterGlob =
           glob !== undefined &&
@@ -461,7 +578,7 @@ export const createHearthGrepDefinition = (
             : basename(file.path);
           const matches = file.lines.filter((line) => line.isMatch);
           let fullLines: string[] | undefined;
-          if (context > 0) {
+          if (context > NO_CONTEXT_LINES) {
             try {
               const content = await engine.readBytesAsync(
                 { path: file.path },
@@ -477,9 +594,12 @@ export const createHearthGrepDefinition = (
             }
           }
           for (const match of matches) {
-            const firstLine = Math.max(1, match.lineNumber - context);
+            const firstLine = Math.max(
+              FIRST_LINE_NUMBER,
+              match.lineNumber - context,
+            );
             const block =
-              context === 0 || fullLines === undefined
+              context === NO_CONTEXT_LINES || fullLines === undefined
                 ? [match]
                 : fullLines
                     .slice(
@@ -511,14 +631,14 @@ export const createHearthGrepDefinition = (
         const notices: string[] = [];
         if (matchLimitReached !== undefined) {
           notices.push(
-            `${limit} matches limit reached. Use limit=${limit * 2} for more, or refine pattern`,
+            `${limit} matches limit reached. Use limit=${limit * GREP_LIMIT_REFINEMENT_MULTIPLIER} for more, or refine pattern`,
           );
         }
         if (truncation.truncated)
           notices.push(`${formatSize(DEFAULT_MAX_BYTES)} limit reached`);
         if (linesTruncated)
           notices.push(
-            "Some lines truncated to 500 chars. Use read tool to see full lines",
+            `Some lines truncated to ${GREP_MAX_LINE_LENGTH} chars. Use read tool to see full lines`,
           );
         const output = `${truncation.content}${
           notices.length === 0 ? "" : `\n\n[${notices.join(". ")}]`
@@ -549,10 +669,10 @@ const timeoutMs = (seconds: number | undefined): number | undefined => {
   if (!Number.isFinite(seconds) || seconds <= 0) {
     throw new Error("Invalid timeout: must be a finite number of seconds");
   }
-  const milliseconds = seconds * 1000;
+  const milliseconds = seconds * MILLISECONDS_PER_SECOND;
   if (milliseconds > MAX_TIMEOUT_MS) {
     throw new Error(
-      `Invalid timeout: maximum is ${MAX_TIMEOUT_MS / 1000} seconds`,
+      `Invalid timeout: maximum is ${MAX_TIMEOUT_MS / MILLISECONDS_PER_SECOND} seconds`,
     );
   }
   return milliseconds;
@@ -599,10 +719,13 @@ export const createHearthBashOperations = (
         );
         if (result.aborted) throw new Error("aborted");
         if (result.timedOut)
-          throw new Error(`timeout:${effectiveTimeoutMs / 1000}`);
+          throw new Error(
+            `timeout:${effectiveTimeoutMs / MILLISECONDS_PER_SECOND}`,
+          );
         return {
           exitCode:
-            result.signal !== undefined && result.exitCode === -1
+            result.signal !== undefined &&
+            result.exitCode === HEARTH_SIGNAL_EXIT_CODE
               ? null
               : result.exitCode,
         };

--- a/pi/extensions/hearth-tools/adapters.ts
+++ b/pi/extensions/hearth-tools/adapters.ts
@@ -273,32 +273,34 @@ export const createHearthEditDefinition = (
 const normalizedGlobPath = (value: string): string =>
   value.replaceAll("\\", "/");
 
-const hearthGlobs = (
-  searchPath: string,
-  glob: string | undefined,
-): string[] => {
+const hearthGlobs = (cwd: string, glob: string | undefined): string[] => {
   if (glob === undefined || glob.startsWith("!")) return [];
   const normalized = normalizedGlobPath(glob);
   if (!normalized.includes("/")) return [normalized];
-  return [
-    normalizedGlobPath(resolve(searchPath, normalized.replace(/^\/+/, ""))),
-  ];
+  return [normalizedGlobPath(resolve(cwd, normalized.replace(/^\/+/, "")))];
 };
 
 const excludeNegativeGlob = (
   files: FileMatches[],
-  root: string,
+  cwd: string,
   glob: string | undefined,
+  rootIsDirectory: boolean,
 ): FileMatches[] => {
-  if (glob === undefined || !glob.startsWith("!")) return files;
-  const pattern = normalizedGlobPath(glob.slice(1)).replace(/^\/+/, "");
+  if (glob === undefined || !glob.startsWith("!") || !rootIsDirectory) {
+    return files;
+  }
+  const rawPattern = normalizedGlobPath(glob.slice(1));
+  const rooted = rawPattern.startsWith("/");
+  const pattern = rawPattern.replace(/^\/+/, "");
   const matcher = new Bun.Glob(pattern);
   return files.filter((file) => {
-    const relativePath = normalizedGlobPath(relative(root, file.path));
-    return !(
-      matcher.match(relativePath) ||
-      matcher.match(normalizedGlobPath(basename(file.path)))
-    );
+    const relativePath = normalizedGlobPath(relative(cwd, file.path));
+    const pathMatches = matcher.match(relativePath);
+    const basenameMatches =
+      !rooted &&
+      !pattern.includes("/") &&
+      matcher.match(normalizedGlobPath(basename(file.path)));
+    return !(pathMatches || basenameMatches);
   });
 };
 
@@ -359,7 +361,7 @@ export const createHearthGrepDefinition = (
               pattern: input.pattern,
               path: searchPath,
               mode: "content" as GrepMode,
-              globs: hearthGlobs(searchPath, input.glob),
+              globs: hearthGlobs(cwd, input.glob),
               caseInsensitive: input.ignoreCase ?? false,
               fixedStrings: input.literal ?? false,
               beforeContext: context,
@@ -376,8 +378,9 @@ export const createHearthGrepDefinition = (
 
         const filtered = excludeNegativeGlob(
           result.files,
-          result.root,
+          cwd,
           input.glob,
+          result.rootIsDir,
         );
         const totalMatches = filtered.reduce(
           (total, file) => total + file.matchCount,
@@ -405,14 +408,36 @@ export const createHearthGrepDefinition = (
             ? relative(result.root, file.path).replaceAll("\\", "/")
             : basename(file.path);
           const matches = file.lines.filter((line) => line.isMatch);
+          let fullLines: string[] | undefined;
+          if (context > 0) {
+            try {
+              const content = await engine.readBytesAsync(
+                { path: file.path },
+                signal,
+              );
+              fullLines = content
+                .toString("utf8")
+                .replace(/\r\n/g, "\n")
+                .replace(/\r/g, "\n")
+                .split("\n");
+            } catch (error) {
+              mapCancelled(error, "Operation aborted");
+            }
+          }
           for (const match of matches) {
+            const firstLine = Math.max(1, match.lineNumber - context);
             const block =
-              context === 0
+              context === 0 || fullLines === undefined
                 ? [match]
-                : file.lines.filter(
-                    (line) =>
-                      Math.abs(line.lineNumber - match.lineNumber) <= context,
-                  );
+                : fullLines
+                    .slice(
+                      firstLine - 1,
+                      Math.min(fullLines.length, match.lineNumber + context),
+                    )
+                    .map((text, index) => ({
+                      lineNumber: firstLine + index,
+                      text,
+                    }));
             for (const line of block) {
               const truncated = truncateLine(line.text.replaceAll("\r", ""));
               linesTruncated ||= truncated.wasTruncated;

--- a/pi/extensions/hearth-tools/adapters.ts
+++ b/pi/extensions/hearth-tools/adapters.ts
@@ -1,0 +1,448 @@
+import {
+  createBashToolDefinition,
+  createEditToolDefinition,
+  createGrepToolDefinition,
+  createReadTool,
+  createReadToolDefinition,
+  createWriteToolDefinition,
+  DEFAULT_MAX_BYTES,
+  formatSize,
+  truncateHead,
+  truncateLine,
+  withFileMutationQueue,
+  type BashOperations,
+  type EditToolDetails,
+} from "@earendil-works/pi-coding-agent";
+import type {
+  BashChunk,
+  DiffHunk,
+  GrepMode,
+  HearthEngine,
+  ShellSpec,
+  WriteMode,
+} from "@hearthdev/napi";
+import { constants } from "node:fs";
+import { access, open } from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, isAbsolute, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { PiToolSettings } from "./engine";
+
+const DEFAULT_GREP_LIMIT = 100;
+const MAX_TIMEOUT_MS = 2_147_483_647;
+
+const absolutePath = (cwd: string, input: string): string => {
+  let normalized = input.replace(
+    /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g,
+    " ",
+  );
+  if (normalized.startsWith("@")) normalized = normalized.slice(1);
+  if (normalized === "~") normalized = homedir();
+  else if (normalized.startsWith("~/"))
+    normalized = join(homedir(), normalized.slice(2));
+  if (normalized.startsWith("file://")) normalized = fileURLToPath(normalized);
+  return isAbsolute(normalized)
+    ? resolve(normalized)
+    : resolve(cwd, normalized);
+};
+
+const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+const PNG_SIGNATURE = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+
+const asciiAt = (buffer: Buffer, offset: number, text: string): boolean =>
+  buffer.length >= offset + text.length &&
+  [...text].every(
+    (character, index) => buffer[offset + index] === character.charCodeAt(0),
+  );
+
+const validBmp = (buffer: Buffer): boolean => {
+  if (buffer.length < 26) return false;
+  const size = buffer.readUInt32LE(2);
+  const pixels = buffer.readUInt32LE(10);
+  const dib = buffer.readUInt32LE(14);
+  if (
+    (size !== 0 && size < 26) ||
+    pixels < 14 + dib ||
+    (size !== 0 && pixels >= size)
+  ) {
+    return false;
+  }
+  if (dib !== 12 && buffer.length < 30) return false;
+  const planes = buffer.readUInt16LE(dib === 12 ? 22 : 26);
+  const bits = buffer.readUInt16LE(dib === 12 ? 24 : 28);
+  return (
+    (dib === 12 || (dib >= 40 && dib <= 124)) &&
+    planes === 1 &&
+    [1, 4, 8, 16, 24, 32].includes(bits)
+  );
+};
+
+const animatedPng = (buffer: Buffer): boolean => {
+  let offset = PNG_SIGNATURE.length;
+  while (offset + 8 <= buffer.length) {
+    const length = buffer.readUInt32BE(offset);
+    if (asciiAt(buffer, offset + 4, "acTL")) return true;
+    if (asciiAt(buffer, offset + 4, "IDAT")) return false;
+    const next = offset + 12 + length;
+    if (next <= offset || next > buffer.length) return false;
+    offset = next;
+  }
+  return false;
+};
+
+const imageMime = async (path: string): Promise<string | null> => {
+  const handle = await open(path, "r");
+  try {
+    const bytes = Buffer.alloc(4_100);
+    const { bytesRead } = await handle.read(bytes, 0, bytes.length, 0);
+    const data = bytes.subarray(0, bytesRead);
+    if (data[0] === 0xff && data[1] === 0xd8 && data[2] === 0xff) {
+      return data[3] === 0xf7 ? null : "image/jpeg";
+    }
+    if (
+      data.subarray(0, 8).equals(PNG_SIGNATURE) &&
+      data.length >= 16 &&
+      data.readUInt32BE(8) === 13 &&
+      asciiAt(data, 12, "IHDR")
+    ) {
+      return animatedPng(data) ? null : "image/png";
+    }
+    if (asciiAt(data, 0, "GIF")) return "image/gif";
+    if (asciiAt(data, 0, "RIFF") && asciiAt(data, 8, "WEBP"))
+      return "image/webp";
+    if (asciiAt(data, 0, "BM") && validBmp(data)) return "image/bmp";
+    return null;
+  } finally {
+    await handle.close();
+  }
+};
+
+const hearthReadOperations = (
+  engine: HearthEngine,
+  signal: AbortSignal | undefined,
+) => ({
+  access: (path: string) => access(path, constants.R_OK),
+  detectImageMimeType: imageMime,
+  readFile: (path: string) => engine.readBytesAsync({ path }, signal),
+});
+
+export const createHearthReadDefinition = (
+  cwd: string,
+  engine: HearthEngine,
+  settings: PiToolSettings,
+) => {
+  const base = createReadToolDefinition(cwd, {
+    autoResizeImages: settings.imageAutoResize,
+  });
+  const definition: typeof base = {
+    ...base,
+    execute(id, params, signal, onUpdate, ctx) {
+      const delegated = createReadToolDefinition(cwd, {
+        autoResizeImages: settings.imageAutoResize,
+        operations: hearthReadOperations(engine, signal),
+      });
+      return delegated.execute(id, params, signal, onUpdate, ctx);
+    },
+  };
+  return definition;
+};
+
+export const createHearthReadTool = (
+  cwd: string,
+  engine: HearthEngine,
+  settings: PiToolSettings,
+) => {
+  const base = createReadTool(cwd, {
+    autoResizeImages: settings.imageAutoResize,
+  });
+  const tool: typeof base = {
+    ...base,
+    execute(id, params, signal, onUpdate) {
+      return createReadTool(cwd, {
+        autoResizeImages: settings.imageAutoResize,
+        operations: hearthReadOperations(engine, signal),
+      }).execute(id, params, signal, onUpdate);
+    },
+  };
+  return tool;
+};
+
+export const createHearthWriteDefinition = (
+  cwd: string,
+  engine: HearthEngine,
+) => {
+  const base = createWriteToolDefinition(cwd);
+  const definition: typeof base = {
+    ...base,
+    execute(id, params, signal, onUpdate, ctx) {
+      const delegated = createWriteToolDefinition(cwd, {
+        operations: {
+          mkdir: async () => {},
+          writeFile: async (path, content) => {
+            await engine.writeAsync(
+              {
+                path,
+                content,
+                createDirs: true,
+                mode: "inPlace" as WriteMode,
+                followSymlinks: true,
+              },
+              signal,
+            );
+          },
+        },
+      });
+      return delegated.execute(id, params, signal, onUpdate, ctx);
+    },
+  };
+  return definition;
+};
+
+const displayDiff = (
+  hunks: DiffHunk[],
+  oldLines: number,
+  newLines: number,
+): string => {
+  const width = String(Math.max(oldLines, newLines)).length;
+  const output: string[] = [];
+  for (let index = 0; index < hunks.length; index += 1) {
+    if (index > 0) output.push(` ${"".padStart(width)} ...`);
+    for (const row of hunks[index]!.rows) {
+      if (row.op === "insert") {
+        output.push(`+${String(row.newLine).padStart(width)} ${row.text}`);
+      } else if (row.op === "delete") {
+        output.push(`-${String(row.oldLine).padStart(width)} ${row.text}`);
+      } else {
+        output.push(` ${String(row.oldLine).padStart(width)} ${row.text}`);
+      }
+    }
+  }
+  return output.join("\n");
+};
+
+const unifiedPatch = (path: string, hunks: DiffHunk[]): string => {
+  const lines = [`--- ${path}`, `+++ ${path}`];
+  for (const hunk of hunks) {
+    lines.push(
+      `@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@`,
+    );
+    for (const row of hunk.rows) {
+      const prefix =
+        row.op === "insert" ? "+" : row.op === "delete" ? "-" : " ";
+      lines.push(`${prefix}${row.text}`);
+    }
+  }
+  return `${lines.join("\n")}\n`;
+};
+
+export const createHearthEditDefinition = (
+  cwd: string,
+  engine: HearthEngine,
+) => {
+  const base = createEditToolDefinition(cwd);
+  const definition: typeof base = {
+    ...base,
+    async execute(_id, input, signal) {
+      if (!Array.isArray(input.edits) || input.edits.length === 0) {
+        throw new Error(
+          "Edit tool input is invalid. edits must contain at least one replacement.",
+        );
+      }
+      const path = absolutePath(cwd, input.path);
+      return withFileMutationQueue(path, async () => {
+        const result = await engine.editBatchAsync(
+          {
+            path,
+            edits: input.edits,
+            diffContext: 4,
+            mode: "inPlace" as WriteMode,
+            followSymlinks: true,
+          },
+          signal,
+        );
+        const details: EditToolDetails = {
+          diff: displayDiff(
+            result.hunks,
+            result.oldLineCount,
+            result.newLineCount,
+          ),
+          patch: unifiedPatch(input.path, result.hunks),
+          ...(result.firstChangedLine === undefined
+            ? {}
+            : { firstChangedLine: result.firstChangedLine }),
+        };
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Successfully replaced ${input.edits.length} block(s) in ${input.path}.`,
+            },
+          ],
+          details,
+        };
+      });
+    },
+  };
+  return definition;
+};
+
+export const createHearthGrepDefinition = (
+  cwd: string,
+  engine: HearthEngine,
+) => {
+  const base = createGrepToolDefinition(cwd);
+  const definition: typeof base = {
+    ...base,
+    async execute(_id, input, signal) {
+      const searchPath = absolutePath(cwd, input.path || ".");
+      const limit = Math.max(1, input.limit ?? DEFAULT_GREP_LIMIT);
+      const context = input.context && input.context > 0 ? input.context : 0;
+      const result = await engine.grepAsync(
+        {
+          pattern: input.pattern,
+          path: searchPath,
+          mode: "content" as GrepMode,
+          globs: input.glob ? [input.glob] : [],
+          caseInsensitive: input.ignoreCase ?? false,
+          fixedStrings: input.literal ?? false,
+          beforeContext: context,
+          afterContext: context,
+          maxTotalCount: limit,
+          hidden: true,
+          respectGitignore: true,
+        },
+        signal,
+      );
+      if (result.totalMatches === 0) {
+        return {
+          content: [{ type: "text" as const, text: "No matches found" }],
+          details: undefined,
+        };
+      }
+
+      let linesTruncated = false;
+      const lines: string[] = [];
+      for (const file of result.files) {
+        const shownPath = result.rootIsDir
+          ? relative(result.root, file.path).replaceAll("\\", "/")
+          : basename(file.path);
+        for (const line of file.lines) {
+          const truncated = truncateLine(line.text.replaceAll("\r", ""));
+          linesTruncated ||= truncated.wasTruncated;
+          lines.push(
+            line.isMatch
+              ? `${shownPath}:${line.lineNumber}: ${truncated.text}`
+              : `${shownPath}-${line.lineNumber}- ${truncated.text}`,
+          );
+        }
+      }
+      const truncation = truncateHead(lines.join("\n"), {
+        maxLines: Number.MAX_SAFE_INTEGER,
+      });
+      const matchLimitReached = result.limitReached ? limit : undefined;
+      const notices: string[] = [];
+      if (matchLimitReached !== undefined) {
+        notices.push(
+          `${limit} matches limit reached. Use limit=${limit * 2} for more, or refine pattern`,
+        );
+      }
+      if (truncation.truncated)
+        notices.push(`${formatSize(DEFAULT_MAX_BYTES)} limit reached`);
+      if (linesTruncated)
+        notices.push(
+          "Some lines truncated to 500 chars. Use read tool to see full lines",
+        );
+      const output = `${truncation.content}${
+        notices.length === 0 ? "" : `\n\n[${notices.join(". ")}]`
+      }`;
+      return {
+        content: [{ type: "text" as const, text: output }],
+        details:
+          matchLimitReached === undefined &&
+          !truncation.truncated &&
+          !linesTruncated
+            ? undefined
+            : {
+                ...(matchLimitReached === undefined
+                  ? {}
+                  : { matchLimitReached }),
+                ...(truncation.truncated ? { truncation } : {}),
+                ...(linesTruncated ? { linesTruncated: true } : {}),
+              },
+      };
+    },
+  };
+  return definition;
+};
+
+const timeoutMs = (seconds: number | undefined): number | undefined => {
+  if (seconds === undefined) return undefined;
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    throw new Error("Invalid timeout: must be a finite number of seconds");
+  }
+  const milliseconds = seconds * 1000;
+  if (milliseconds > MAX_TIMEOUT_MS) {
+    throw new Error(
+      `Invalid timeout: maximum is ${MAX_TIMEOUT_MS / 1000} seconds`,
+    );
+  }
+  return milliseconds;
+};
+
+const environment = (
+  env: NodeJS.ProcessEnv | undefined,
+): Record<string, string> =>
+  Object.fromEntries(
+    Object.entries(env ?? {}).filter(
+      (entry): entry is [string, string] => entry[1] !== undefined,
+    ),
+  );
+
+export const createHearthBashOperations = (
+  engine: HearthEngine,
+  shell: ShellSpec,
+): BashOperations => ({
+  async exec(command, cwd, options) {
+    try {
+      const result = await engine.bashStream(
+        {
+          command,
+          cwd,
+          timeoutMs: timeoutMs(options.timeout),
+          env: environment(options.env),
+          shell,
+          collectOutput: false,
+        },
+        (chunk: BashChunk) => options.onData(Buffer.from(chunk.text, "utf8")),
+        options.signal,
+      );
+      if (result.aborted) throw new Error("aborted");
+      if (result.timedOut) throw new Error(`timeout:${options.timeout}`);
+      return { exitCode: result.exitCode };
+    } catch (error) {
+      if (errorMessage(error).startsWith("indeterminate:")) {
+        throw new Error(
+          "Hearth reported an indeterminate command outcome; inspect state before retrying",
+        );
+      }
+      throw error;
+    } finally {
+      engine.clearCaches();
+    }
+  },
+});
+
+export const createHearthBashDefinition = (
+  cwd: string,
+  engine: HearthEngine,
+  settings: PiToolSettings,
+) =>
+  createBashToolDefinition(cwd, {
+    commandPrefix: settings.shellCommandPrefix,
+    shellPath: settings.shellPath,
+    operations: createHearthBashOperations(engine, settings.shell),
+  });

--- a/pi/extensions/hearth-tools/adapters.ts
+++ b/pi/extensions/hearth-tools/adapters.ts
@@ -304,12 +304,7 @@ const parseGrepGlob = (glob: string | undefined): GrepGlob | undefined => {
 
 const hearthGlobs = (glob: GrepGlob | undefined): string[] => {
   if (glob === undefined) return [];
-  if (
-    glob.negative ||
-    glob.rooted ||
-    glob.directoryOnly ||
-    glob.hasSlash
-  ) {
+  if (glob.negative || glob.rooted || glob.directoryOnly || glob.hasSlash) {
     // Hearth's native globset is the same strict parser family as ripgrep.
     // `**` keeps the candidate walk unfiltered while the second entry validates
     // malformed classes, ranges, alternates, and escapes before JS post-filtering.
@@ -345,10 +340,7 @@ const filterPostProcessedGlob = (
   if (
     glob === undefined ||
     !rootIsDirectory ||
-    (!glob.negative &&
-      !glob.rooted &&
-      !glob.directoryOnly &&
-      !glob.hasSlash)
+    (!glob.negative && !glob.rooted && !glob.directoryOnly && !glob.hasSlash)
   ) {
     return files;
   }
@@ -413,10 +405,7 @@ export const createHearthGrepDefinition = (
         const glob = parseGrepGlob(input.glob);
         const postFilterGlob =
           glob !== undefined &&
-          (glob.negative ||
-            glob.rooted ||
-            glob.directoryOnly ||
-            glob.hasSlash);
+          (glob.negative || glob.rooted || glob.directoryOnly || glob.hasSlash);
         const result = await engine
           .grepAsync(
             {

--- a/pi/extensions/hearth-tools/adapters.ts
+++ b/pi/extensions/hearth-tools/adapters.ts
@@ -9,13 +9,11 @@ import {
   formatSize,
   truncateHead,
   truncateLine,
-  withFileMutationQueue,
   type BashOperations,
-  type EditToolDetails,
 } from "@earendil-works/pi-coding-agent";
 import type {
   BashChunk,
-  DiffHunk,
+  FileMatches,
   GrepMode,
   HearthEngine,
   ShellSpec,
@@ -26,7 +24,11 @@ import { access, open } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { PiToolSettings } from "./engine";
+import {
+  IMMEDIATE_HEARTH_ACCESS_GATE,
+  type HearthAccessGate,
+  type PiToolSettings,
+} from "./engine";
 
 const DEFAULT_GREP_LIMIT = 100;
 const MAX_TIMEOUT_MS = 2_147_483_647;
@@ -48,6 +50,11 @@ const absolutePath = (cwd: string, input: string): string => {
 
 const errorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
+
+const mapCancelled = (error: unknown, message: string): never => {
+  if (errorMessage(error).startsWith("cancelled:")) throw new Error(message);
+  throw error;
+};
 
 const PNG_SIGNATURE = Buffer.from([
   0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
@@ -134,6 +141,7 @@ export const createHearthReadDefinition = (
   cwd: string,
   engine: HearthEngine,
   settings: PiToolSettings,
+  gate: HearthAccessGate = IMMEDIATE_HEARTH_ACCESS_GATE,
 ) => {
   const base = createReadToolDefinition(cwd, {
     autoResizeImages: settings.imageAutoResize,
@@ -145,7 +153,9 @@ export const createHearthReadDefinition = (
         autoResizeImages: settings.imageAutoResize,
         operations: hearthReadOperations(engine, signal),
       });
-      return delegated.execute(id, params, signal, onUpdate, ctx);
+      return gate.shared(() =>
+        delegated.execute(id, params, signal, onUpdate, ctx),
+      );
     },
   };
   return definition;
@@ -155,6 +165,7 @@ export const createHearthReadTool = (
   cwd: string,
   engine: HearthEngine,
   settings: PiToolSettings,
+  gate: HearthAccessGate = IMMEDIATE_HEARTH_ACCESS_GATE,
 ) => {
   const base = createReadTool(cwd, {
     autoResizeImages: settings.imageAutoResize,
@@ -162,10 +173,12 @@ export const createHearthReadTool = (
   const tool: typeof base = {
     ...base,
     execute(id, params, signal, onUpdate) {
-      return createReadTool(cwd, {
-        autoResizeImages: settings.imageAutoResize,
-        operations: hearthReadOperations(engine, signal),
-      }).execute(id, params, signal, onUpdate);
+      return gate.shared(() =>
+        createReadTool(cwd, {
+          autoResizeImages: settings.imageAutoResize,
+          operations: hearthReadOperations(engine, signal),
+        }).execute(id, params, signal, onUpdate),
+      );
     },
   };
   return tool;
@@ -174,6 +187,7 @@ export const createHearthReadTool = (
 export const createHearthWriteDefinition = (
   cwd: string,
   engine: HearthEngine,
+  gate: HearthAccessGate = IMMEDIATE_HEARTH_ACCESS_GATE,
 ) => {
   const base = createWriteToolDefinition(cwd);
   const definition: typeof base = {
@@ -183,197 +197,244 @@ export const createHearthWriteDefinition = (
         operations: {
           mkdir: async () => {},
           writeFile: async (path, content) => {
-            await engine.writeAsync(
-              {
-                path,
-                content,
-                createDirs: true,
-                mode: "inPlace" as WriteMode,
-                followSymlinks: true,
-              },
-              signal,
-            );
+            try {
+              await engine.writeAsync(
+                {
+                  path,
+                  content,
+                  createDirs: true,
+                  mode: "inPlace" as WriteMode,
+                  followSymlinks: true,
+                },
+                signal,
+              );
+            } catch (error) {
+              mapCancelled(error, "Operation aborted");
+            }
           },
         },
       });
-      return delegated.execute(id, params, signal, onUpdate, ctx);
+      return gate.shared(() =>
+        delegated.execute(id, params, signal, onUpdate, ctx),
+      );
     },
   };
   return definition;
-};
-
-const displayDiff = (
-  hunks: DiffHunk[],
-  oldLines: number,
-  newLines: number,
-): string => {
-  const width = String(Math.max(oldLines, newLines)).length;
-  const output: string[] = [];
-  for (let index = 0; index < hunks.length; index += 1) {
-    if (index > 0) output.push(` ${"".padStart(width)} ...`);
-    for (const row of hunks[index]!.rows) {
-      if (row.op === "insert") {
-        output.push(`+${String(row.newLine).padStart(width)} ${row.text}`);
-      } else if (row.op === "delete") {
-        output.push(`-${String(row.oldLine).padStart(width)} ${row.text}`);
-      } else {
-        output.push(` ${String(row.oldLine).padStart(width)} ${row.text}`);
-      }
-    }
-  }
-  return output.join("\n");
-};
-
-const unifiedPatch = (path: string, hunks: DiffHunk[]): string => {
-  const lines = [`--- ${path}`, `+++ ${path}`];
-  for (const hunk of hunks) {
-    lines.push(
-      `@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@`,
-    );
-    for (const row of hunk.rows) {
-      const prefix =
-        row.op === "insert" ? "+" : row.op === "delete" ? "-" : " ";
-      lines.push(`${prefix}${row.text}`);
-    }
-  }
-  return `${lines.join("\n")}\n`;
 };
 
 export const createHearthEditDefinition = (
   cwd: string,
   engine: HearthEngine,
+  gate: HearthAccessGate = IMMEDIATE_HEARTH_ACCESS_GATE,
 ) => {
   const base = createEditToolDefinition(cwd);
   const definition: typeof base = {
     ...base,
-    async execute(_id, input, signal) {
-      if (!Array.isArray(input.edits) || input.edits.length === 0) {
-        throw new Error(
-          "Edit tool input is invalid. edits must contain at least one replacement.",
-        );
-      }
-      const path = absolutePath(cwd, input.path);
-      return withFileMutationQueue(path, async () => {
-        const result = await engine.editBatchAsync(
-          {
-            path,
-            edits: input.edits,
-            diffContext: 4,
-            mode: "inPlace" as WriteMode,
-            followSymlinks: true,
+    execute(id, input, signal, onUpdate, ctx) {
+      const delegated = createEditToolDefinition(cwd, {
+        operations: {
+          access: (path) =>
+            access(path, constants.R_OK | constants.W_OK).catch((error) =>
+              mapCancelled(error, "Operation aborted"),
+            ),
+          readFile: (path) =>
+            engine
+              .readBytesAsync({ path }, signal)
+              .catch((error) => mapCancelled(error, "Operation aborted")),
+          writeFile: async (path, content) => {
+            try {
+              await engine.writeAsync(
+                {
+                  path,
+                  content,
+                  createDirs: false,
+                  mode: "inPlace" as WriteMode,
+                  followSymlinks: true,
+                },
+                signal,
+              );
+            } catch (error) {
+              mapCancelled(error, "Operation aborted");
+            }
           },
-          signal,
-        );
-        const details: EditToolDetails = {
-          diff: displayDiff(
-            result.hunks,
-            result.oldLineCount,
-            result.newLineCount,
-          ),
-          patch: unifiedPatch(input.path, result.hunks),
-          ...(result.firstChangedLine === undefined
-            ? {}
-            : { firstChangedLine: result.firstChangedLine }),
-        };
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: `Successfully replaced ${input.edits.length} block(s) in ${input.path}.`,
-            },
-          ],
-          details,
-        };
+        },
       });
+      return gate.shared(() =>
+        delegated.execute(id, input, signal, onUpdate, ctx),
+      );
     },
   };
   return definition;
 };
 
+const normalizedGlobPath = (value: string): string =>
+  value.replaceAll("\\", "/");
+
+const hearthGlobs = (
+  searchPath: string,
+  glob: string | undefined,
+): string[] => {
+  if (glob === undefined || glob.startsWith("!")) return [];
+  const normalized = normalizedGlobPath(glob);
+  if (!normalized.includes("/")) return [normalized];
+  return [
+    normalizedGlobPath(resolve(searchPath, normalized.replace(/^\/+/, ""))),
+  ];
+};
+
+const excludeNegativeGlob = (
+  files: FileMatches[],
+  root: string,
+  glob: string | undefined,
+): FileMatches[] => {
+  if (glob === undefined || !glob.startsWith("!")) return files;
+  const matcher = new Bun.Glob(glob.slice(1));
+  return files.filter((file) => {
+    const relativePath = normalizedGlobPath(relative(root, file.path));
+    return !(
+      matcher.match(relativePath) ||
+      matcher.match(normalizedGlobPath(basename(file.path)))
+    );
+  });
+};
+
+const limitFileMatches = (
+  files: FileMatches[],
+  limit: number,
+  context: number,
+): FileMatches[] => {
+  let remaining = limit;
+  const limited: FileMatches[] = [];
+  for (const file of files) {
+    if (remaining === 0) break;
+    const matchLines = file.lines
+      .filter((line) => line.isMatch)
+      .slice(0, remaining)
+      .map((line) => line.lineNumber);
+    if (matchLines.length === 0) continue;
+    const kept = new Set(matchLines);
+    limited.push({
+      ...file,
+      matchCount: matchLines.length,
+      lines: file.lines.filter((line) =>
+        line.isMatch
+          ? kept.has(line.lineNumber)
+          : matchLines.some(
+              (matchLine) => Math.abs(matchLine - line.lineNumber) <= context,
+            ),
+      ),
+    });
+    remaining -= matchLines.length;
+  }
+  return limited;
+};
+
 export const createHearthGrepDefinition = (
   cwd: string,
   engine: HearthEngine,
+  gate: HearthAccessGate = IMMEDIATE_HEARTH_ACCESS_GATE,
 ) => {
   const base = createGrepToolDefinition(cwd);
   const definition: typeof base = {
     ...base,
-    async execute(_id, input, signal) {
-      const searchPath = absolutePath(cwd, input.path || ".");
-      const limit = Math.max(1, input.limit ?? DEFAULT_GREP_LIMIT);
-      const context = input.context && input.context > 0 ? input.context : 0;
-      const result = await engine.grepAsync(
-        {
-          pattern: input.pattern,
-          path: searchPath,
-          mode: "content" as GrepMode,
-          globs: input.glob ? [input.glob] : [],
-          caseInsensitive: input.ignoreCase ?? false,
-          fixedStrings: input.literal ?? false,
-          beforeContext: context,
-          afterContext: context,
-          maxTotalCount: limit,
-          hidden: true,
-          respectGitignore: true,
-        },
-        signal,
-      );
-      if (result.totalMatches === 0) {
-        return {
-          content: [{ type: "text" as const, text: "No matches found" }],
-          details: undefined,
-        };
-      }
+    execute(_id, input, signal) {
+      return gate.shared(async () => {
+        const searchPath = absolutePath(cwd, input.path || ".");
+        const limit = Math.max(1, input.limit ?? DEFAULT_GREP_LIMIT);
+        const context = input.context && input.context > 0 ? input.context : 0;
+        const negativeGlob = input.glob?.startsWith("!") === true;
+        const result = await engine
+          .grepAsync(
+            {
+              pattern: input.pattern,
+              path: searchPath,
+              mode: "content" as GrepMode,
+              globs: hearthGlobs(searchPath, input.glob),
+              caseInsensitive: input.ignoreCase ?? false,
+              fixedStrings: input.literal ?? false,
+              beforeContext: context,
+              afterContext: context,
+              ...(negativeGlob ? {} : { maxTotalCount: limit }),
+              hidden: true,
+              respectGitignore: true,
+            },
+            signal,
+          )
+          .catch((error) => mapCancelled(error, "Operation aborted"));
 
-      let linesTruncated = false;
-      const lines: string[] = [];
-      for (const file of result.files) {
-        const shownPath = result.rootIsDir
-          ? relative(result.root, file.path).replaceAll("\\", "/")
-          : basename(file.path);
-        for (const line of file.lines) {
-          const truncated = truncateLine(line.text.replaceAll("\r", ""));
-          linesTruncated ||= truncated.wasTruncated;
-          lines.push(
-            line.isMatch
-              ? `${shownPath}:${line.lineNumber}: ${truncated.text}`
-              : `${shownPath}-${line.lineNumber}- ${truncated.text}`,
+        const filtered = excludeNegativeGlob(
+          result.files,
+          result.root,
+          input.glob,
+        );
+        const totalMatches = filtered.reduce(
+          (total, file) => total + file.matchCount,
+          0,
+        );
+        if (totalMatches === 0) {
+          return {
+            content: [{ type: "text" as const, text: "No matches found" }],
+            details: undefined,
+          };
+        }
+
+        const files = negativeGlob
+          ? limitFileMatches(filtered, limit, context)
+          : filtered;
+        let linesTruncated = false;
+        const lines: string[] = [];
+        for (const file of files) {
+          const shownPath = result.rootIsDir
+            ? relative(result.root, file.path).replaceAll("\\", "/")
+            : basename(file.path);
+          for (const line of file.lines) {
+            const truncated = truncateLine(line.text.replaceAll("\r", ""));
+            linesTruncated ||= truncated.wasTruncated;
+            lines.push(
+              line.isMatch
+                ? `${shownPath}:${line.lineNumber}: ${truncated.text}`
+                : `${shownPath}-${line.lineNumber}- ${truncated.text}`,
+            );
+          }
+        }
+        const truncation = truncateHead(lines.join("\n"), {
+          maxLines: Number.MAX_SAFE_INTEGER,
+        });
+        const limitReached = negativeGlob
+          ? totalMatches >= limit
+          : result.limitReached;
+        const matchLimitReached = limitReached ? limit : undefined;
+        const notices: string[] = [];
+        if (matchLimitReached !== undefined) {
+          notices.push(
+            `${limit} matches limit reached. Use limit=${limit * 2} for more, or refine pattern`,
           );
         }
-      }
-      const truncation = truncateHead(lines.join("\n"), {
-        maxLines: Number.MAX_SAFE_INTEGER,
+        if (truncation.truncated)
+          notices.push(`${formatSize(DEFAULT_MAX_BYTES)} limit reached`);
+        if (linesTruncated)
+          notices.push(
+            "Some lines truncated to 500 chars. Use read tool to see full lines",
+          );
+        const output = `${truncation.content}${
+          notices.length === 0 ? "" : `\n\n[${notices.join(". ")}]`
+        }`;
+        return {
+          content: [{ type: "text" as const, text: output }],
+          details:
+            matchLimitReached === undefined &&
+            !truncation.truncated &&
+            !linesTruncated
+              ? undefined
+              : {
+                  ...(matchLimitReached === undefined
+                    ? {}
+                    : { matchLimitReached }),
+                  ...(truncation.truncated ? { truncation } : {}),
+                  ...(linesTruncated ? { linesTruncated: true } : {}),
+                },
+        };
       });
-      const matchLimitReached = result.limitReached ? limit : undefined;
-      const notices: string[] = [];
-      if (matchLimitReached !== undefined) {
-        notices.push(
-          `${limit} matches limit reached. Use limit=${limit * 2} for more, or refine pattern`,
-        );
-      }
-      if (truncation.truncated)
-        notices.push(`${formatSize(DEFAULT_MAX_BYTES)} limit reached`);
-      if (linesTruncated)
-        notices.push(
-          "Some lines truncated to 500 chars. Use read tool to see full lines",
-        );
-      const output = `${truncation.content}${
-        notices.length === 0 ? "" : `\n\n[${notices.join(". ")}]`
-      }`;
-      return {
-        content: [{ type: "text" as const, text: output }],
-        details:
-          matchLimitReached === undefined &&
-          !truncation.truncated &&
-          !linesTruncated
-            ? undefined
-            : {
-                ...(matchLimitReached === undefined
-                  ? {}
-                  : { matchLimitReached }),
-                ...(truncation.truncated ? { truncation } : {}),
-                ...(linesTruncated ? { linesTruncated: true } : {}),
-              },
-      };
     },
   };
   return definition;
@@ -402,37 +463,58 @@ const environment = (
     ),
   );
 
+export interface HearthBashAdapterOptions {
+  defaultTimeoutMs?: number;
+  gate?: HearthAccessGate;
+}
+
 export const createHearthBashOperations = (
   engine: HearthEngine,
   shell: ShellSpec,
+  adapterOptions: HearthBashAdapterOptions = {},
 ): BashOperations => ({
-  async exec(command, cwd, options) {
-    try {
-      const result = await engine.bashStream(
-        {
-          command,
-          cwd,
-          timeoutMs: timeoutMs(options.timeout),
-          env: environment(options.env),
-          shell,
-          collectOutput: false,
-        },
-        (chunk: BashChunk) => options.onData(Buffer.from(chunk.text, "utf8")),
-        options.signal,
-      );
-      if (result.aborted) throw new Error("aborted");
-      if (result.timedOut) throw new Error(`timeout:${options.timeout}`);
-      return { exitCode: result.exitCode };
-    } catch (error) {
-      if (errorMessage(error).startsWith("indeterminate:")) {
-        throw new Error(
-          "Hearth reported an indeterminate command outcome; inspect state before retrying",
+  exec(command, cwd, options) {
+    const gate = adapterOptions.gate ?? IMMEDIATE_HEARTH_ACCESS_GATE;
+    return gate.exclusive(async () => {
+      const effectiveTimeoutMs =
+        timeoutMs(options.timeout) ??
+        adapterOptions.defaultTimeoutMs ??
+        MAX_TIMEOUT_MS;
+      try {
+        const result = await engine.bashStream(
+          {
+            command,
+            cwd,
+            timeoutMs: effectiveTimeoutMs,
+            env: environment(options.env),
+            shell,
+            collectOutput: false,
+          },
+          (chunk: BashChunk) => options.onData(Buffer.from(chunk.text, "utf8")),
+          options.signal,
         );
+        if (result.aborted) throw new Error("aborted");
+        if (result.timedOut)
+          throw new Error(`timeout:${effectiveTimeoutMs / 1000}`);
+        return {
+          exitCode:
+            result.signal !== undefined && result.exitCode === -1
+              ? null
+              : result.exitCode,
+        };
+      } catch (error) {
+        const message = errorMessage(error);
+        if (message.startsWith("cancelled:")) throw new Error("aborted");
+        if (message.startsWith("indeterminate:")) {
+          throw new Error(
+            "Hearth reported an indeterminate command outcome; inspect state before retrying",
+          );
+        }
+        throw error;
+      } finally {
+        engine.clearCaches();
       }
-      throw error;
-    } finally {
-      engine.clearCaches();
-    }
+    });
   },
 });
 
@@ -440,9 +522,14 @@ export const createHearthBashDefinition = (
   cwd: string,
   engine: HearthEngine,
   settings: PiToolSettings,
+  adapterOptions: HearthBashAdapterOptions = {},
 ) =>
   createBashToolDefinition(cwd, {
     commandPrefix: settings.shellCommandPrefix,
     shellPath: settings.shellPath,
-    operations: createHearthBashOperations(engine, settings.shell),
+    operations: createHearthBashOperations(
+      engine,
+      settings.shell,
+      adapterOptions,
+    ),
   });

--- a/pi/extensions/hearth-tools/config.ts
+++ b/pi/extensions/hearth-tools/config.ts
@@ -48,9 +48,21 @@ const boundedInteger = (
   return value;
 };
 
+const CONFIG_KEYS = new Set([
+  "trustCache",
+  "warmShell",
+  "enableOptimizer",
+  "maxCachedFiles",
+  "bashTimeoutMs",
+]);
+
 export const parseHearthToolsConfig = (value: unknown): HearthToolsConfig => {
   if (!isRecord(value))
     throw new Error("hearth-tools config must be an object");
+  for (const key of Object.keys(value)) {
+    if (!CONFIG_KEYS.has(key))
+      throw new Error(`unknown hearth-tools config key: ${key}`);
+  }
   const maxCachedFiles = boundedInteger(
     value.maxCachedFiles,
     "maxCachedFiles",

--- a/pi/extensions/hearth-tools/config.ts
+++ b/pi/extensions/hearth-tools/config.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface HearthToolsConfig {
+  trustCache: boolean;
+  warmShell: boolean;
+  enableOptimizer: boolean;
+  maxCachedFiles?: number;
+  bashTimeoutMs: number;
+}
+
+export const DEFAULT_HEARTH_TOOLS_CONFIG: Readonly<HearthToolsConfig> = {
+  trustCache: true,
+  warmShell: true,
+  enableOptimizer: true,
+  bashTimeoutMs: 2_147_483_647,
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const optionalBoolean = (
+  value: unknown,
+  name: string,
+  fallback: boolean,
+): boolean => {
+  if (value === undefined) return fallback;
+  if (typeof value !== "boolean") throw new Error(`${name} must be boolean`);
+  return value;
+};
+
+const boundedInteger = (
+  value: unknown,
+  name: string,
+  minimum: number,
+  maximum: number,
+  fallback?: number,
+): number | undefined => {
+  if (value === undefined) return fallback;
+  if (
+    typeof value !== "number" ||
+    !Number.isSafeInteger(value) ||
+    value < minimum ||
+    value > maximum
+  ) {
+    throw new Error(`${name} must be an integer from ${minimum} to ${maximum}`);
+  }
+  return value;
+};
+
+export const parseHearthToolsConfig = (value: unknown): HearthToolsConfig => {
+  if (!isRecord(value))
+    throw new Error("hearth-tools config must be an object");
+  const maxCachedFiles = boundedInteger(
+    value.maxCachedFiles,
+    "maxCachedFiles",
+    1,
+    1_000_000,
+  );
+  return {
+    trustCache: optionalBoolean(
+      value.trustCache,
+      "trustCache",
+      DEFAULT_HEARTH_TOOLS_CONFIG.trustCache,
+    ),
+    warmShell: optionalBoolean(
+      value.warmShell,
+      "warmShell",
+      DEFAULT_HEARTH_TOOLS_CONFIG.warmShell,
+    ),
+    enableOptimizer: optionalBoolean(
+      value.enableOptimizer,
+      "enableOptimizer",
+      DEFAULT_HEARTH_TOOLS_CONFIG.enableOptimizer,
+    ),
+    ...(maxCachedFiles === undefined ? {} : { maxCachedFiles }),
+    bashTimeoutMs: boundedInteger(
+      value.bashTimeoutMs,
+      "bashTimeoutMs",
+      1,
+      2_147_483_647,
+      DEFAULT_HEARTH_TOOLS_CONFIG.bashTimeoutMs,
+    )!,
+  };
+};
+
+export const loadHearthToolsConfig = (agentDir: string): HearthToolsConfig => {
+  const path = join(agentDir, "hearth-tools.local.json");
+  try {
+    return parseHearthToolsConfig(JSON.parse(readFileSync(path, "utf8")));
+  } catch (error) {
+    if (isRecord(error) && "code" in error && error.code === "ENOENT") {
+      return { ...DEFAULT_HEARTH_TOOLS_CONFIG };
+    }
+    throw new Error("invalid hearth-tools.local.json", { cause: error });
+  }
+};

--- a/pi/extensions/hearth-tools/config.ts
+++ b/pi/extensions/hearth-tools/config.ts
@@ -1,5 +1,10 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { MAX_TIMEOUT_MS } from "./constants";
+
+const MIN_CACHED_FILES = 1;
+const MAX_CACHED_FILES = 1_000_000;
+const MIN_TIMEOUT_MS = 1;
 
 export interface HearthToolsConfig {
   trustCache: boolean;
@@ -13,7 +18,7 @@ export const DEFAULT_HEARTH_TOOLS_CONFIG: Readonly<HearthToolsConfig> = {
   trustCache: true,
   warmShell: true,
   enableOptimizer: true,
-  bashTimeoutMs: 2_147_483_647,
+  bashTimeoutMs: MAX_TIMEOUT_MS,
 };
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -66,8 +71,8 @@ export const parseHearthToolsConfig = (value: unknown): HearthToolsConfig => {
   const maxCachedFiles = boundedInteger(
     value.maxCachedFiles,
     "maxCachedFiles",
-    1,
-    1_000_000,
+    MIN_CACHED_FILES,
+    MAX_CACHED_FILES,
   );
   return {
     trustCache: optionalBoolean(
@@ -89,8 +94,8 @@ export const parseHearthToolsConfig = (value: unknown): HearthToolsConfig => {
     bashTimeoutMs: boundedInteger(
       value.bashTimeoutMs,
       "bashTimeoutMs",
-      1,
-      2_147_483_647,
+      MIN_TIMEOUT_MS,
+      MAX_TIMEOUT_MS,
       DEFAULT_HEARTH_TOOLS_CONFIG.bashTimeoutMs,
     )!,
   };

--- a/pi/extensions/hearth-tools/constants.ts
+++ b/pi/extensions/hearth-tools/constants.ts
@@ -1,0 +1,2 @@
+/** Maximum signed 32-bit millisecond timeout accepted across JS/native timers. */
+export const MAX_TIMEOUT_MS = 2_147_483_647;

--- a/pi/extensions/hearth-tools/engine.ts
+++ b/pi/extensions/hearth-tools/engine.ts
@@ -1,0 +1,53 @@
+import type { EngineOptions, HearthEngine, ShellSpec } from "@hearthdev/napi";
+import type { HearthToolsConfig } from "./config";
+
+export interface HearthModule {
+  HearthEngine: new (options?: EngineOptions) => HearthEngine;
+}
+
+export interface PiToolSettings {
+  shellPath?: string;
+  shellCommandPrefix?: string;
+  imageAutoResize: boolean;
+  shell: ShellSpec;
+}
+
+interface EngineSlot {
+  engine: HearthEngine;
+  options: EngineOptions;
+}
+
+const ENGINE_SLOT = Symbol.for("ushironoko.pi-hearth-tools.engine.v1");
+
+type GlobalWithEngine = typeof globalThis & {
+  [ENGINE_SLOT]?: EngineSlot;
+};
+
+export const getOrCreateEngine = (
+  module: HearthModule,
+  cwd: string,
+  config: HearthToolsConfig,
+  shell: ShellSpec,
+): HearthEngine => {
+  const host = globalThis as GlobalWithEngine;
+  if (host[ENGINE_SLOT] !== undefined) return host[ENGINE_SLOT].engine;
+
+  const options: EngineOptions = {
+    cwd,
+    trustCache: config.trustCache,
+    warmShell: config.warmShell,
+    enableOptimizer: config.enableOptimizer,
+    bashTimeoutMs: config.bashTimeoutMs,
+    shell,
+    ...(config.maxCachedFiles === undefined
+      ? {}
+      : { maxCachedFiles: config.maxCachedFiles }),
+  };
+  const engine = new module.HearthEngine(options);
+  host[ENGINE_SLOT] = { engine, options };
+  return engine;
+};
+
+export const clearProcessEngineForTests = (): void => {
+  delete (globalThis as GlobalWithEngine)[ENGINE_SLOT];
+};

--- a/pi/extensions/hearth-tools/engine.ts
+++ b/pi/extensions/hearth-tools/engine.ts
@@ -12,40 +12,181 @@ export interface PiToolSettings {
   shell: ShellSpec;
 }
 
-interface EngineSlot {
+export interface HearthAccessGate {
+  shared<T>(operation: () => Promise<T>): Promise<T>;
+  exclusive<T>(operation: () => Promise<T>): Promise<T>;
+}
+
+type AccessMode = "shared" | "exclusive";
+
+interface AccessWaiter {
+  mode: AccessMode;
+  operation(): Promise<unknown>;
+  resolve(value: unknown): void;
+  reject(error: unknown): void;
+}
+
+/**
+ * A fair process-local shared/exclusive gate around one resident Engine.
+ *
+ * File-backed tools may overlap. Bash and explicit invalidation wait for every
+ * active file operation, then keep later operations out until cache clearing is
+ * complete. FIFO admission prevents a stream of reads from starving Bash.
+ */
+export class HearthEngineGate implements HearthAccessGate {
+  private readonly waiters: AccessWaiter[] = [];
+  private activeReaders = 0;
+  private activeWriter = false;
+
+  shared<T>(operation: () => Promise<T>): Promise<T> {
+    return this.enqueue("shared", operation);
+  }
+
+  exclusive<T>(operation: () => Promise<T>): Promise<T> {
+    return this.enqueue("exclusive", operation);
+  }
+
+  private enqueue<T>(
+    mode: AccessMode,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      this.waiters.push({
+        mode,
+        operation,
+        resolve: (value) => resolve(value as T),
+        reject,
+      });
+      this.drain();
+    });
+  }
+
+  private drain(): void {
+    if (this.activeWriter) return;
+    const first = this.waiters[0];
+    if (first === undefined) return;
+
+    if (first.mode === "exclusive") {
+      if (this.activeReaders > 0) return;
+      this.waiters.shift();
+      this.activeWriter = true;
+      this.start(first, () => {
+        this.activeWriter = false;
+      });
+      return;
+    }
+
+    while (this.waiters[0]?.mode === "shared" && !this.activeWriter) {
+      const waiter = this.waiters.shift();
+      if (waiter === undefined) break;
+      this.activeReaders += 1;
+      this.start(waiter, () => {
+        this.activeReaders -= 1;
+      });
+    }
+  }
+
+  private start(waiter: AccessWaiter, release: () => void): void {
+    void Promise.resolve()
+      .then(waiter.operation)
+      .then(waiter.resolve, waiter.reject)
+      .finally(() => {
+        release();
+        this.drain();
+      });
+  }
+}
+
+class ImmediateHearthAccessGate implements HearthAccessGate {
+  shared<T>(operation: () => Promise<T>): Promise<T> {
+    return operation();
+  }
+
+  exclusive<T>(operation: () => Promise<T>): Promise<T> {
+    return operation();
+  }
+}
+
+export const IMMEDIATE_HEARTH_ACCESS_GATE: HearthAccessGate =
+  new ImmediateHearthAccessGate();
+
+export interface HearthEngineRuntime {
   engine: HearthEngine;
+  gate: HearthEngineGate;
   options: EngineOptions;
 }
 
-const ENGINE_SLOT = Symbol.for("ushironoko.pi-hearth-tools.engine.v1");
+// Bump the symbol whenever the slot shape changes so /reload cannot interpret
+// a runtime created by an older extension revision as the current contract.
+const ENGINE_SLOT = Symbol.for("ushironoko.pi-hearth-tools.engine.v2");
 
-type GlobalWithEngine = typeof globalThis & {
-  [ENGINE_SLOT]?: EngineSlot;
-};
+interface GlobalWithEngine {
+  [ENGINE_SLOT]?: HearthEngineRuntime;
+}
 
-export const getOrCreateEngine = (
+export class HearthEngineRestartRequiredError extends Error {
+  constructor() {
+    super("Hearth Engine settings changed; restart pi to apply them");
+    this.name = "HearthEngineRestartRequiredError";
+  }
+}
+
+const createOptions = (
+  cwd: string,
+  config: HearthToolsConfig,
+  shell: ShellSpec,
+): EngineOptions => ({
+  cwd,
+  trustCache: config.trustCache,
+  warmShell: config.warmShell,
+  enableOptimizer: config.enableOptimizer,
+  bashTimeoutMs: config.bashTimeoutMs,
+  shell,
+  ...(config.maxCachedFiles === undefined
+    ? {}
+    : { maxCachedFiles: config.maxCachedFiles }),
+});
+
+const sameShell = (
+  left: ShellSpec | undefined,
+  right: ShellSpec | undefined,
+): boolean =>
+  left?.program === right?.program &&
+  left?.transport === right?.transport &&
+  JSON.stringify(left?.args ?? []) === JSON.stringify(right?.args ?? []);
+
+const sameOptions = (left: EngineOptions, right: EngineOptions): boolean =>
+  left.cwd === right.cwd &&
+  left.trustCache === right.trustCache &&
+  left.warmShell === right.warmShell &&
+  left.enableOptimizer === right.enableOptimizer &&
+  left.bashTimeoutMs === right.bashTimeoutMs &&
+  left.maxCachedFiles === right.maxCachedFiles &&
+  sameShell(left.shell, right.shell);
+
+export const getOrCreateEngineRuntime = (
   module: HearthModule,
   cwd: string,
   config: HearthToolsConfig,
   shell: ShellSpec,
-): HearthEngine => {
+): HearthEngineRuntime => {
   const host = globalThis as GlobalWithEngine;
-  if (host[ENGINE_SLOT] !== undefined) return host[ENGINE_SLOT].engine;
+  const options = createOptions(cwd, config, shell);
+  const existing = host[ENGINE_SLOT];
+  if (existing !== undefined) {
+    if (!sameOptions(existing.options, options)) {
+      throw new HearthEngineRestartRequiredError();
+    }
+    return existing;
+  }
 
-  const options: EngineOptions = {
-    cwd,
-    trustCache: config.trustCache,
-    warmShell: config.warmShell,
-    enableOptimizer: config.enableOptimizer,
-    bashTimeoutMs: config.bashTimeoutMs,
-    shell,
-    ...(config.maxCachedFiles === undefined
-      ? {}
-      : { maxCachedFiles: config.maxCachedFiles }),
+  const runtime: HearthEngineRuntime = {
+    engine: new module.HearthEngine(options),
+    gate: new HearthEngineGate(),
+    options,
   };
-  const engine = new module.HearthEngine(options);
-  host[ENGINE_SLOT] = { engine, options };
-  return engine;
+  host[ENGINE_SLOT] = runtime;
+  return runtime;
 };
 
 export const clearProcessEngineForTests = (): void => {

--- a/pi/extensions/hearth-tools/engine.ts
+++ b/pi/extensions/hearth-tools/engine.ts
@@ -119,9 +119,11 @@ export interface HearthEngineRuntime {
 // Bump the symbol whenever the slot shape changes so /reload cannot interpret
 // a runtime created by an older extension revision as the current contract.
 const ENGINE_SLOT = Symbol.for("ushironoko.pi-hearth-tools.engine.v2");
+const LEGACY_ENGINE_SLOT = Symbol.for("ushironoko.pi-hearth-tools.engine.v1");
 
 interface GlobalWithEngine {
   [ENGINE_SLOT]?: HearthEngineRuntime;
+  [LEGACY_ENGINE_SLOT]?: unknown;
 }
 
 export class HearthEngineRestartRequiredError extends Error {
@@ -171,6 +173,11 @@ export const getOrCreateEngineRuntime = (
   shell: ShellSpec,
 ): HearthEngineRuntime => {
   const host = globalThis as GlobalWithEngine;
+  // A live /reload from the pre-gate slot must release its global root before
+  // constructing v2. The stale extension runtime may keep a short-lived local
+  // reference until reload teardown completes, but the old optimizer/warm shell
+  // can then drop instead of remaining process-rooted forever.
+  delete host[LEGACY_ENGINE_SLOT];
   const options = createOptions(cwd, config, shell);
   const existing = host[ENGINE_SLOT];
   if (existing !== undefined) {
@@ -190,5 +197,7 @@ export const getOrCreateEngineRuntime = (
 };
 
 export const clearProcessEngineForTests = (): void => {
-  delete (globalThis as GlobalWithEngine)[ENGINE_SLOT];
+  const host = globalThis as GlobalWithEngine;
+  delete host[ENGINE_SLOT];
+  delete host[LEGACY_ENGINE_SLOT];
 };

--- a/pi/extensions/hearth-tools/index.ts
+++ b/pi/extensions/hearth-tools/index.ts
@@ -100,6 +100,62 @@ const definitions = (
     createHearthGrepDefinition(cwd, runtime.engine, runtime.gate),
   ] as const;
 
+interface ExternalWriterGroup {
+  accepting: boolean;
+  active: number;
+  ready: Promise<void>;
+  markReady(): void;
+  drained: Promise<void>;
+  markDrained(): void;
+  complete: Promise<void>;
+}
+
+const createExternalWriterProtector = (runtime: HearthEngineRuntime) => {
+  let group: ExternalWriterGroup | undefined;
+
+  return (finished: Promise<void>) => {
+    if (group === undefined || !group.accepting) {
+      let markReady = (): void => {};
+      let markDrained = (): void => {};
+      const next: ExternalWriterGroup = {
+        accepting: true,
+        active: 0,
+        ready: new Promise<void>((resolve) => {
+          markReady = resolve;
+        }),
+        markReady: () => markReady(),
+        drained: new Promise<void>((resolve) => {
+          markDrained = resolve;
+        }),
+        markDrained: () => markDrained(),
+        complete: Promise.resolve(),
+      };
+      next.complete = runtime.gate.exclusive(async () => {
+        next.markReady();
+        await next.drained;
+        runtime.engine.clearCaches();
+      });
+      const retire = (): void => {
+        if (group === next) group = undefined;
+      };
+      void next.complete.then(retire, retire);
+      group = next;
+    }
+
+    const current = group;
+    current.active += 1;
+    const release = (): void => {
+      current.active -= 1;
+      if (current.active === 0) {
+        current.accepting = false;
+        current.markDrained();
+      }
+    };
+    void finished.then(release, release);
+    return { ready: current.ready, complete: current.complete };
+  };
+};
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object";
 
@@ -172,6 +228,7 @@ export const setupHearthTools = async (
   let state: RuntimeState | undefined;
   let registered = false;
   const service = registerHearthReadService(pi, () => state);
+  const invalidation = registerHearthInvalidationService(pi);
   const clearCaches = async (): Promise<void> => {
     const current = state;
     if (current === undefined) return;
@@ -179,7 +236,6 @@ export const setupHearthTools = async (
       current.runtime.engine.clearCaches();
     });
   };
-  registerHearthInvalidationService(pi, clearCaches);
 
   pi.on("session_start", (_event, ctx) => {
     if (registered) return;
@@ -208,6 +264,10 @@ export const setupHearthTools = async (
         settings.shell,
       );
       state = { runtime, settings, config };
+      invalidation.activate({
+        clearCaches,
+        protectExternalWriter: createExternalWriterProtector(runtime),
+      });
 
       assertNoExistingOverride(pi);
       const activeBefore = pi.getActiveTools();

--- a/pi/extensions/hearth-tools/index.ts
+++ b/pi/extensions/hearth-tools/index.ts
@@ -5,7 +5,7 @@ import {
   type ExtensionAPI,
   type ExtensionFactory,
 } from "@earendil-works/pi-coding-agent";
-import type { HearthEngine, ShellSpec } from "@hearthdev/napi";
+import type { ShellSpec } from "@hearthdev/napi";
 import {
   createHearthBashDefinition,
   createHearthBashOperations,
@@ -14,9 +14,11 @@ import {
   createHearthReadDefinition,
   createHearthWriteDefinition,
 } from "./adapters";
-import { loadHearthToolsConfig } from "./config";
+import { loadHearthToolsConfig, type HearthToolsConfig } from "./config";
 import {
-  getOrCreateEngine,
+  getOrCreateEngineRuntime,
+  HearthEngineRestartRequiredError,
+  type HearthEngineRuntime,
   type HearthModule,
   type PiToolSettings,
 } from "./engine";
@@ -31,6 +33,18 @@ export const HEARTH_TOOL_NAMES = [
 ] as const;
 
 const STARTUP_ERROR = "pi-hearth-tools: Hearth native backend is unavailable";
+const CONFIG_ERROR = "pi-hearth-tools: invalid local configuration";
+const COLLISION_ERROR = "pi-hearth-tools: competing tool override detected";
+const RESTART_ERROR =
+  "pi-hearth-tools: Engine settings changed; restart pi to apply them";
+const CHILD_RUN_COMPLETION_ENTRY = "pi-harness/child-run-completion";
+const POST_TOOL_INVALIDATION = new Set([
+  "write",
+  "edit",
+  "bash",
+  "subagent",
+  "workflow",
+]);
 
 type Fatal = (message: string) => never;
 
@@ -43,8 +57,9 @@ export interface HearthSetupDependencies {
 }
 
 export interface RuntimeState {
-  engine: HearthEngine;
+  runtime: HearthEngineRuntime;
   settings: PiToolSettings;
+  config: HearthToolsConfig;
 }
 
 const defaultFatal: Fatal = (message) => {
@@ -63,19 +78,69 @@ const shellSpec = (shellPath?: string): ShellSpec => {
 
 const definitions = (
   cwd: string,
-  engine: HearthEngine,
+  runtime: HearthEngineRuntime,
   settings: PiToolSettings,
+  config: HearthToolsConfig,
 ) =>
   [
-    createHearthReadDefinition(cwd, engine, settings),
-    createHearthWriteDefinition(cwd, engine),
-    createHearthEditDefinition(cwd, engine),
-    createHearthBashDefinition(cwd, engine, settings),
-    createHearthGrepDefinition(cwd, engine),
+    createHearthReadDefinition(cwd, runtime.engine, settings, runtime.gate),
+    createHearthWriteDefinition(cwd, runtime.engine, runtime.gate),
+    createHearthEditDefinition(cwd, runtime.engine, runtime.gate),
+    createHearthBashDefinition(cwd, runtime.engine, settings, {
+      defaultTimeoutMs: config.bashTimeoutMs,
+      gate: runtime.gate,
+    }),
+    createHearthGrepDefinition(cwd, runtime.engine, runtime.gate),
   ] as const;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object";
 
 const isHearthSource = (path: string): boolean =>
   /(?:^|[/\\])hearth-tools(?:[/\\]|$)/.test(path);
+
+const effectiveTools = (pi: ExtensionAPI) =>
+  new Map(pi.getAllTools().map((tool) => [tool.name, tool]));
+
+const assertNoExistingOverride = (pi: ExtensionAPI): void => {
+  const byName = effectiveTools(pi);
+  for (const name of HEARTH_TOOL_NAMES) {
+    const tool = byName.get(name);
+    if (
+      tool !== undefined &&
+      tool.sourceInfo.source !== "builtin" &&
+      !isHearthSource(tool.sourceInfo.path)
+    ) {
+      throw new Error(COLLISION_ERROR);
+    }
+  }
+};
+
+const assertHearthOwnership = (pi: ExtensionAPI): void => {
+  const byName = effectiveTools(pi);
+  for (const name of HEARTH_TOOL_NAMES) {
+    const sourcePath = byName.get(name)?.sourceInfo.path;
+    if (sourcePath === undefined || !isHearthSource(sourcePath)) {
+      throw new Error(COLLISION_ERROR);
+    }
+  }
+};
+
+const isChildCompletion = (event: unknown): boolean => {
+  if (!isRecord(event) || !isRecord(event.message)) return false;
+  return (
+    event.message.role === "custom" &&
+    event.message.customType === CHILD_RUN_COMPLETION_ENTRY
+  );
+};
+
+const completedToolName = (event: unknown): string | undefined => {
+  if (!isRecord(event) || !isRecord(event.message)) return undefined;
+  if (event.message.role !== "toolResult") return undefined;
+  return typeof event.message.toolName === "string"
+    ? event.message.toolName
+    : undefined;
+};
 
 export const setupHearthTools = async (
   pi: ExtensionAPI,
@@ -92,14 +157,25 @@ export const setupHearthTools = async (
   let state: RuntimeState | undefined;
   let registered = false;
   const service = registerHearthReadService(pi, () => state);
+  const clearCaches = async (): Promise<void> => {
+    const current = state;
+    if (current === undefined) return;
+    await current.runtime.gate.exclusive(async () => {
+      current.runtime.engine.clearCaches();
+    });
+  };
 
   pi.on("session_start", (_event, ctx) => {
     if (registered) return;
+
+    let config: HearthToolsConfig;
     try {
       const agentDir = (dependencies.getAgentDir ?? getAgentDir)();
-      const config = (dependencies.loadConfig ?? loadHearthToolsConfig)(
-        agentDir,
-      );
+      try {
+        config = (dependencies.loadConfig ?? loadHearthToolsConfig)(agentDir);
+      } catch {
+        throw new Error(CONFIG_ERROR);
+      }
       const settingsManager = (
         dependencies.createSettings ?? SettingsManager.create
       )(ctx.cwd, agentDir, { projectTrusted: ctx.isProjectTrusted() });
@@ -109,14 +185,21 @@ export const setupHearthTools = async (
         imageAutoResize: settingsManager.getImageAutoResize(),
         shell: shellSpec(settingsManager.getShellPath()),
       };
-      const engine = getOrCreateEngine(module, ctx.cwd, config, settings.shell);
-      state = { engine, settings };
+      const runtime = getOrCreateEngineRuntime(
+        module,
+        ctx.cwd,
+        config,
+        settings.shell,
+      );
+      state = { runtime, settings, config };
 
+      assertNoExistingOverride(pi);
       const activeBefore = pi.getActiveTools();
       const [read, write, edit, bash, grep] = definitions(
         ctx.cwd,
-        engine,
+        runtime,
         settings,
+        config,
       );
       pi.registerTool(read);
       pi.registerTool(write);
@@ -124,18 +207,42 @@ export const setupHearthTools = async (
       pi.registerTool(bash);
       pi.registerTool(grep);
       pi.setActiveTools(activeBefore);
+      assertHearthOwnership(pi);
 
-      const byName = new Map(pi.getAllTools().map((tool) => [tool.name, tool]));
-      for (const name of HEARTH_TOOL_NAMES) {
-        const sourcePath = byName.get(name)?.sourceInfo.path;
-        if (sourcePath === undefined || !isHearthSource(sourcePath)) {
-          fatal("pi-hearth-tools: competing tool override detected");
-        }
-      }
       registered = true;
       service.announce();
-    } catch {
+    } catch (error) {
+      if (error instanceof HearthEngineRestartRequiredError) {
+        fatal(RESTART_ERROR);
+      }
+      if (error instanceof Error && error.message === COLLISION_ERROR) {
+        fatal(COLLISION_ERROR);
+      }
+      if (error instanceof Error && error.message === CONFIG_ERROR) {
+        fatal(CONFIG_ERROR);
+      }
       fatal(STARTUP_ERROR);
+    }
+  });
+
+  pi.on("before_agent_start", () => {
+    if (registered) {
+      try {
+        assertHearthOwnership(pi);
+      } catch {
+        fatal(COLLISION_ERROR);
+      }
+    }
+  });
+
+  pi.on("message_start", async (event) => {
+    if (isChildCompletion(event)) await clearCaches();
+  });
+
+  pi.on("message_end", async (event) => {
+    const toolName = completedToolName(event);
+    if (toolName !== undefined && POST_TOOL_INVALIDATION.has(toolName)) {
+      await clearCaches();
     }
   });
 
@@ -145,8 +252,12 @@ export const setupHearthTools = async (
     if (state === undefined) return;
     return {
       operations: createHearthBashOperations(
-        state.engine,
+        state.runtime.engine,
         state.settings.shell,
+        {
+          defaultTimeoutMs: state.config.bashTimeoutMs,
+          gate: state.runtime.gate,
+        },
       ),
     };
   });
@@ -154,9 +265,12 @@ export const setupHearthTools = async (
   pi.registerCommand("hearth-clear-cache", {
     description: "Clear all Hearth file and walk caches",
     handler: async (_args, ctx) => {
-      if (state === undefined)
+      const current = state;
+      if (current === undefined)
         throw new Error("Hearth Engine is not initialized");
-      const result = state.engine.clearCaches();
+      const result = await current.runtime.gate.exclusive(async () =>
+        current.runtime.engine.clearCaches(),
+      );
       ctx.ui.notify(
         `Hearth cache cleared (${result.filesInvalidated} files, ${result.walksInvalidated} walks)`,
         "info",
@@ -167,5 +281,5 @@ export const setupHearthTools = async (
 
 const hearthTools: ExtensionFactory = async (pi) => setupHearthTools(pi);
 
-export { STARTUP_ERROR };
+export { CONFIG_ERROR, COLLISION_ERROR, RESTART_ERROR, STARTUP_ERROR };
 export default hearthTools;

--- a/pi/extensions/hearth-tools/index.ts
+++ b/pi/extensions/hearth-tools/index.ts
@@ -1,3 +1,6 @@
+import { realpathSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   getAgentDir,
   getShellConfig,
@@ -22,7 +25,10 @@ import {
   type HearthModule,
   type PiToolSettings,
 } from "./engine";
-import { registerHearthReadService } from "./service";
+import {
+  registerHearthInvalidationService,
+  registerHearthReadService,
+} from "./service";
 
 export const HEARTH_TOOL_NAMES = [
   "read",
@@ -38,6 +44,7 @@ const COLLISION_ERROR = "pi-hearth-tools: competing tool override detected";
 const RESTART_ERROR =
   "pi-hearth-tools: Engine settings changed; restart pi to apply them";
 const CHILD_RUN_COMPLETION_ENTRY = "pi-harness/child-run-completion";
+const HEARTH_ENTRY_PATH = fileURLToPath(import.meta.url);
 const POST_TOOL_INVALIDATION = new Set([
   "write",
   "edit",
@@ -96,8 +103,16 @@ const definitions = (
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object";
 
+const canonicalSourcePath = (path: string): string => {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+};
+
 const isHearthSource = (path: string): boolean =>
-  /(?:^|[/\\])hearth-tools(?:[/\\]|$)/.test(path);
+  canonicalSourcePath(path) === canonicalSourcePath(HEARTH_ENTRY_PATH);
 
 const effectiveTools = (pi: ExtensionAPI) =>
   new Map(pi.getAllTools().map((tool) => [tool.name, tool]));
@@ -164,6 +179,7 @@ export const setupHearthTools = async (
       current.runtime.engine.clearCaches();
     });
   };
+  registerHearthInvalidationService(pi, clearCaches);
 
   pi.on("session_start", (_event, ctx) => {
     if (registered) return;

--- a/pi/extensions/hearth-tools/index.ts
+++ b/pi/extensions/hearth-tools/index.ts
@@ -51,6 +51,8 @@ const POST_TOOL_INVALIDATION = new Set([
   "bash",
   "subagent",
   "workflow",
+  "worktree_create",
+  "worktree_remove",
 ]);
 
 type Fatal = (message: string) => never;
@@ -213,6 +215,16 @@ const completedToolName = (event: unknown): string | undefined => {
     : undefined;
 };
 
+const isBackgroundAcceptance = (event: unknown): boolean => {
+  if (!isRecord(event) || !isRecord(event.message)) return false;
+  const { details } = event.message;
+  return (
+    isRecord(details) &&
+    isRecord(details.background) &&
+    details.background.status === "accepted"
+  );
+};
+
 export const setupHearthTools = async (
   pi: ExtensionAPI,
   dependencies: HearthSetupDependencies = {},
@@ -301,15 +313,16 @@ export const setupHearthTools = async (
     }
   });
 
-  pi.on("before_agent_start", () => {
-    if (registered) {
-      try {
-        assertHearthOwnership(pi);
-      } catch {
-        fatal(COLLISION_ERROR);
-      }
+  const verifyOwnership = (): void => {
+    if (!registered) return;
+    try {
+      assertHearthOwnership(pi);
+    } catch {
+      fatal(COLLISION_ERROR);
     }
-  });
+  };
+  pi.on("before_agent_start", verifyOwnership);
+  pi.on("tool_call", verifyOwnership);
 
   pi.on("message_start", async (event) => {
     if (isChildCompletion(event)) await clearCaches();
@@ -317,9 +330,14 @@ export const setupHearthTools = async (
 
   pi.on("message_end", async (event) => {
     const toolName = completedToolName(event);
-    if (toolName !== undefined && POST_TOOL_INVALIDATION.has(toolName)) {
-      await clearCaches();
+    if (toolName === undefined || !POST_TOOL_INVALIDATION.has(toolName)) return;
+    if (
+      (toolName === "subagent" || toolName === "workflow") &&
+      isBackgroundAcceptance(event)
+    ) {
+      return;
     }
+    await clearCaches();
   });
 
   pi.on("session_shutdown", () => service.dispose());

--- a/pi/extensions/hearth-tools/index.ts
+++ b/pi/extensions/hearth-tools/index.ts
@@ -1,0 +1,171 @@
+import {
+  getAgentDir,
+  getShellConfig,
+  SettingsManager,
+  type ExtensionAPI,
+  type ExtensionFactory,
+} from "@earendil-works/pi-coding-agent";
+import type { HearthEngine, ShellSpec } from "@hearthdev/napi";
+import {
+  createHearthBashDefinition,
+  createHearthBashOperations,
+  createHearthEditDefinition,
+  createHearthGrepDefinition,
+  createHearthReadDefinition,
+  createHearthWriteDefinition,
+} from "./adapters";
+import { loadHearthToolsConfig } from "./config";
+import {
+  getOrCreateEngine,
+  type HearthModule,
+  type PiToolSettings,
+} from "./engine";
+import { registerHearthReadService } from "./service";
+
+export const HEARTH_TOOL_NAMES = [
+  "read",
+  "write",
+  "edit",
+  "bash",
+  "grep",
+] as const;
+
+const STARTUP_ERROR = "pi-hearth-tools: Hearth native backend is unavailable";
+
+type Fatal = (message: string) => never;
+
+export interface HearthSetupDependencies {
+  loadModule?: () => Promise<HearthModule>;
+  fatal?: Fatal;
+  getAgentDir?: () => string;
+  loadConfig?: typeof loadHearthToolsConfig;
+  createSettings?: typeof SettingsManager.create;
+}
+
+export interface RuntimeState {
+  engine: HearthEngine;
+  settings: PiToolSettings;
+}
+
+const defaultFatal: Fatal = (message) => {
+  console.error(message);
+  process.exit(1);
+};
+
+const shellSpec = (shellPath?: string): ShellSpec => {
+  const resolved = getShellConfig(shellPath);
+  return {
+    program: resolved.shell,
+    args: resolved.args,
+    transport: resolved.commandTransport === "stdin" ? "stdin" : "arg",
+  } as ShellSpec;
+};
+
+const definitions = (
+  cwd: string,
+  engine: HearthEngine,
+  settings: PiToolSettings,
+) =>
+  [
+    createHearthReadDefinition(cwd, engine, settings),
+    createHearthWriteDefinition(cwd, engine),
+    createHearthEditDefinition(cwd, engine),
+    createHearthBashDefinition(cwd, engine, settings),
+    createHearthGrepDefinition(cwd, engine),
+  ] as const;
+
+const isHearthSource = (path: string): boolean =>
+  /(?:^|[/\\])hearth-tools(?:[/\\]|$)/.test(path);
+
+export const setupHearthTools = async (
+  pi: ExtensionAPI,
+  dependencies: HearthSetupDependencies = {},
+): Promise<void> => {
+  const fatal = dependencies.fatal ?? defaultFatal;
+  let module: HearthModule;
+  try {
+    module = await (dependencies.loadModule?.() ?? import("@hearthdev/napi"));
+  } catch {
+    fatal(STARTUP_ERROR);
+  }
+
+  let state: RuntimeState | undefined;
+  let registered = false;
+  const service = registerHearthReadService(pi, () => state);
+
+  pi.on("session_start", (_event, ctx) => {
+    if (registered) return;
+    try {
+      const agentDir = (dependencies.getAgentDir ?? getAgentDir)();
+      const config = (dependencies.loadConfig ?? loadHearthToolsConfig)(
+        agentDir,
+      );
+      const settingsManager = (
+        dependencies.createSettings ?? SettingsManager.create
+      )(ctx.cwd, agentDir, { projectTrusted: ctx.isProjectTrusted() });
+      const settings: PiToolSettings = {
+        shellPath: settingsManager.getShellPath(),
+        shellCommandPrefix: settingsManager.getShellCommandPrefix(),
+        imageAutoResize: settingsManager.getImageAutoResize(),
+        shell: shellSpec(settingsManager.getShellPath()),
+      };
+      const engine = getOrCreateEngine(module, ctx.cwd, config, settings.shell);
+      state = { engine, settings };
+
+      const activeBefore = pi.getActiveTools();
+      const [read, write, edit, bash, grep] = definitions(
+        ctx.cwd,
+        engine,
+        settings,
+      );
+      pi.registerTool(read);
+      pi.registerTool(write);
+      pi.registerTool(edit);
+      pi.registerTool(bash);
+      pi.registerTool(grep);
+      pi.setActiveTools(activeBefore);
+
+      const byName = new Map(pi.getAllTools().map((tool) => [tool.name, tool]));
+      for (const name of HEARTH_TOOL_NAMES) {
+        const sourcePath = byName.get(name)?.sourceInfo.path;
+        if (sourcePath === undefined || !isHearthSource(sourcePath)) {
+          fatal("pi-hearth-tools: competing tool override detected");
+        }
+      }
+      registered = true;
+      service.announce();
+    } catch {
+      fatal(STARTUP_ERROR);
+    }
+  });
+
+  pi.on("session_shutdown", () => service.dispose());
+
+  pi.on("user_bash", () => {
+    if (state === undefined) return;
+    return {
+      operations: createHearthBashOperations(
+        state.engine,
+        state.settings.shell,
+      ),
+    };
+  });
+
+  pi.registerCommand("hearth-clear-cache", {
+    description: "Clear all Hearth file and walk caches",
+    handler: async (_args, ctx) => {
+      if (state === undefined)
+        throw new Error("Hearth Engine is not initialized");
+      const result = state.engine.clearCaches();
+      ctx.ui.notify(
+        `Hearth cache cleared (${result.filesInvalidated} files, ${result.walksInvalidated} walks)`,
+        "info",
+      );
+    },
+  });
+};
+
+const hearthTools: ExtensionFactory = async (pi) => setupHearthTools(pi);
+
+export { STARTUP_ERROR };
+export default hearthTools;

--- a/pi/extensions/hearth-tools/service.ts
+++ b/pi/extensions/hearth-tools/service.ts
@@ -7,6 +7,12 @@ import type { RuntimeState } from "./index";
 
 export const HEARTH_SERVICE_READY = "pi-hearth-tools:service-ready:v1";
 export const HEARTH_SERVICE_REQUEST = "pi-hearth-tools:service-request:v1";
+export const HEARTH_INVALIDATE_REQUEST =
+  "pi-hearth-tools:invalidate-request:v1";
+
+const INVALIDATION_BROKERS = Symbol.for(
+  "ushironoko.pi-hearth-tools.invalidation-brokers.v1",
+);
 
 export interface HearthReadService {
   generation: string;
@@ -18,6 +24,18 @@ interface ServiceRequest {
   accept(service: HearthReadService, requestId: string): void;
 }
 
+interface InvalidationRequest {
+  accept(operation: Promise<void>): void;
+}
+
+interface InvalidationBroker {
+  current: () => Promise<void>;
+}
+
+interface GlobalWithInvalidationBrokers {
+  [INVALIDATION_BROKERS]?: WeakMap<object, InvalidationBroker>;
+}
+
 const isRequest = (value: unknown): value is ServiceRequest => {
   if (value === null || typeof value !== "object") return false;
   const candidate = value as Partial<ServiceRequest>;
@@ -25,6 +43,35 @@ const isRequest = (value: unknown): value is ServiceRequest => {
     typeof candidate.requestId === "string" &&
     typeof candidate.accept === "function"
   );
+};
+
+const isInvalidationRequest = (
+  value: unknown,
+): value is InvalidationRequest => {
+  if (value === null || typeof value !== "object") return false;
+  return typeof (value as Partial<InvalidationRequest>).accept === "function";
+};
+
+export const registerHearthInvalidationService = (
+  pi: ExtensionAPI,
+  clearCaches: () => Promise<void>,
+): void => {
+  const host = globalThis as GlobalWithInvalidationBrokers;
+  const brokers =
+    host[INVALIDATION_BROKERS] ?? new WeakMap<object, InvalidationBroker>();
+  host[INVALIDATION_BROKERS] = brokers;
+  const eventBus = pi.events as object;
+  const existing = brokers.get(eventBus);
+  if (existing !== undefined) {
+    existing.current = clearCaches;
+    return;
+  }
+
+  const broker: InvalidationBroker = { current: clearCaches };
+  brokers.set(eventBus, broker);
+  pi.events.on(HEARTH_INVALIDATE_REQUEST, (value) => {
+    if (isInvalidationRequest(value)) value.accept(broker.current());
+  });
 };
 
 export const registerHearthReadService = (

--- a/pi/extensions/hearth-tools/service.ts
+++ b/pi/extensions/hearth-tools/service.ts
@@ -9,14 +9,30 @@ export const HEARTH_SERVICE_READY = "pi-hearth-tools:service-ready:v1";
 export const HEARTH_SERVICE_REQUEST = "pi-hearth-tools:service-request:v1";
 export const HEARTH_INVALIDATE_REQUEST =
   "pi-hearth-tools:invalidate-request:v1";
+export const HEARTH_EXTERNAL_WRITER_REQUEST =
+  "pi-hearth-tools:external-writer-request:v1";
 
 const INVALIDATION_BROKERS = Symbol.for(
-  "ushironoko.pi-hearth-tools.invalidation-brokers.v1",
+  "ushironoko.pi-hearth-tools.invalidation-brokers.v2",
 );
 
 export interface HearthReadService {
   generation: string;
   createReadTool(cwd: string): AgentTool<TSchema, unknown>;
+}
+
+export interface ExternalWriterLease {
+  ready: Promise<void>;
+  complete: Promise<void>;
+}
+
+export interface HearthInvalidationHandlers {
+  clearCaches(): Promise<void>;
+  protectExternalWriter(finished: Promise<void>): ExternalWriterLease;
+}
+
+export interface HearthInvalidationRegistration {
+  activate(handlers: HearthInvalidationHandlers): void;
 }
 
 interface ServiceRequest {
@@ -28,8 +44,13 @@ interface InvalidationRequest {
   accept(operation: Promise<void>): void;
 }
 
+interface ExternalWriterRequest {
+  finished: Promise<void>;
+  accept(lease: ExternalWriterLease): void;
+}
+
 interface InvalidationBroker {
-  current: () => Promise<void>;
+  current?: HearthInvalidationHandlers;
 }
 
 interface GlobalWithInvalidationBrokers {
@@ -52,26 +73,48 @@ const isInvalidationRequest = (
   return typeof (value as Partial<InvalidationRequest>).accept === "function";
 };
 
+const isExternalWriterRequest = (
+  value: unknown,
+): value is ExternalWriterRequest => {
+  if (value === null || typeof value !== "object") return false;
+  const candidate = value as Partial<ExternalWriterRequest>;
+  return (
+    candidate.finished instanceof Promise &&
+    typeof candidate.accept === "function"
+  );
+};
+
 export const registerHearthInvalidationService = (
   pi: ExtensionAPI,
-  clearCaches: () => Promise<void>,
-): void => {
+): HearthInvalidationRegistration => {
   const host = globalThis as GlobalWithInvalidationBrokers;
   const brokers =
     host[INVALIDATION_BROKERS] ?? new WeakMap<object, InvalidationBroker>();
   host[INVALIDATION_BROKERS] = brokers;
   const eventBus = pi.events as object;
-  const existing = brokers.get(eventBus);
-  if (existing !== undefined) {
-    existing.current = clearCaches;
-    return;
+  let broker = brokers.get(eventBus);
+  if (broker === undefined) {
+    broker = {};
+    brokers.set(eventBus, broker);
+    pi.events.on(HEARTH_INVALIDATE_REQUEST, (value) => {
+      const current = broker?.current;
+      if (current !== undefined && isInvalidationRequest(value)) {
+        value.accept(current.clearCaches());
+      }
+    });
+    pi.events.on(HEARTH_EXTERNAL_WRITER_REQUEST, (value) => {
+      const current = broker?.current;
+      if (current !== undefined && isExternalWriterRequest(value)) {
+        value.accept(current.protectExternalWriter(value.finished));
+      }
+    });
   }
 
-  const broker: InvalidationBroker = { current: clearCaches };
-  brokers.set(eventBus, broker);
-  pi.events.on(HEARTH_INVALIDATE_REQUEST, (value) => {
-    if (isInvalidationRequest(value)) value.accept(broker.current());
-  });
+  return {
+    activate(handlers) {
+      if (broker !== undefined) broker.current = handlers;
+    },
+  };
 };
 
 export const registerHearthReadService = (

--- a/pi/extensions/hearth-tools/service.ts
+++ b/pi/extensions/hearth-tools/service.ts
@@ -1,0 +1,54 @@
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { TSchema } from "typebox";
+import { randomUUID } from "node:crypto";
+import { createHearthReadTool } from "./adapters";
+import type { RuntimeState } from "./index";
+
+export const HEARTH_SERVICE_READY = "pi-hearth-tools:service-ready:v1";
+export const HEARTH_SERVICE_REQUEST = "pi-hearth-tools:service-request:v1";
+
+export interface HearthReadService {
+  generation: string;
+  createReadTool(cwd: string): AgentTool<TSchema, unknown>;
+}
+
+interface ServiceRequest {
+  requestId: string;
+  accept(service: HearthReadService, requestId: string): void;
+}
+
+const isRequest = (value: unknown): value is ServiceRequest => {
+  if (value === null || typeof value !== "object") return false;
+  const candidate = value as Partial<ServiceRequest>;
+  return (
+    typeof candidate.requestId === "string" &&
+    typeof candidate.accept === "function"
+  );
+};
+
+export const registerHearthReadService = (
+  pi: ExtensionAPI,
+  state: () => RuntimeState | undefined,
+): { announce(): void; dispose(): void } => {
+  const generation = randomUUID();
+  const service: HearthReadService = {
+    generation,
+    createReadTool(cwd) {
+      const current = state();
+      if (current === undefined)
+        throw new Error("Hearth Engine is not initialized");
+      return createHearthReadTool(cwd, current.engine, current.settings);
+    },
+  };
+  const dispose = pi.events.on(HEARTH_SERVICE_REQUEST, (value) => {
+    if (!isRequest(value) || state() === undefined) return;
+    value.accept(service, value.requestId);
+  });
+  return {
+    announce() {
+      if (state() !== undefined) pi.events.emit(HEARTH_SERVICE_READY, service);
+    },
+    dispose,
+  };
+};

--- a/pi/extensions/hearth-tools/service.ts
+++ b/pi/extensions/hearth-tools/service.ts
@@ -38,7 +38,12 @@ export const registerHearthReadService = (
       const current = state();
       if (current === undefined)
         throw new Error("Hearth Engine is not initialized");
-      return createHearthReadTool(cwd, current.engine, current.settings);
+      return createHearthReadTool(
+        cwd,
+        current.runtime.engine,
+        current.settings,
+        current.runtime.gate,
+      );
     },
   };
   const dispose = pi.events.on(HEARTH_SERVICE_REQUEST, (value) => {

--- a/pi/extensions/pi-harness/features/btw/index.ts
+++ b/pi/extensions/pi-harness/features/btw/index.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type {
   AgentMessage,
+  AgentTool,
   ThinkingLevel,
 } from "@earendil-works/pi-agent-core";
 import {
@@ -19,11 +20,14 @@ import {
   SettingsManager,
 } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
+import type { TSchema } from "typebox";
 import type { PiLike } from "../../lib/pi-like";
 import { stripTerminalControls } from "../../lib/terminal-text";
 
 const HISTORY_TYPE = "pi-harness:btw";
 const STATUS_KEY = "pi-harness-btw";
+const HEARTH_SERVICE_READY = "pi-hearth-tools:service-ready:v1";
+const HEARTH_SERVICE_REQUEST = "pi-hearth-tools:service-request:v1";
 const QUESTION_MAX_BYTES = 16 * 1024;
 const ANSWER_MAX_BYTES = 64 * 1024;
 const ERROR_MAX_BYTES = 4 * 1024;
@@ -212,6 +216,7 @@ const answerFromReadOnlyFork = async (
   snapshot: BtwSnapshot,
   question: string,
   dependencies: BtwForkDependencies = defaultForkDependencies,
+  hearthReadTool?: AgentTool<TSchema, unknown>,
 ): Promise<string> => {
   assertQuestion(question);
   const agentDir = dependencies.getAgentDir();
@@ -249,6 +254,7 @@ const answerFromReadOnlyFork = async (
     thinkingLevel: snapshot.thinkingLevel,
     tools: [...BTW_READ_ONLY_TOOLS],
     excludeTools: [...BTW_DENIED_TOOLS],
+    ...(hearthReadTool === undefined ? {} : { customTools: [hearthReadTool] }),
     resourceLoader,
     sessionManager,
     settingsManager,
@@ -336,6 +342,20 @@ interface BtwFeatureDependencies {
   createId?: () => string;
 }
 
+interface HearthReadService {
+  generation: string;
+  createReadTool(cwd: string): AgentTool<TSchema, unknown>;
+}
+
+const isHearthReadService = (value: unknown): value is HearthReadService => {
+  if (value === null || typeof value !== "object") return false;
+  const candidate = value as Partial<HearthReadService>;
+  return (
+    typeof candidate.generation === "string" &&
+    typeof candidate.createReadTool === "function"
+  );
+};
+
 interface NativeAbortControllerLike {
   readonly signal: AbortSignal;
   abort(): void;
@@ -391,10 +411,40 @@ const setupBtw = (
   pi: PiLike,
   dependencies: BtwFeatureDependencies = {},
 ): void => {
-  const answerQuestion = dependencies.answerQuestion ?? answerFromReadOnlyFork;
   const now = dependencies.now ?? Date.now;
   const createId = dependencies.createId ?? randomUUID;
   const runtime = pi as unknown as ExtensionAPI;
+  let hearthService: HearthReadService | undefined;
+  const acceptHearthService = (value: unknown): void => {
+    if (isHearthReadService(value)) hearthService = value;
+  };
+  const unsubscribeHearthReady = runtime.events.on(
+    HEARTH_SERVICE_READY,
+    acceptHearthService,
+  );
+  const requestHearthService = (): void => {
+    const requestId = randomUUID();
+    runtime.events.emit(HEARTH_SERVICE_REQUEST, {
+      requestId,
+      accept(service: unknown, responseId: string) {
+        if (responseId === requestId) acceptHearthService(service);
+      },
+    });
+  };
+  requestHearthService();
+  const answerQuestion =
+    dependencies.answerQuestion ??
+    ((snapshot: BtwSnapshot, question: string) => {
+      if (hearthService === undefined) {
+        throw new Error("Hearth read service is unavailable");
+      }
+      return answerFromReadOnlyFork(
+        snapshot,
+        question,
+        defaultForkDependencies,
+        hearthService.createReadTool(snapshot.cwd),
+      );
+    });
   let running = false;
   let activeAbort: BtwCancellationController | undefined;
   let activeOperation: Promise<void> | undefined;
@@ -403,6 +453,7 @@ const setupBtw = (
 
   pi.on("session_start", () => {
     sessionGeneration += 1;
+    requestHearthService();
   });
   pi.on("session_before_tree", () => {
     // Invalidate before navigation changes the active leaf. Cancelling even if
@@ -416,6 +467,8 @@ const setupBtw = (
     activeAbort?.abort();
     const operation = activeOperation;
     await operation;
+    unsubscribeHearthReady();
+    hearthService = undefined;
   });
   runtime.on("session_compact", (_event, ctx) => {
     const visibleIds = new Set<string>();

--- a/pi/extensions/pi-harness/features/child-runs/background.ts
+++ b/pi/extensions/pi-harness/features/child-runs/background.ts
@@ -16,6 +16,7 @@ export const MAX_NOTIFICATION_RESULT_BYTES = 32 * 1024;
 
 export interface BackgroundHost {
   appendEntry(customType: string, data?: unknown): void;
+  onWorkSettled?(): Promise<void> | void;
   sendMessage(
     message: {
       customType: string;
@@ -298,7 +299,14 @@ export class BackgroundInvocationManager {
           }
         },
       )
-      .then(() => {
+      .then(async () => {
+        try {
+          await this.host.onWorkSettled?.();
+        } catch {
+          // Cache invalidation is a best-effort integration boundary when the
+          // Hearth extension is absent or shutting down. Child persistence and
+          // lifecycle cleanup must still complete.
+        }
         this.tryArchive(record);
       })
       .catch(() => {

--- a/pi/extensions/pi-harness/features/child-runs/background.ts
+++ b/pi/extensions/pi-harness/features/child-runs/background.ts
@@ -17,6 +17,7 @@ export const MAX_NOTIFICATION_RESULT_BYTES = 32 * 1024;
 export interface BackgroundHost {
   appendEntry(customType: string, data?: unknown): void;
   onWorkSettled?(): Promise<void> | void;
+  runExternalWork?<T>(operation: () => Promise<T>): Promise<T>;
   sendMessage(
     message: {
       customType: string;
@@ -52,6 +53,7 @@ interface BackgroundRecord extends BackgroundSchedule {
   controller: AbortControllerLike;
   accepted: boolean;
   settled?: BackgroundWorkResult;
+  invalidationCompleted: boolean;
   archived: boolean;
   suppressNotification: boolean;
   abortReason?: ChildRunTerminalReason;
@@ -252,6 +254,7 @@ export class BackgroundInvocationManager {
       ...spec,
       controller,
       accepted: false,
+      invalidationCompleted: false,
       archived: false,
       suppressNotification: false,
       workPromise: Promise.resolve(),
@@ -267,7 +270,15 @@ export class BackgroundInvocationManager {
         if (isAborted(controller.signal)) {
           throw new Error("Background child run was aborted");
         }
-        return spec.run(controller.signal);
+        const run = () => {
+          if (isAborted(controller.signal)) {
+            throw new Error("Background child run was aborted");
+          }
+          return spec.run(controller.signal);
+        };
+        return this.host.runExternalWork === undefined
+          ? run()
+          : this.host.runExternalWork(run);
       })
       .then(
         (completion) => {
@@ -307,6 +318,7 @@ export class BackgroundInvocationManager {
           // Hearth extension is absent or shutting down. Child persistence and
           // lifecycle cleanup must still complete.
         }
+        record.invalidationCompleted = true;
         this.tryArchive(record);
       })
       .catch(() => {
@@ -536,7 +548,12 @@ export class BackgroundInvocationManager {
   }
 
   private tryArchive(record: BackgroundRecord): void {
-    if (record.archived || !record.accepted || record.settled === undefined) {
+    if (
+      record.archived ||
+      !record.accepted ||
+      record.settled === undefined ||
+      !record.invalidationCompleted
+    ) {
       return;
     }
 

--- a/pi/extensions/pi-harness/features/child-runs/index.ts
+++ b/pi/extensions/pi-harness/features/child-runs/index.ts
@@ -88,6 +88,13 @@ const completionInvocationId = (details: unknown): string | undefined => {
 };
 
 const HEARTH_INVALIDATE_REQUEST = "pi-hearth-tools:invalidate-request:v1";
+const HEARTH_EXTERNAL_WRITER_REQUEST =
+  "pi-hearth-tools:external-writer-request:v1";
+
+interface ExternalWriterLease {
+  ready: Promise<void>;
+  complete: Promise<void>;
+}
 
 const BACKGROUND_AGENT_SYSTEM_PROMPT = `## Background agent completion
 
@@ -169,6 +176,30 @@ const setupChildRuns = (
     });
     await Promise.allSettled(pending);
   };
+  const runExternalWork = async <T>(
+    operation: () => Promise<T>,
+  ): Promise<T> => {
+    let finish = (): void => {};
+    const finished = new Promise<void>((resolveFinished) => {
+      finish = resolveFinished;
+    });
+    const leases: ExternalWriterLease[] = [];
+    runtime.events?.emit(HEARTH_EXTERNAL_WRITER_REQUEST, {
+      finished,
+      accept(lease: ExternalWriterLease) {
+        leases.push(lease);
+      },
+    });
+    try {
+      if (leases.length > 0) {
+        await Promise.all(leases.map((lease) => lease.ready));
+      }
+      return await operation();
+    } finally {
+      finish();
+      await Promise.allSettled(leases.map((lease) => lease.complete));
+    }
+  };
   const background =
     options.childExecution !== false &&
     typeof runtime.appendEntry === "function" &&
@@ -177,6 +208,7 @@ const setupChildRuns = (
           appendEntry: runtime.appendEntry.bind(runtime),
           sendMessage: runtime.sendMessage.bind(runtime),
           onWorkSettled: invalidateHearthCaches,
+          runExternalWork,
         })
       : undefined;
   const pendingTreeTransitions: PendingTreeTransition[] = [];

--- a/pi/extensions/pi-harness/features/child-runs/index.ts
+++ b/pi/extensions/pi-harness/features/child-runs/index.ts
@@ -116,6 +116,7 @@ export interface SetupChildRunsOptions {
   readonly bitIssues?: boolean;
   readonly bitIssueCli?: BitIssueCli;
   readonly childExecution?: boolean;
+  readonly backgroundDrainTimeoutMs?: number;
 }
 
 const replayBranch = (
@@ -204,12 +205,18 @@ const setupChildRuns = (
     options.childExecution !== false &&
     typeof runtime.appendEntry === "function" &&
     typeof runtime.sendMessage === "function"
-      ? new BackgroundInvocationManager(registry, {
-          appendEntry: runtime.appendEntry.bind(runtime),
-          sendMessage: runtime.sendMessage.bind(runtime),
-          onWorkSettled: invalidateHearthCaches,
-          runExternalWork,
-        })
+      ? new BackgroundInvocationManager(
+          registry,
+          {
+            appendEntry: runtime.appendEntry.bind(runtime),
+            sendMessage: runtime.sendMessage.bind(runtime),
+            onWorkSettled: invalidateHearthCaches,
+            runExternalWork,
+          },
+          options.backgroundDrainTimeoutMs === undefined
+            ? {}
+            : { drainTimeoutMs: options.backgroundDrainTimeoutMs },
+        )
       : undefined;
   const pendingTreeTransitions: PendingTreeTransition[] = [];
   const releaseTreeTransition = (entry: PendingTreeTransition): void => {
@@ -413,7 +420,10 @@ const setupChildRuns = (
       return { cancel: true };
     }
     if (pending?.released) return { cancel: true };
-    if (background?.shouldCancelBranchNavigation()) {
+    if (
+      background?.hasActiveInvocations() ||
+      background?.shouldCancelBranchNavigation()
+    ) {
       if (pending !== undefined) releaseTreeTransition(pending);
       return { cancel: true };
     }

--- a/pi/extensions/pi-harness/features/child-runs/index.ts
+++ b/pi/extensions/pi-harness/features/child-runs/index.ts
@@ -33,6 +33,9 @@ interface RuntimeBeforeAgentStartEvent {
 }
 
 interface RuntimePiLike {
+  events?: {
+    emit(event: string, value: unknown): void;
+  };
   on(
     event: string,
     handler: (event: unknown, ctx: RuntimeContextLike) => unknown,
@@ -83,6 +86,8 @@ const completionInvocationId = (details: unknown): string | undefined => {
   const invocationId = (details as { invocationId?: unknown }).invocationId;
   return typeof invocationId === "string" ? invocationId : undefined;
 };
+
+const HEARTH_INVALIDATE_REQUEST = "pi-hearth-tools:invalidate-request:v1";
 
 const BACKGROUND_AGENT_SYSTEM_PROMPT = `## Background agent completion
 
@@ -155,6 +160,15 @@ const setupChildRuns = (
       if (activeContext !== undefined) await refreshBitIssues(activeContext);
     },
   });
+  const invalidateHearthCaches = async (): Promise<void> => {
+    const pending: Promise<void>[] = [];
+    runtime.events?.emit(HEARTH_INVALIDATE_REQUEST, {
+      accept(operation: Promise<void>) {
+        pending.push(Promise.resolve(operation));
+      },
+    });
+    await Promise.allSettled(pending);
+  };
   const background =
     options.childExecution !== false &&
     typeof runtime.appendEntry === "function" &&
@@ -162,6 +176,7 @@ const setupChildRuns = (
       ? new BackgroundInvocationManager(registry, {
           appendEntry: runtime.appendEntry.bind(runtime),
           sendMessage: runtime.sendMessage.bind(runtime),
+          onWorkSettled: invalidateHearthCaches,
         })
       : undefined;
   const pendingTreeTransitions: PendingTreeTransition[] = [];

--- a/scripts/benchmark-hearth-tools.ts
+++ b/scripts/benchmark-hearth-tools.ts
@@ -1,0 +1,569 @@
+import {
+  createGrepToolDefinition,
+  createReadToolDefinition,
+} from "@earendil-works/pi-coding-agent";
+import { HearthEngine, type GrepMode, type ShellSpec } from "@hearthdev/napi";
+import { cpus, tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  createHearthGrepDefinition,
+  createHearthReadDefinition,
+} from "../pi/extensions/hearth-tools/adapters";
+import {
+  HearthEngineGate,
+  type PiToolSettings,
+} from "../pi/extensions/hearth-tools/engine";
+
+const DEFAULT_WARMUP_ITERATIONS = 8;
+const DEFAULT_READ_ITERATIONS = 200;
+const DEFAULT_GREP_ITERATIONS = 30;
+const DEFAULT_SYNTHETIC_FILES = 512;
+const DEFAULT_SYNTHETIC_FILE_BYTES = 16 * 1024;
+const SYNTHETIC_READ_BYTES = 8 * 1024 * 1024;
+const RAW_GREP_MATCH_LIMIT = 100_000;
+const EQUIVALENCE_DIAGNOSTIC_CHARACTERS = 1_000;
+const SYNTHETIC_NEEDLE = "HEARTH_BENCHMARK_NEEDLE";
+const SYNTHETIC_MATCH_EVERY_FILES = 8;
+const MILLISECONDS_PER_NANOSECOND = 1 / 1_000_000;
+const TOOL_CONTEXT = { model: undefined } as never;
+
+interface BenchmarkOptions {
+  warmupIterations: number;
+  readIterations: number;
+  grepIterations: number;
+  syntheticFiles: number;
+  syntheticFileBytes: number;
+  json: boolean;
+}
+
+interface Workload {
+  name: "repository" | "synthetic";
+  cwd: string;
+  readPath: string;
+  grepPath: string;
+  grepPattern: string;
+  grepGlob: string;
+}
+
+interface SampleStats {
+  iterations: number;
+  medianMs: number;
+  meanMs: number;
+  p95Ms: number;
+  minMs: number;
+  maxMs: number;
+}
+
+interface Comparison {
+  dataset: Workload["name"];
+  tool: "read" | "grep";
+  layer: "end-to-end" | "raw";
+  baseline: SampleStats;
+  hearth: SampleStats;
+  medianSpeedup: number;
+}
+
+interface ToolResultLike {
+  content?: unknown;
+  details?: unknown;
+}
+
+let benchmarkSink = 0;
+
+const shell: ShellSpec = {
+  program: "/bin/bash",
+  args: ["-c"],
+  transport: "arg" as ShellSpec["transport"],
+};
+
+const settings: PiToolSettings = {
+  imageAutoResize: false,
+  shell,
+};
+
+const usage = (): string => `Usage: bun run benchmark:hearth-tools -- [options]
+
+Options:
+  --warmup <n>               Warm-up calls per implementation (default: ${DEFAULT_WARMUP_ITERATIONS})
+  --read-iterations <n>       Timed read calls per implementation (default: ${DEFAULT_READ_ITERATIONS})
+  --grep-iterations <n>       Timed grep calls per implementation (default: ${DEFAULT_GREP_ITERATIONS})
+  --synthetic-files <n>       Synthetic grep corpus file count (default: ${DEFAULT_SYNTHETIC_FILES})
+  --synthetic-file-bytes <n>  Approximate bytes per synthetic grep file (default: ${DEFAULT_SYNTHETIC_FILE_BYTES})
+  --json                     Emit machine-readable JSON only
+  --help                     Show this help
+`;
+
+const positiveInteger = (value: string | undefined, option: string): number => {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${option} must be a positive integer`);
+  }
+  return parsed;
+};
+
+const parseOptions = (argv: string[]): BenchmarkOptions => {
+  const options: BenchmarkOptions = {
+    warmupIterations: DEFAULT_WARMUP_ITERATIONS,
+    readIterations: DEFAULT_READ_ITERATIONS,
+    grepIterations: DEFAULT_GREP_ITERATIONS,
+    syntheticFiles: DEFAULT_SYNTHETIC_FILES,
+    syntheticFileBytes: DEFAULT_SYNTHETIC_FILE_BYTES,
+    json: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--help") {
+      console.log(usage());
+      process.exit(0);
+    }
+    if (argument === "--json") {
+      options.json = true;
+      continue;
+    }
+    const value = argv[index + 1];
+    switch (argument) {
+      case "--warmup": {
+        options.warmupIterations = positiveInteger(value, argument);
+        break;
+      }
+      case "--read-iterations": {
+        options.readIterations = positiveInteger(value, argument);
+        break;
+      }
+      case "--grep-iterations": {
+        options.grepIterations = positiveInteger(value, argument);
+        break;
+      }
+      case "--synthetic-files": {
+        options.syntheticFiles = positiveInteger(value, argument);
+        break;
+      }
+      case "--synthetic-file-bytes": {
+        options.syntheticFileBytes = positiveInteger(value, argument);
+        break;
+      }
+      default: {
+        throw new Error(`Unknown option: ${argument ?? "(missing)"}`);
+      }
+    }
+    index += 1;
+  }
+  return options;
+};
+
+const consume = (value: unknown): void => {
+  if (Buffer.isBuffer(value)) {
+    benchmarkSink ^= value.length;
+    return;
+  }
+  if (typeof value === "number") {
+    benchmarkSink ^= value;
+    return;
+  }
+  benchmarkSink ^= JSON.stringify(value).length;
+};
+
+const percentile = (sorted: number[], fraction: number): number => {
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil(sorted.length * fraction) - 1),
+  );
+  return sorted[index] ?? 0;
+};
+
+const summarize = (samples: number[]): SampleStats => {
+  const sorted = [...samples].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  const median =
+    sorted.length % 2 === 0
+      ? ((sorted[middle - 1] ?? 0) + (sorted[middle] ?? 0)) / 2
+      : (sorted[middle] ?? 0);
+  return {
+    iterations: sorted.length,
+    medianMs: median,
+    meanMs: sorted.reduce((total, value) => total + value, 0) / sorted.length,
+    p95Ms: percentile(sorted, 0.95),
+    minMs: sorted[0] ?? 0,
+    maxMs: sorted.at(-1) ?? 0,
+  };
+};
+
+const measure = async (operation: () => Promise<unknown>): Promise<number> => {
+  const started = Bun.nanoseconds();
+  const value = await operation();
+  const elapsed = (Bun.nanoseconds() - started) * MILLISECONDS_PER_NANOSECOND;
+  consume(value);
+  return elapsed;
+};
+
+const compare = async (
+  workload: Workload,
+  tool: Comparison["tool"],
+  layer: Comparison["layer"],
+  baselineOperation: () => Promise<unknown>,
+  hearthOperation: () => Promise<unknown>,
+  warmupIterations: number,
+  iterations: number,
+): Promise<Comparison> => {
+  for (let index = 0; index < warmupIterations; index += 1) {
+    consume(await baselineOperation());
+    consume(await hearthOperation());
+  }
+
+  const baselineSamples: number[] = [];
+  const hearthSamples: number[] = [];
+  for (let index = 0; index < iterations; index += 1) {
+    if (index % 2 === 0) {
+      baselineSamples.push(await measure(baselineOperation));
+      hearthSamples.push(await measure(hearthOperation));
+    } else {
+      hearthSamples.push(await measure(hearthOperation));
+      baselineSamples.push(await measure(baselineOperation));
+    }
+  }
+  const baseline = summarize(baselineSamples);
+  const hearth = summarize(hearthSamples);
+  return {
+    dataset: workload.name,
+    tool,
+    layer,
+    baseline,
+    hearth,
+    medianSpeedup: baseline.medianMs / hearth.medianMs,
+  };
+};
+
+const canonicalizeGrepResult = (result: ToolResultLike): ToolResultLike => ({
+  ...result,
+  content: Array.isArray(result.content)
+    ? result.content.map((block) => {
+        if (
+          block === null ||
+          typeof block !== "object" ||
+          !("type" in block) ||
+          block.type !== "text" ||
+          !("text" in block) ||
+          typeof block.text !== "string"
+        ) {
+          return block;
+        }
+        return {
+          ...block,
+          text: block.text.split("\n").sort().join("\n"),
+        };
+      })
+    : result.content,
+});
+
+const assertEquivalent = (
+  label: string,
+  baseline: unknown,
+  hearth: unknown,
+): void => {
+  const baselineJson = JSON.stringify(baseline);
+  const hearthJson = JSON.stringify(hearth);
+  if (baselineJson !== hearthJson) {
+    throw new Error(
+      `${label} output mismatch between baseline and Hearth\nbaseline=${baselineJson.slice(0, EQUIVALENCE_DIAGNOSTIC_CHARACTERS)}\nhearth=${hearthJson.slice(0, EQUIVALENCE_DIAGNOSTIC_CHARACTERS)}`,
+    );
+  }
+};
+
+const createEngine = (cwd: string): HearthEngine =>
+  new HearthEngine({
+    cwd,
+    trustCache: true,
+    warmShell: false,
+    enableOptimizer: true,
+    shell,
+  });
+
+const rawRipgrep = async (rg: string, workload: Workload): Promise<number> => {
+  const process = Bun.spawn(
+    [
+      rg,
+      "--json",
+      "--line-number",
+      "--color=never",
+      "--hidden",
+      "--glob",
+      workload.grepGlob,
+      "--",
+      workload.grepPattern,
+      workload.grepPath,
+    ],
+    {
+      cwd: workload.cwd,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+    process.exited,
+  ]);
+  if (exitCode !== 0 && exitCode !== 1) {
+    throw new Error(`rg exited ${exitCode}: ${stderr.trim()}`);
+  }
+  let matches = 0;
+  for (const line of stdout.split("\n")) {
+    if (line === "") continue;
+    const event = JSON.parse(line) as { type?: unknown };
+    if (event.type === "match") matches += 1;
+  }
+  return matches;
+};
+
+const createSyntheticWorkload = async (
+  options: BenchmarkOptions,
+): Promise<{ root: string; workload: Workload }> => {
+  const root = await mkdtemp(join(tmpdir(), "hearth-tools-benchmark-"));
+  const corpus = join(root, "grep-corpus");
+  await mkdir(corpus);
+
+  const fillerLine = `${"0123456789abcdef".repeat(16)}\n`;
+  const filler = fillerLine.repeat(
+    Math.max(1, Math.ceil(options.syntheticFileBytes / fillerLine.length)),
+  );
+  await Promise.all(
+    Array.from({ length: options.syntheticFiles }, async (_value, index) => {
+      const prefix =
+        index % SYNTHETIC_MATCH_EVERY_FILES === 0
+          ? `${SYNTHETIC_NEEDLE} file=${index}\n`
+          : `ordinary file=${index}\n`;
+      await writeFile(
+        join(corpus, `file-${index.toString().padStart(4, "0")}.txt`),
+        `${prefix}${filler}`,
+      );
+    }),
+  );
+
+  const readUnit = "abcdefghijklmnopqrstuvwxyz0123456789\n";
+  const readContent = readUnit.repeat(
+    Math.ceil(SYNTHETIC_READ_BYTES / readUnit.length),
+  );
+  await writeFile(join(root, "read-target.txt"), readContent);
+
+  return {
+    root,
+    workload: {
+      name: "synthetic",
+      cwd: root,
+      readPath: "read-target.txt",
+      grepPath: "grep-corpus",
+      grepPattern: SYNTHETIC_NEEDLE,
+      grepGlob: "*.txt",
+    },
+  };
+};
+
+const benchmarkWorkload = async (
+  workload: Workload,
+  options: BenchmarkOptions,
+  rg: string,
+): Promise<Comparison[]> => {
+  const engine = createEngine(workload.cwd);
+  const productionGate = new HearthEngineGate();
+  const builtinRead = createReadToolDefinition(workload.cwd);
+  const hearthRead = createHearthReadDefinition(
+    workload.cwd,
+    engine,
+    settings,
+    productionGate,
+  );
+  const builtinGrep = createGrepToolDefinition(workload.cwd);
+  const hearthGrep = createHearthGrepDefinition(
+    workload.cwd,
+    engine,
+    productionGate,
+  );
+  const grepInput = {
+    pattern: workload.grepPattern,
+    path: workload.grepPath,
+    glob: workload.grepGlob,
+    limit: RAW_GREP_MATCH_LIMIT,
+  };
+
+  const builtinReadOperation = (): Promise<ToolResultLike> =>
+    builtinRead.execute(
+      `${workload.name}-builtin-read`,
+      { path: workload.readPath },
+      undefined,
+      undefined,
+      TOOL_CONTEXT,
+    );
+  const hearthReadOperation = (): Promise<ToolResultLike> =>
+    hearthRead.execute(
+      `${workload.name}-hearth-read`,
+      { path: workload.readPath },
+      undefined,
+      undefined,
+      TOOL_CONTEXT,
+    );
+  const builtinGrepOperation = (): Promise<ToolResultLike> =>
+    builtinGrep.execute(
+      `${workload.name}-builtin-grep`,
+      grepInput,
+      undefined,
+      undefined,
+      TOOL_CONTEXT,
+    );
+  const hearthGrepOperation = (): Promise<ToolResultLike> =>
+    hearthGrep.execute(
+      `${workload.name}-hearth-grep`,
+      grepInput,
+      undefined,
+      undefined,
+      TOOL_CONTEXT,
+    );
+  const rawFsReadOperation = (): Promise<Buffer> =>
+    readFile(resolve(workload.cwd, workload.readPath));
+  const rawHearthReadOperation = (): Promise<Buffer> =>
+    engine.readBytesAsync({ path: workload.readPath });
+  const rawRgOperation = (): Promise<number> => rawRipgrep(rg, workload);
+  const rawHearthGrepOperation = async (): Promise<number> => {
+    const result = await engine.grepAsync({
+      pattern: workload.grepPattern,
+      path: workload.grepPath,
+      mode: "content" as GrepMode,
+      globs: [workload.grepGlob],
+      maxTotalCount: RAW_GREP_MATCH_LIMIT,
+      hidden: true,
+      respectGitignore: true,
+    });
+    return result.totalMatches;
+  };
+
+  assertEquivalent(
+    `${workload.name} end-to-end read`,
+    await builtinReadOperation(),
+    await hearthReadOperation(),
+  );
+  assertEquivalent(
+    `${workload.name} end-to-end grep`,
+    canonicalizeGrepResult(await builtinGrepOperation()),
+    canonicalizeGrepResult(await hearthGrepOperation()),
+  );
+  const rawBaselineBytes = await rawFsReadOperation();
+  const rawHearthBytes = await rawHearthReadOperation();
+  if (!rawBaselineBytes.equals(rawHearthBytes)) {
+    throw new Error(`${workload.name} raw read bytes differ`);
+  }
+  assertEquivalent(
+    `${workload.name} raw grep match count`,
+    await rawRgOperation(),
+    await rawHearthGrepOperation(),
+  );
+
+  return [
+    await compare(
+      workload,
+      "read",
+      "end-to-end",
+      builtinReadOperation,
+      hearthReadOperation,
+      options.warmupIterations,
+      options.readIterations,
+    ),
+    await compare(
+      workload,
+      "read",
+      "raw",
+      rawFsReadOperation,
+      rawHearthReadOperation,
+      options.warmupIterations,
+      options.readIterations,
+    ),
+    await compare(
+      workload,
+      "grep",
+      "end-to-end",
+      builtinGrepOperation,
+      hearthGrepOperation,
+      options.warmupIterations,
+      options.grepIterations,
+    ),
+    await compare(
+      workload,
+      "grep",
+      "raw",
+      rawRgOperation,
+      rawHearthGrepOperation,
+      options.warmupIterations,
+      options.grepIterations,
+    ),
+  ];
+};
+
+const formatMs = (value: number): string => value.toFixed(3);
+const formatSpeedup = (value: number): string => `${value.toFixed(2)}x`;
+
+const printTable = (comparisons: Comparison[]): void => {
+  console.log(
+    "| Dataset | Tool | Layer | Baseline median | Hearth median | Speedup | Baseline mean | Hearth mean | Baseline p95 | Hearth p95 |",
+  );
+  console.log("|---|---|---|---:|---:|---:|---:|---:|---:|---:|");
+  for (const comparison of comparisons) {
+    console.log(
+      `| ${comparison.dataset} | ${comparison.tool} | ${comparison.layer} | ${formatMs(comparison.baseline.medianMs)} ms | ${formatMs(comparison.hearth.medianMs)} ms | ${formatSpeedup(comparison.medianSpeedup)} | ${formatMs(comparison.baseline.meanMs)} ms | ${formatMs(comparison.hearth.meanMs)} ms | ${formatMs(comparison.baseline.p95Ms)} ms | ${formatMs(comparison.hearth.p95Ms)} ms |`,
+    );
+  }
+};
+
+const main = async (): Promise<void> => {
+  const options = parseOptions(process.argv.slice(2));
+  const rg = Bun.which("rg");
+  if (rg === null) throw new Error("rg is required for the baseline benchmark");
+
+  const repositoryRoot = resolve(import.meta.dir, "..");
+  const repositoryWorkload: Workload = {
+    name: "repository",
+    cwd: repositoryRoot,
+    readPath: "bun.lock",
+    grepPath: "pi/extensions/hearth-tools",
+    grepPattern: "createHearth",
+    grepGlob: "*.ts",
+  };
+  const synthetic = await createSyntheticWorkload(options);
+  try {
+    const comparisons = [
+      ...(await benchmarkWorkload(repositoryWorkload, options, rg)),
+      ...(await benchmarkWorkload(synthetic.workload, options, rg)),
+    ];
+    const report = {
+      environment: {
+        platform: process.platform,
+        arch: process.arch,
+        cpu: cpus()[0]?.model ?? "unknown",
+        bun: Bun.version,
+        rg,
+        trustCache: true,
+      },
+      options,
+      comparisons,
+      sink: benchmarkSink,
+    };
+    if (options.json) {
+      console.log(JSON.stringify(report, null, 2));
+      return;
+    }
+    console.log("# Hearth tool benchmark\n");
+    console.log(
+      `Environment: ${report.environment.cpu}; ${report.environment.platform}/${report.environment.arch}; Bun ${report.environment.bun}`,
+    );
+    console.log(
+      `Warm-up: ${options.warmupIterations}; read iterations: ${options.readIterations}; grep iterations: ${options.grepIterations}; trustCache: true\n`,
+    );
+    printTable(comparisons);
+    console.log(
+      "\nMedian speedup is baseline median / Hearth median. Setup, corpus generation, and equivalence checks are outside timed regions.",
+    );
+  } finally {
+    await rm(synthetic.root, { recursive: true, force: true });
+  }
+};
+
+await main();

--- a/scripts/check-pi-imports.ts
+++ b/scripts/check-pi-imports.ts
@@ -24,9 +24,14 @@ export const CODEX_WEB_EXTENSION_ROOT = resolve(
   PI_EXTENSIONS_ROOT,
   "codex-web",
 );
+export const HEARTH_TOOLS_EXTENSION_ROOT = resolve(
+  PI_EXTENSIONS_ROOT,
+  "hearth-tools",
+);
 export const EXTENSION_ROOTS = [
   EXTENSION_ROOT,
   CODEX_WEB_EXTENSION_ROOT,
+  HEARTH_TOOLS_EXTENSION_ROOT,
 ] as const;
 
 // pi's extension loader aliases this documented root import to the copy bundled
@@ -36,6 +41,10 @@ const RUNTIME_IMPORTS_BY_ROOT = new Map<string, ReadonlySet<string>>([
   [
     EXTENSION_ROOT,
     new Set(["@earendil-works/pi-coding-agent", "@earendil-works/pi-tui"]),
+  ],
+  [
+    HEARTH_TOOLS_EXTENSION_ROOT,
+    new Set(["@earendil-works/pi-coding-agent", "@hearthdev/napi"]),
   ],
 ]);
 
@@ -209,10 +218,10 @@ export const collectViolations = (
 
   for (const specifier of specifiers) {
     if (specifier.startsWith("node:")) continue;
+    // Type-only imports are erased before this scan. Runtime imports are
+    // limited to exact documented/package roots per extension.
+    if (RUNTIME_IMPORTS_BY_ROOT.get(root)?.has(specifier) === true) continue;
     if (specifier.startsWith("@earendil-works/")) {
-      // Type-only imports are erased before this scan. Runtime imports are
-      // limited to exact roots virtualized by pi for this extension.
-      if (RUNTIME_IMPORTS_BY_ROOT.get(root)?.has(specifier) === true) continue;
       violations.push(
         `${relFile}: runtime import of ${specifier} (type-only imports and explicitly bundled roots only)`,
       );

--- a/scripts/pi-compat/compile.ts
+++ b/scripts/pi-compat/compile.ts
@@ -68,6 +68,11 @@ export const compileExtensionsAgainstGlobalPi = async (
         recursive: true,
       },
     );
+    await cp(
+      join(repoRoot, "pi/extensions/hearth-tools"),
+      join(sourceRoot, "hearth-tools"),
+      { recursive: true },
+    );
 
     // Recreate only pi's captured package closure under a temporary
     // node_modules. TypeScript now honors package exports/types normally.
@@ -80,6 +85,13 @@ export const compileExtensionsAgainstGlobalPi = async (
       await mkdir(resolve(target, ".."), { recursive: true });
       await symlink(pkg.root, target, "dir");
     }
+    const hearthTarget = join(tempModules, "@hearthdev", "napi");
+    await mkdir(resolve(hearthTarget, ".."), { recursive: true });
+    await symlink(
+      join(repoRoot, "node_modules/@hearthdev/napi"),
+      hearthTarget,
+      "dir",
+    );
 
     const tsconfigPath = join(tempRoot, "tsconfig.json");
     await writeFile(

--- a/scripts/pi-compat/rpc-smoke.ts
+++ b/scripts/pi-compat/rpc-smoke.ts
@@ -5,7 +5,10 @@ import { join } from "node:path";
 import type { PiInstallation } from "./installation";
 import { StrictJsonlDecoder, terminateProcessGroup } from "./process";
 
+const HEARTH_TOOLS = ["read", "write", "edit", "bash", "grep"];
+
 const EXPECTED_TOOLS = [
+  ...HEARTH_TOOLS,
   "subagent",
   "workflow",
   "worktree_create",
@@ -54,9 +57,15 @@ export default function compatProbe(pi: ExtensionAPI): void {
   pi.registerCommand(${JSON.stringify(command)}, {
     description: "Internal compatibility probe",
     handler: async (_args, ctx) => {
-      const tools = new Set(pi.getAllTools().map((tool) => tool.name));
+      const allTools = pi.getAllTools();
+      const tools = new Set(allTools.map((tool) => tool.name));
       const missing = ${JSON.stringify(EXPECTED_TOOLS)}.filter((name) => !tools.has(name));
       if (missing.length > 0) throw new Error("missing tools: " + missing.join(", "));
+      const wrongBackend = ${JSON.stringify(HEARTH_TOOLS)}.filter((name) => {
+        const tool = allTools.find((candidate) => candidate.name === name);
+        return !tool?.sourceInfo.path.includes("hearth-tools");
+      });
+      if (wrongBackend.length > 0) throw new Error("non-Hearth tools: " + wrongBackend.join(", "));
       if (ctx.mode !== "rpc" || !ctx.hasUI || typeof ctx.shutdown !== "function") {
         throw new Error("incompatible extension context");
       }
@@ -103,6 +112,8 @@ export const smokeGlobalPiRpc = async (
       "pi-compat-smoke",
       "--model",
       "never-invoked",
+      "-e",
+      join(options.repoRoot, "pi/extensions/hearth-tools/index.ts"),
       "-e",
       join(options.repoRoot, "pi/extensions/pi-harness/index.ts"),
       "-e",

--- a/tests/pi-harness/background-child-runs.test.ts
+++ b/tests/pi-harness/background-child-runs.test.ts
@@ -30,6 +30,7 @@ const runtime = (
     failSends?: number;
     reentrantSend?: boolean;
     onWorkSettled?: BackgroundHost["onWorkSettled"];
+    runExternalWork?: BackgroundHost["runExternalWork"];
   } = {},
 ) => {
   let id = 0;
@@ -43,6 +44,7 @@ const runtime = (
   let manager!: BackgroundInvocationManager;
   const host: BackgroundHost = {
     onWorkSettled: options.onWorkSettled,
+    runExternalWork: options.runExternalWork,
     appendEntry(customType, data) {
       entries.push({ customType, data });
     },
@@ -221,11 +223,54 @@ describe("background child-run manager", () => {
     });
     await invalidationStarted.promise;
     expect(invalidationCalls).toBe(1);
+    expect(manager.hasActiveInvocations()).toBe(true);
     expect(shutdownFinished).toBe(false);
 
     invalidated.resolve();
     await shutdown;
     expect(shutdownFinished).toBe(true);
+  });
+
+  test("drain timeout retains the invocation and external-writer lease", async () => {
+    const childDone = deferred<{ text: string }>();
+    const leaseStarted = deferred<void>();
+    let externalLeaseActive = false;
+    let invalidationCalls = 0;
+    const { registry, manager } = runtime({
+      drainTimeoutMs: 1,
+      async runExternalWork(operation) {
+        externalLeaseActive = true;
+        leaseStarted.resolve();
+        try {
+          return await operation();
+        } finally {
+          externalLeaseActive = false;
+        }
+      },
+      onWorkSettled() {
+        invalidationCalls += 1;
+      },
+    });
+    const started = begin(registry);
+    manager.schedule({
+      invocationId: started.invocationId,
+      toolCallId: "tool-1",
+      source: "subagent",
+      run: () => childDone.promise,
+    });
+    manager.acknowledgeToolResult("tool-1");
+    await leaseStarted.promise;
+
+    await manager.shutdown();
+    expect(externalLeaseActive).toBe(true);
+    expect(manager.hasActiveInvocations()).toBe(true);
+    expect(invalidationCalls).toBe(0);
+
+    childDone.resolve({ text: "late completion" });
+    await manager.drain(started.invocationId);
+    expect(externalLeaseActive).toBe(false);
+    expect(invalidationCalls).toBe(1);
+    expect(manager.hasActiveInvocations()).toBe(false);
   });
 
   test("branch navigation aborts and persists without parent delivery", async () => {

--- a/tests/pi-harness/background-child-runs.test.ts
+++ b/tests/pi-harness/background-child-runs.test.ts
@@ -29,6 +29,7 @@ const runtime = (
     drainTimeoutMs?: number;
     failSends?: number;
     reentrantSend?: boolean;
+    onWorkSettled?: BackgroundHost["onWorkSettled"];
   } = {},
 ) => {
   let id = 0;
@@ -41,6 +42,7 @@ const runtime = (
   let sendCount = 0;
   let manager!: BackgroundInvocationManager;
   const host: BackgroundHost = {
+    onWorkSettled: options.onWorkSettled,
     appendEntry(customType, data) {
       entries.push({ customType, data });
     },
@@ -181,6 +183,49 @@ describe("background child-run manager", () => {
     expect(registry.getInvocation(started.invocationId)?.runs[0]).toMatchObject(
       { status: "aborted", terminalReason: "shutdown" },
     );
+  });
+
+  test("shutdown awaits settlement invalidation even when notification is suppressed", async () => {
+    const invalidationStarted = deferred<void>();
+    const invalidated = deferred<void>();
+    let invalidationCalls = 0;
+    const { registry, manager } = runtime({
+      onWorkSettled() {
+        invalidationCalls += 1;
+        invalidationStarted.resolve();
+        return invalidated.promise;
+      },
+    });
+    const started = begin(registry);
+    manager.schedule({
+      invocationId: started.invocationId,
+      toolCallId: "tool-1",
+      source: "subagent",
+      run(signal) {
+        return new Promise((_resolve, reject) => {
+          const abort = () => reject(new Error("aborted"));
+          if (
+            "addEventListener" in signal &&
+            typeof signal.addEventListener === "function"
+          ) {
+            signal.addEventListener("abort", abort, { once: true });
+          }
+        });
+      },
+    });
+    manager.acknowledgeToolResult("tool-1");
+
+    let shutdownFinished = false;
+    const shutdown = manager.shutdown().then(() => {
+      shutdownFinished = true;
+    });
+    await invalidationStarted.promise;
+    expect(invalidationCalls).toBe(1);
+    expect(shutdownFinished).toBe(false);
+
+    invalidated.resolve();
+    await shutdown;
+    expect(shutdownFinished).toBe(true);
   });
 
   test("branch navigation aborts and persists without parent delivery", async () => {

--- a/tests/pi-harness/btw.test.ts
+++ b/tests/pi-harness/btw.test.ts
@@ -6,6 +6,7 @@ import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { UserMessage } from "@earendil-works/pi-ai/compat";
 import {
   buildSessionContext,
+  createEventBus,
   type CreateAgentSessionOptions,
   type EntryRenderer,
   type ExtensionCommandContext,
@@ -259,6 +260,30 @@ describe("BTW read-only fork runner", () => {
     expect(harness.child.disposed).toBe(true);
   });
 
+  test("injects a Hearth read override without enabling extensions", async () => {
+    const harness = childHarness();
+    const readTool = {
+      name: "read",
+      label: "read",
+      description: "Hearth read",
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({
+        content: [{ type: "text" as const, text: "ok" }],
+      }),
+    } as never;
+
+    await answerFromReadOnlyFork(
+      snapshot(),
+      "question",
+      harness.dependencies,
+      readTool,
+    );
+
+    expect(harness.createOptions[0].customTools).toEqual([readTool]);
+    expect(harness.createOptions[0].tools).toEqual([...BTW_READ_ONLY_TOOLS]);
+    expect(harness.loaderOptions[0].noExtensions).toBe(true);
+  });
+
   test("seeds compaction summaries into the recoverable child session", async () => {
     const harness = childHarness();
     const parent = snapshot();
@@ -374,7 +399,9 @@ const commandHarness = (
   let startHandler: (() => Promise<void> | void) | undefined;
   let shutdownHandler: (() => Promise<void> | void) | undefined;
   const entries: { customType: string; data: unknown }[] = [];
+  const events = createEventBus();
   const pi = {
+    events,
     on(event: string, handler: () => Promise<void> | void) {
       if (event === "session_compact") {
         compactHandler = handler as unknown as typeof compactHandler;

--- a/tests/pi-harness/check-pi-imports.test.ts
+++ b/tests/pi-harness/check-pi-imports.test.ts
@@ -6,6 +6,7 @@ import {
   CODEX_WEB_EXTENSION_ROOT,
   collectViolations,
   EXTENSION_ROOT,
+  HEARTH_TOOLS_EXTENSION_ROOT,
   scanExtension,
 } from "../../scripts/check-pi-imports";
 
@@ -60,6 +61,30 @@ describe("check-pi-imports self-containment analysis", () => {
         check(`import { x } from ${JSON.stringify(specifier)};`)[0],
       ).toContain(`runtime import of ${specifier}`);
     }
+  });
+
+  test("allows only pi and Hearth package roots in hearth-tools", () => {
+    for (const specifier of [
+      "@earendil-works/pi-coding-agent",
+      "@hearthdev/napi",
+    ]) {
+      expect(
+        collectViolations(
+          "index.ts",
+          join(HEARTH_TOOLS_EXTENSION_ROOT, "index.ts"),
+          `import { x } from ${JSON.stringify(specifier)};`,
+          HEARTH_TOOLS_EXTENSION_ROOT,
+        ),
+      ).toEqual([]);
+    }
+    expect(
+      collectViolations(
+        "index.ts",
+        join(HEARTH_TOOLS_EXTENSION_ROOT, "index.ts"),
+        'import { x } from "@hearthdev/napi/subpath";',
+        HEARTH_TOOLS_EXTENSION_ROOT,
+      )[0],
+    ).toContain("disallowed bare import");
   });
 
   test("does not grant the pi-harness runtime allowlist to codex-web", () => {
@@ -135,8 +160,9 @@ describe("check-pi-imports self-containment analysis", () => {
 });
 
 describe("check-pi-imports scanExtension enumeration", () => {
-  test("the codex-web extension is self-contained", async () => {
+  test("the managed extensions are self-contained", async () => {
     expect(await scanExtension(CODEX_WEB_EXTENSION_ROOT)).toEqual([]);
+    expect(await scanExtension(HEARTH_TOOLS_EXTENSION_ROOT)).toEqual([]);
   });
 
   test("analyzes dotfile .ts and rejects escaping/broken symlinks", async () => {

--- a/tests/pi-harness/child-run-integration.test.ts
+++ b/tests/pi-harness/child-run-integration.test.ts
@@ -956,6 +956,54 @@ describe("child-run subagent integration", () => {
     expect(() => childRuns.background?.assertCanAccept()).not.toThrow();
   });
 
+  test("cancels tree navigation while a timed-out child can still archive", async () => {
+    const home = await setupTestDirectory("pi-child-background-tree-timeout");
+    tempDirectories.push(home);
+    const runtime = createRuntime(home, { background: true });
+    const childRuns = setupChildRuns(runtime.pi, {
+      backgroundDrainTimeoutMs: 1,
+    });
+    const started = childRuns.registry.beginInvocation({
+      toolCallId: "tree-timeout-parent",
+      source: "workflow",
+      label: "tree timeout",
+      runs: [{ agent: "worker", task: "late", taskIndex: 0 }],
+    });
+    let finishChild!: (value: { text: string }) => void;
+    const childDone = new Promise<{ text: string }>((resolve) => {
+      finishChild = resolve;
+    });
+    childRuns.background!.schedule({
+      invocationId: started.invocationId,
+      toolCallId: "tree-timeout-parent",
+      source: "workflow",
+      run: () => childDone,
+    });
+    childRuns.background!.acknowledgeToolResult("tree-timeout-parent");
+    await Promise.resolve();
+
+    expect(
+      await runtime.emit("session_before_tree", {
+        type: "session_before_tree",
+      }),
+    ).toEqual({ cancel: true });
+    expect(childRuns.background?.hasActiveInvocations()).toBe(true);
+    expect(runtime.getAppendedEntries()).toEqual([]);
+    expect(() => childRuns.background?.assertCanAccept()).not.toThrow();
+
+    finishChild({ text: "late old-branch completion" });
+    await childRuns.background?.drain(started.invocationId);
+    expect(childRuns.background?.hasActiveInvocations()).toBe(false);
+    expect(runtime.getAppendedEntries()).toHaveLength(1);
+
+    expect(
+      await runtime.emit("session_before_tree", {
+        type: "session_before_tree",
+      }),
+    ).toBeUndefined();
+    await runtime.emit("session_tree", { type: "session_tree" });
+  });
+
   test("session_before_tree aborts and persists production work without cross-branch delivery", async () => {
     const home = await setupTestDirectory("pi-child-background-tree");
     tempDirectories.push(home);

--- a/tests/pi-harness/fake-pi.ts
+++ b/tests/pi-harness/fake-pi.ts
@@ -17,6 +17,7 @@
  * - Blocked tool calls fire NO tool_result event (V2 measurement: blocked
  *   bash produced no tool_result in fixtures).
  */
+import { createEventBus, type EventBus } from "@earendil-works/pi-coding-agent";
 import type {
   AgentStartInjection,
   BeforeAgentStartEvent,
@@ -86,6 +87,7 @@ interface HandlerStore {
 }
 
 export interface FakePi extends PiLike {
+  readonly events: EventBus;
   emitSessionStart(payload: SessionStartEvent): Promise<void>;
   emitInput(payload: InputEvent): Promise<void>;
   emitBeforeAgentStart(
@@ -173,6 +175,7 @@ export function createFakePi(
     after_provider_response: [],
   };
   const tools: ToolDefLike[] = [];
+  const events = createEventBus();
   const commands = new Set<string>();
   const shortcuts = new Set<string>();
   const entryRenderers = new Set<string>();
@@ -271,6 +274,7 @@ export function createFakePi(
   };
 
   return {
+    events,
     on<K extends PiEventName>(event: K, handler: PiEventHandler<K>) {
       const registrar = (
         registrars as Partial<

--- a/tests/pi-harness/hearth-tools-native.test.ts
+++ b/tests/pi-harness/hearth-tools-native.test.ts
@@ -253,6 +253,81 @@ describe("Hearth-backed pi tool contracts", () => {
     expect(negativeText).toContain("root.ts:1: needle");
     expect(negativeText).toContain("src/a.ts:1: needle");
     expect(negativeText).not.toContain("a.md");
+
+    const rootedNegative = await grep.execute(
+      "grep-rooted-negative",
+      { pattern: "needle", path: ".", glob: "!/src/*.ts" },
+      undefined,
+      undefined,
+      context,
+    );
+    const rootedText =
+      rootedNegative.content[0]?.type === "text"
+        ? rootedNegative.content[0].text
+        : "";
+    expect(rootedText).toContain("root.ts:1: needle");
+    expect(rootedText).toContain("src/a.md:1: needle");
+    expect(rootedText).not.toContain("src/a.ts");
+  });
+
+  test("grep reproduces pi context blocks for adjacent matches", async () => {
+    const cwd = await root();
+    await writeFile(
+      join(cwd, "adjacent.txt"),
+      "first\nmatch one\nmatch two\nlast\n",
+    );
+    const grep = createHearthGrepDefinition(cwd, engine(cwd));
+
+    const result = await grep.execute(
+      "grep-adjacent",
+      { pattern: "match", path: ".", context: 1 },
+      undefined,
+      undefined,
+      context,
+    );
+    expect(result.content[0]).toEqual({
+      type: "text",
+      text: [
+        "adjacent.txt-1- first",
+        "adjacent.txt:2: match one",
+        "adjacent.txt-3- match two",
+        "adjacent.txt-2- match one",
+        "adjacent.txt:3: match two",
+        "adjacent.txt-4- last",
+      ].join("\n"),
+    });
+  });
+
+  test("bounds negative-glob candidates and fails closed if underfilled", async () => {
+    const cwd = await root();
+    let maxTotalCount: number | undefined;
+    const fakeEngine = {
+      async grepAsync(params: { maxTotalCount?: number }) {
+        maxTotalCount = params.maxTotalCount;
+        return {
+          files: [],
+          totalMatches: maxTotalCount ?? 0,
+          filesSearched: 1,
+          walkCacheHit: false,
+          limitReached: true,
+          root: cwd,
+          rootIsDir: true,
+        };
+      },
+    } as unknown as HearthEngine;
+    const grep = createHearthGrepDefinition(cwd, fakeEngine);
+
+    await expect(
+      grep.execute(
+        "grep-negative-bound",
+        { pattern: ".", path: ".", glob: "!*.md", limit: 1 },
+        undefined,
+        undefined,
+        context,
+      ),
+    ).rejects.toThrow("Negative glob candidate scan limit reached");
+    expect(maxTotalCount).toBeGreaterThan(0);
+    expect(maxTotalCount).toBeLessThanOrEqual(100_000);
   });
 
   test("grep maps a pre-aborted request to pi's error", async () => {
@@ -331,7 +406,7 @@ describe("Hearth-backed pi tool contracts", () => {
     ).rejects.toThrow("Command aborted");
   });
 
-  test("bash treats a signal exit like pi's null exit code", async () => {
+  test("bash treats a fresh-shell signal exit like pi's null exit code", async () => {
     const cwd = await root();
     const hearth = new HearthEngine({
       cwd,
@@ -353,5 +428,22 @@ describe("Hearth-backed pi tool contracts", () => {
       type: "text",
       text: "(no output)",
     });
+  });
+
+  test("bash never retries an indeterminate warm-shell signal", async () => {
+    const cwd = await root();
+    const bash = createHearthBashDefinition(cwd, engine(cwd), settings);
+
+    await expect(
+      bash.execute(
+        "bash-warm-signal",
+        { command: "kill -TERM $$" },
+        undefined,
+        undefined,
+        context,
+      ),
+    ).rejects.toThrow(
+      "Hearth reported an indeterminate command outcome; inspect state before retrying",
+    );
   });
 });

--- a/tests/pi-harness/hearth-tools-native.test.ts
+++ b/tests/pi-harness/hearth-tools-native.test.ts
@@ -227,6 +227,8 @@ describe("Hearth-backed pi tool contracts", () => {
     await writeFile(join(cwd, "src", "a.ts"), "needle\n");
     await writeFile(join(cwd, "src", "a.md"), "needle\n");
     await writeFile(join(cwd, "src", "nested", "deep.ts"), "needle\n");
+    await writeFile(join(cwd, "src", "README.md"), "needle\n");
+    await writeFile(join(cwd, "README.md"), "needle\n");
     await writeFile(join(cwd, "root.ts"), "needle\n");
     const grep = createHearthGrepDefinition(cwd, engine(cwd));
 
@@ -252,6 +254,18 @@ describe("Hearth-backed pi tool contracts", () => {
     expect(rootedPositive.content[0]).toEqual({
       type: "text",
       text: "src/a.ts:1: needle",
+    });
+
+    const rootedBasename = await grep.execute(
+      "grep-rooted-basename",
+      { pattern: "needle", path: "src", glob: "/README.md" },
+      undefined,
+      undefined,
+      context,
+    );
+    expect(rootedBasename.content[0]).toEqual({
+      type: "text",
+      text: "No matches found",
     });
 
     const cwdRelative = await grep.execute(
@@ -302,10 +316,29 @@ describe("Hearth-backed pi tool contracts", () => {
       undefined,
       context,
     );
-    expect(excludedDirectory.content[0]).toEqual({
-      type: "text",
-      text: "root.ts:1: needle",
-    });
+    const excludedDirectoryText =
+      excludedDirectory.content[0]?.type === "text"
+        ? excludedDirectory.content[0].text
+        : "";
+    expect(excludedDirectoryText).toContain("README.md:1: needle");
+    expect(excludedDirectoryText).toContain("root.ts:1: needle");
+    expect(excludedDirectoryText).not.toContain("src/");
+
+    for (const glob of ["!src/nested/", "!nested/"]) {
+      const directoryOnly = await grep.execute(
+        `grep-directory-only-${glob}`,
+        { pattern: "needle", path: ".", glob },
+        undefined,
+        undefined,
+        context,
+      );
+      const directoryOnlyText =
+        directoryOnly.content[0]?.type === "text"
+          ? directoryOnly.content[0].text
+          : "";
+      expect(directoryOnlyText).toContain("src/a.ts:1: needle");
+      expect(directoryOnlyText).not.toContain("src/nested/deep.ts");
+    }
 
     const rootedFromSubdir = await grep.execute(
       "grep-rooted-subdir",
@@ -333,15 +366,29 @@ describe("Hearth-backed pi tool contracts", () => {
       text: "a.ts:1: needle",
     });
 
-    await expect(
-      grep.execute(
-        "grep-invalid-file-glob",
-        { pattern: "needle", path: "src/a.ts", glob: "![" },
-        undefined,
-        undefined,
-        context,
-      ),
-    ).rejects.toThrow("unclosed character class");
+    const escapedFileGlob = await grep.execute(
+      "grep-escaped-file-glob",
+      { pattern: "needle", path: "src/a.ts", glob: "!\\[" },
+      undefined,
+      undefined,
+      context,
+    );
+    expect(escapedFileGlob.content[0]).toEqual({
+      type: "text",
+      text: "a.ts:1: needle",
+    });
+
+    for (const glob of ["![", "![z-a]", "!{a,b", "!a}", "!\\"]) {
+      await expect(
+        grep.execute(
+          `grep-invalid-file-glob-${glob}`,
+          { pattern: "needle", path: "src/a.ts", glob },
+          undefined,
+          undefined,
+          context,
+        ),
+      ).rejects.toThrow(/invalid glob|error parsing glob/);
+    }
   });
 
   test("grep reproduces pi context blocks for adjacent matches", async () => {

--- a/tests/pi-harness/hearth-tools-native.test.ts
+++ b/tests/pi-harness/hearth-tools-native.test.ts
@@ -4,7 +4,7 @@ import {
   generateUnifiedPatch,
 } from "@earendil-works/pi-coding-agent";
 import { HearthEngine, type ShellSpec } from "@hearthdev/napi";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -35,6 +35,17 @@ const settings: PiToolSettings = {
 };
 
 const context = { model: undefined } as never;
+
+interface NativeAbortController {
+  readonly signal: AbortSignal;
+  abort(): void;
+}
+
+const nativeAbortController = (): NativeAbortController => {
+  const Constructor =
+    globalThis.AbortController as unknown as new () => NativeAbortController;
+  return new Constructor();
+};
 
 const engine = (cwd: string): HearthEngine =>
   new HearthEngine({
@@ -116,26 +127,77 @@ describe("Hearth-backed pi tool contracts", () => {
     expect(result.details?.firstChangedLine).toBe(1);
   });
 
-  test("edit patch formatting matches pi for a one-line deletion", async () => {
+  test("edit patch formatting matches pi for deletion edge cases", async () => {
     const cwd = await root();
-    const path = join(cwd, "delete.txt");
-    await writeFile(path, "a\nb\n");
+    const edit = createHearthEditDefinition(cwd, engine(cwd));
+    const cases = [
+      {
+        path: "delete-line.txt",
+        before: "a\nb\n",
+        oldText: "b\n",
+        after: "a\n",
+      },
+      {
+        path: "delete-final.txt",
+        before: "a",
+        oldText: "a",
+        after: "",
+      },
+    ];
+
+    for (const item of cases) {
+      await writeFile(join(cwd, item.path), item.before);
+      const result = await edit.execute(
+        `edit-${item.path}`,
+        {
+          path: item.path,
+          edits: [{ oldText: item.oldText, newText: "" }],
+        },
+        undefined,
+        undefined,
+        context,
+      );
+
+      expect(result.details?.diff).toBe(
+        generateDiffString(item.before, item.after).diff,
+      );
+      expect(result.details?.patch).toBe(
+        generateUnifiedPatch(item.path, item.before, item.after),
+      );
+    }
+  });
+
+  test("edit accepts an exact whitespace-only target and maps failures", async () => {
+    const cwd = await root();
+    const path = join(cwd, "spaces.txt");
+    await writeFile(path, "   ");
     const edit = createHearthEditDefinition(cwd, engine(cwd));
 
-    const result = await edit.execute(
-      "edit-delete",
+    await edit.execute(
+      "edit-spaces",
       {
-        path: "delete.txt",
-        edits: [{ oldText: "b\n", newText: "" }],
+        path: "spaces.txt",
+        edits: [{ oldText: "   ", newText: "x" }],
       },
       undefined,
       undefined,
       context,
     );
+    expect(await readFile(path, "utf8")).toBe("x");
 
-    expect(result.details?.diff).toBe(generateDiffString("a\nb\n", "a\n").diff);
-    expect(result.details?.patch).toBe(
-      generateUnifiedPatch("delete.txt", "a\nb\n", "a\n"),
+    await expect(
+      edit.execute(
+        "edit-missing",
+        {
+          path: "spaces.txt",
+          edits: [{ oldText: "missing", newText: "y" }],
+        },
+        undefined,
+        undefined,
+        context,
+      ),
+    ).rejects.toThrow(
+      "Could not find the exact text in spaces.txt. The old text must match exactly including all whitespace and newlines.",
     );
   });
 
@@ -157,6 +219,57 @@ describe("Hearth-backed pi tool contracts", () => {
     expect(text).toContain("a.txt:2: match one");
     expect(text).toContain("1 matches limit reached");
     expect(result.details?.matchLimitReached).toBe(1);
+  });
+
+  test("grep preserves root-relative and negative ripgrep globs", async () => {
+    const cwd = await root();
+    await mkdir(join(cwd, "src"));
+    await writeFile(join(cwd, "src", "a.ts"), "needle\n");
+    await writeFile(join(cwd, "src", "a.md"), "needle\n");
+    await writeFile(join(cwd, "root.ts"), "needle\n");
+    const grep = createHearthGrepDefinition(cwd, engine(cwd));
+
+    const relative = await grep.execute(
+      "grep-relative",
+      { pattern: "needle", path: ".", glob: "src/*.ts" },
+      undefined,
+      undefined,
+      context,
+    );
+    expect(relative.content[0]).toEqual({
+      type: "text",
+      text: "src/a.ts:1: needle",
+    });
+
+    const negative = await grep.execute(
+      "grep-negative",
+      { pattern: "needle", path: ".", glob: "!*.md" },
+      undefined,
+      undefined,
+      context,
+    );
+    const negativeText =
+      negative.content[0]?.type === "text" ? negative.content[0].text : "";
+    expect(negativeText).toContain("root.ts:1: needle");
+    expect(negativeText).toContain("src/a.ts:1: needle");
+    expect(negativeText).not.toContain("a.md");
+  });
+
+  test("grep maps a pre-aborted request to pi's error", async () => {
+    const cwd = await root();
+    const controller = nativeAbortController();
+    controller.abort();
+    const grep = createHearthGrepDefinition(cwd, engine(cwd));
+
+    await expect(
+      grep.execute(
+        "grep-abort",
+        { pattern: "x", path: "." },
+        controller.signal,
+        undefined,
+        context,
+      ),
+    ).rejects.toThrow("Operation aborted");
   });
 
   test("bash streams output once, applies prefix, and clears stale cache", async () => {
@@ -186,5 +299,59 @@ describe("Hearth-backed pi tool contracts", () => {
     expect(result.content[0]).toEqual({ type: "text", text: "yes" });
     expect(updates.join("\n")).toContain("yes");
     expect((await hearth.readAsync({ path })).content).toBe("new\n");
+  });
+
+  test("bash reports the effective Engine timeout and maps aborts", async () => {
+    const cwd = await root();
+    const hearth = engine(cwd);
+    const bash = createHearthBashDefinition(cwd, hearth, settings, {
+      defaultTimeoutMs: 20,
+    });
+
+    await expect(
+      bash.execute(
+        "bash-timeout",
+        { command: "sleep 1" },
+        undefined,
+        undefined,
+        context,
+      ),
+    ).rejects.toThrow("Command timed out after 0.02 seconds");
+
+    const controller = nativeAbortController();
+    controller.abort();
+    await expect(
+      bash.execute(
+        "bash-abort",
+        { command: "printf never" },
+        controller.signal,
+        undefined,
+        context,
+      ),
+    ).rejects.toThrow("Command aborted");
+  });
+
+  test("bash treats a signal exit like pi's null exit code", async () => {
+    const cwd = await root();
+    const hearth = new HearthEngine({
+      cwd,
+      trustCache: true,
+      warmShell: false,
+      enableOptimizer: false,
+      shell,
+    });
+    const bash = createHearthBashDefinition(cwd, hearth, settings);
+
+    const result = await bash.execute(
+      "bash-signal",
+      { command: "kill -TERM $$" },
+      undefined,
+      undefined,
+      context,
+    );
+    expect(result.content[0]).toEqual({
+      type: "text",
+      text: "(no output)",
+    });
   });
 });

--- a/tests/pi-harness/hearth-tools-native.test.ts
+++ b/tests/pi-harness/hearth-tools-native.test.ts
@@ -223,9 +223,10 @@ describe("Hearth-backed pi tool contracts", () => {
 
   test("grep preserves root-relative and negative ripgrep globs", async () => {
     const cwd = await root();
-    await mkdir(join(cwd, "src"));
+    await mkdir(join(cwd, "src", "nested"), { recursive: true });
     await writeFile(join(cwd, "src", "a.ts"), "needle\n");
     await writeFile(join(cwd, "src", "a.md"), "needle\n");
+    await writeFile(join(cwd, "src", "nested", "deep.ts"), "needle\n");
     await writeFile(join(cwd, "root.ts"), "needle\n");
     const grep = createHearthGrepDefinition(cwd, engine(cwd));
 
@@ -237,6 +238,18 @@ describe("Hearth-backed pi tool contracts", () => {
       context,
     );
     expect(relative.content[0]).toEqual({
+      type: "text",
+      text: "src/a.ts:1: needle",
+    });
+
+    const rootedPositive = await grep.execute(
+      "grep-rooted-positive",
+      { pattern: "needle", path: ".", glob: "/src/*.ts" },
+      undefined,
+      undefined,
+      context,
+    );
+    expect(rootedPositive.content[0]).toEqual({
       type: "text",
       text: "src/a.ts:1: needle",
     });
@@ -279,7 +292,20 @@ describe("Hearth-backed pi tool contracts", () => {
         : "";
     expect(rootedText).toContain("root.ts:1: needle");
     expect(rootedText).toContain("src/a.md:1: needle");
+    expect(rootedText).toContain("src/nested/deep.ts:1: needle");
     expect(rootedText).not.toContain("src/a.ts");
+
+    const excludedDirectory = await grep.execute(
+      "grep-excluded-directory",
+      { pattern: "needle", path: ".", glob: "!src/*" },
+      undefined,
+      undefined,
+      context,
+    );
+    expect(excludedDirectory.content[0]).toEqual({
+      type: "text",
+      text: "root.ts:1: needle",
+    });
 
     const rootedFromSubdir = await grep.execute(
       "grep-rooted-subdir",
@@ -306,6 +332,16 @@ describe("Hearth-backed pi tool contracts", () => {
       type: "text",
       text: "a.ts:1: needle",
     });
+
+    await expect(
+      grep.execute(
+        "grep-invalid-file-glob",
+        { pattern: "needle", path: "src/a.ts", glob: "![" },
+        undefined,
+        undefined,
+        context,
+      ),
+    ).rejects.toThrow("unclosed character class");
   });
 
   test("grep reproduces pi context blocks for adjacent matches", async () => {
@@ -353,7 +389,7 @@ describe("Hearth-backed pi tool contracts", () => {
     );
   });
 
-  test("bounds negative-glob candidates and fails closed if underfilled", async () => {
+  test("bounds post-filtered glob candidates and fails closed if underfilled", async () => {
     const cwd = await root();
     let maxTotalCount: number | undefined;
     const fakeEngine = {
@@ -381,6 +417,15 @@ describe("Hearth-backed pi tool contracts", () => {
         context,
       ),
     ).rejects.toThrow("Negative glob candidate scan limit reached");
+    await expect(
+      grep.execute(
+        "grep-positive-bound",
+        { pattern: ".", path: ".", glob: "src/*.ts", limit: 1 },
+        undefined,
+        undefined,
+        context,
+      ),
+    ).rejects.toThrow("Positive glob candidate scan limit reached");
     expect(maxTotalCount).toBeGreaterThan(0);
     expect(maxTotalCount).toBeLessThanOrEqual(100_000);
   });

--- a/tests/pi-harness/hearth-tools-native.test.ts
+++ b/tests/pi-harness/hearth-tools-native.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  generateDiffString,
+  generateUnifiedPatch,
+} from "@earendil-works/pi-coding-agent";
+import { HearthEngine, type ShellSpec } from "@hearthdev/napi";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createHearthBashDefinition,
+  createHearthEditDefinition,
+  createHearthGrepDefinition,
+  createHearthReadDefinition,
+  createHearthWriteDefinition,
+} from "../../pi/extensions/hearth-tools/adapters";
+import type { PiToolSettings } from "../../pi/extensions/hearth-tools/engine";
+
+const roots: string[] = [];
+const root = async (): Promise<string> => {
+  const value = await mkdtemp(join(tmpdir(), "pi-hearth-tools-"));
+  roots.push(value);
+  return value;
+};
+
+const shell: ShellSpec = {
+  program: "/bin/bash",
+  args: ["-c"],
+  transport: "arg" as ShellSpec["transport"],
+};
+
+const settings: PiToolSettings = {
+  imageAutoResize: true,
+  shell,
+};
+
+const context = { model: undefined } as never;
+
+const engine = (cwd: string): HearthEngine =>
+  new HearthEngine({
+    cwd,
+    trustCache: true,
+    warmShell: true,
+    enableOptimizer: false,
+    shell,
+  });
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+describe("Hearth-backed pi tool contracts", () => {
+  test("write and read preserve pi output and warm cached bytes", async () => {
+    const cwd = await root();
+    const hearth = engine(cwd);
+    const write = createHearthWriteDefinition(cwd, hearth);
+    const read = createHearthReadDefinition(cwd, hearth, settings);
+
+    const written = await write.execute(
+      "write-1",
+      { path: "nested/file.txt", content: "one\ntwo\nthree\n" },
+      undefined,
+      undefined,
+      context,
+    );
+    expect(written.content[0]).toEqual({
+      type: "text",
+      text: "Successfully wrote 14 bytes to nested/file.txt",
+    });
+
+    const result = await read.execute(
+      "read-1",
+      { path: "nested/file.txt", offset: 2, limit: 1 },
+      undefined,
+      undefined,
+      context,
+    );
+    expect(result.content[0]).toEqual({
+      type: "text",
+      text: "two\n\n[2 more lines in file. Use offset=3 to continue.]",
+    });
+  });
+
+  test("edit applies multiple original-relative replacements and returns pi details", async () => {
+    const cwd = await root();
+    const path = join(cwd, "edit.txt");
+    await writeFile(path, "one\ntwo\nthree\n");
+    const edit = createHearthEditDefinition(cwd, engine(cwd));
+
+    const result = await edit.execute(
+      "edit-1",
+      {
+        path: "edit.txt",
+        edits: [
+          { oldText: "one", newText: "ONE" },
+          { oldText: "three", newText: "THREE" },
+        ],
+      },
+      undefined,
+      undefined,
+      context,
+    );
+    expect(await readFile(path, "utf8")).toBe("ONE\ntwo\nTHREE\n");
+    expect(result.details?.diff).toBe(
+      generateDiffString("one\ntwo\nthree\n", "ONE\ntwo\nTHREE\n").diff,
+    );
+    expect(result.details?.patch).toBe(
+      generateUnifiedPatch(
+        "edit.txt",
+        "one\ntwo\nthree\n",
+        "ONE\ntwo\nTHREE\n",
+      ),
+    );
+    expect(result.details?.firstChangedLine).toBe(1);
+  });
+
+  test("edit patch formatting matches pi for a one-line deletion", async () => {
+    const cwd = await root();
+    const path = join(cwd, "delete.txt");
+    await writeFile(path, "a\nb\n");
+    const edit = createHearthEditDefinition(cwd, engine(cwd));
+
+    const result = await edit.execute(
+      "edit-delete",
+      {
+        path: "delete.txt",
+        edits: [{ oldText: "b\n", newText: "" }],
+      },
+      undefined,
+      undefined,
+      context,
+    );
+
+    expect(result.details?.diff).toBe(generateDiffString("a\nb\n", "a\n").diff);
+    expect(result.details?.patch).toBe(
+      generateUnifiedPatch("delete.txt", "a\nb\n", "a\n"),
+    );
+  });
+
+  test("grep formats relative paths, context, and a global limit", async () => {
+    const cwd = await root();
+    await writeFile(join(cwd, "a.txt"), "before\nmatch one\nafter\n");
+    await writeFile(join(cwd, "b.txt"), "match two\n");
+    const grep = createHearthGrepDefinition(cwd, engine(cwd));
+
+    const result = await grep.execute(
+      "grep-1",
+      { pattern: "match", path: ".", context: 1, limit: 1 },
+      undefined,
+      undefined,
+      context,
+    );
+    const text =
+      result.content[0]?.type === "text" ? result.content[0].text : "";
+    expect(text).toContain("a.txt:2: match one");
+    expect(text).toContain("1 matches limit reached");
+    expect(result.details?.matchLimitReached).toBe(1);
+  });
+
+  test("bash streams output once, applies prefix, and clears stale cache", async () => {
+    const cwd = await root();
+    const path = join(cwd, "value.txt");
+    await writeFile(path, "old\n");
+    const hearth = engine(cwd);
+    await hearth.readAsync({ path });
+    const bash = createHearthBashDefinition(cwd, hearth, {
+      ...settings,
+      shellCommandPrefix: "export PREFIXED=yes",
+    });
+    const updates: string[] = [];
+
+    const result = await bash.execute(
+      "bash-1",
+      {
+        command: `printf "$PREFIXED"; printf 'new\\n' > ${JSON.stringify(path)}`,
+      },
+      undefined,
+      (update) => {
+        const block = update.content[0];
+        if (block?.type === "text") updates.push(block.text);
+      },
+      context,
+    );
+    expect(result.content[0]).toEqual({ type: "text", text: "yes" });
+    expect(updates.join("\n")).toContain("yes");
+    expect((await hearth.readAsync({ path })).content).toBe("new\n");
+  });
+});

--- a/tests/pi-harness/hearth-tools-native.test.ts
+++ b/tests/pi-harness/hearth-tools-native.test.ts
@@ -241,6 +241,18 @@ describe("Hearth-backed pi tool contracts", () => {
       text: "src/a.ts:1: needle",
     });
 
+    const cwdRelative = await grep.execute(
+      "grep-cwd-relative",
+      { pattern: "needle", path: "src", glob: "src/*.ts" },
+      undefined,
+      undefined,
+      context,
+    );
+    expect(cwdRelative.content[0]).toEqual({
+      type: "text",
+      text: "a.ts:1: needle",
+    });
+
     const negative = await grep.execute(
       "grep-negative",
       { pattern: "needle", path: ".", glob: "!*.md" },
@@ -268,6 +280,32 @@ describe("Hearth-backed pi tool contracts", () => {
     expect(rootedText).toContain("root.ts:1: needle");
     expect(rootedText).toContain("src/a.md:1: needle");
     expect(rootedText).not.toContain("src/a.ts");
+
+    const rootedFromSubdir = await grep.execute(
+      "grep-rooted-subdir",
+      { pattern: "needle", path: "src", glob: "!/a.ts" },
+      undefined,
+      undefined,
+      context,
+    );
+    const rootedFromSubdirText =
+      rootedFromSubdir.content[0]?.type === "text"
+        ? rootedFromSubdir.content[0].text
+        : "";
+    expect(rootedFromSubdirText).toContain("a.md:1: needle");
+    expect(rootedFromSubdirText).toContain("a.ts:1: needle");
+
+    const explicitFile = await grep.execute(
+      "grep-file-glob",
+      { pattern: "needle", path: "src/a.ts", glob: "!*.ts" },
+      undefined,
+      undefined,
+      context,
+    );
+    expect(explicitFile.content[0]).toEqual({
+      type: "text",
+      text: "a.ts:1: needle",
+    });
   });
 
   test("grep reproduces pi context blocks for adjacent matches", async () => {
@@ -296,6 +334,23 @@ describe("Hearth-backed pi tool contracts", () => {
         "adjacent.txt-4- last",
       ].join("\n"),
     });
+
+    const limited = await grep.execute(
+      "grep-adjacent-limit",
+      { pattern: "match", path: ".", context: 1, limit: 1 },
+      undefined,
+      undefined,
+      context,
+    );
+    const limitedText =
+      limited.content[0]?.type === "text" ? limited.content[0].text : "";
+    expect(limitedText).toContain(
+      [
+        "adjacent.txt-1- first",
+        "adjacent.txt:2: match one",
+        "adjacent.txt-3- match two",
+      ].join("\n"),
+    );
   });
 
   test("bounds negative-glob candidates and fails closed if underfilled", async () => {

--- a/tests/pi-harness/hearth-tools-startup.test.ts
+++ b/tests/pi-harness/hearth-tools-startup.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  createEventBus,
+  type ExtensionAPI,
+  type SessionStartEvent,
+  type ToolDefinition,
+} from "@earendil-works/pi-coding-agent";
+import {
+  DEFAULT_HEARTH_TOOLS_CONFIG,
+  parseHearthToolsConfig,
+} from "../../pi/extensions/hearth-tools/config";
+import { clearProcessEngineForTests } from "../../pi/extensions/hearth-tools/engine";
+import {
+  HEARTH_TOOL_NAMES,
+  setupHearthTools,
+} from "../../pi/extensions/hearth-tools/index";
+
+interface FakeEngineOptions {
+  cwd?: string;
+  trustCache?: boolean;
+  warmShell?: boolean;
+  bashTimeoutMs?: number;
+}
+
+class FakeEngine {
+  static constructed: FakeEngineOptions[] = [];
+  constructor(options: FakeEngineOptions = {}) {
+    FakeEngine.constructed.push(options);
+  }
+  clearCaches() {
+    return { filesInvalidated: 2, walksInvalidated: 1 };
+  }
+}
+
+const fakePi = () => {
+  const sessionStart: Array<
+    (event: SessionStartEvent, ctx: Record<string, unknown>) => unknown
+  > = [];
+  const tools: ToolDefinition[] = [];
+  const commands = new Map<string, { handler: Function }>();
+  let active = ["read", "bash", "write", "edit"];
+  const pi = {
+    events: createEventBus(),
+    on(event: string, handler: Function) {
+      if (event === "session_start") sessionStart.push(handler as never);
+    },
+    registerTool(tool: ToolDefinition) {
+      tools.push(tool);
+    },
+    registerCommand(name: string, options: { handler: Function }) {
+      commands.set(name, options);
+    },
+    getActiveTools: () => [...active],
+    setActiveTools(names: string[]) {
+      active = [...names];
+    },
+    getAllTools: () =>
+      tools.map((tool) => ({
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.parameters,
+        promptGuidelines: tool.promptGuidelines,
+        sourceInfo: {
+          path: `/repo/pi/extensions/hearth-tools/${tool.name}.ts`,
+          source: "extension",
+          scope: "user",
+          origin: "top-level",
+        },
+      })),
+  } as unknown as ExtensionAPI;
+  return { pi, sessionStart, tools, commands, active: () => active };
+};
+
+const settings = {
+  getShellPath: () => "/bin/bash",
+  getShellCommandPrefix: () => "set -e",
+  getImageAutoResize: () => false,
+};
+
+const context = {
+  cwd: "/workspace",
+  isProjectTrusted: () => true,
+  ui: { notify() {} },
+};
+
+afterEach(() => {
+  clearProcessEngineForTests();
+  FakeEngine.constructed = [];
+});
+
+describe("hearth-tools config", () => {
+  test("defaults to the requested maximum-speed profile", () => {
+    expect(parseHearthToolsConfig({})).toEqual(DEFAULT_HEARTH_TOOLS_CONFIG);
+  });
+
+  test("rejects malformed and out-of-range fields", () => {
+    expect(() => parseHearthToolsConfig({ trustCache: "yes" })).toThrow(
+      "trustCache",
+    );
+    expect(() => parseHearthToolsConfig({ maxCachedFiles: 0 })).toThrow(
+      "maxCachedFiles",
+    );
+    expect(() => parseHearthToolsConfig({ bashTimeoutMs: Infinity })).toThrow(
+      "bashTimeoutMs",
+    );
+  });
+});
+
+describe("hearth-tools startup", () => {
+  test("fails through the injected fatal boundary when the addon cannot load", async () => {
+    await expect(
+      setupHearthTools(fakePi().pi, {
+        loadModule: async () => {
+          throw new Error("private loader path");
+        },
+        fatal: (message) => {
+          throw new Error(`fatal:${message}`);
+        },
+      }),
+    ).rejects.toThrow(
+      "fatal:pi-hearth-tools: Hearth native backend is unavailable",
+    );
+  });
+
+  test("registers five overrides on session start without activating grep", async () => {
+    const fake = fakePi();
+    await setupHearthTools(fake.pi, {
+      loadModule: async () => ({ HearthEngine: FakeEngine as never }),
+      getAgentDir: () => "/agent",
+      loadConfig: () => ({ ...DEFAULT_HEARTH_TOOLS_CONFIG }),
+      createSettings: (() => settings) as never,
+      fatal: (message) => {
+        throw new Error(message);
+      },
+    });
+
+    expect(fake.tools).toHaveLength(0);
+    await fake.sessionStart[0]?.(
+      { reason: "startup" } as SessionStartEvent,
+      context,
+    );
+
+    expect(fake.tools.map((tool) => tool.name)).toEqual([...HEARTH_TOOL_NAMES]);
+    expect(fake.active()).toEqual(["read", "bash", "write", "edit"]);
+    expect(FakeEngine.constructed).toHaveLength(1);
+    expect(FakeEngine.constructed[0]).toMatchObject({
+      cwd: "/workspace",
+      trustCache: true,
+      warmShell: true,
+      bashTimeoutMs: 2_147_483_647,
+    });
+    expect(fake.commands.has("hearth-clear-cache")).toBe(true);
+  });
+
+  test("reuses the process Engine across extension reloads", async () => {
+    for (let index = 0; index < 2; index += 1) {
+      const fake = fakePi();
+      await setupHearthTools(fake.pi, {
+        loadModule: async () => ({ HearthEngine: FakeEngine as never }),
+        getAgentDir: () => "/agent",
+        loadConfig: () => ({ ...DEFAULT_HEARTH_TOOLS_CONFIG }),
+        createSettings: (() => settings) as never,
+        fatal: (message) => {
+          throw new Error(message);
+        },
+      });
+      await fake.sessionStart[0]?.(
+        { reason: index === 0 ? "startup" : "reload" } as SessionStartEvent,
+        context,
+      );
+    }
+    expect(FakeEngine.constructed).toHaveLength(1);
+  });
+});

--- a/tests/pi-harness/hearth-tools-startup.test.ts
+++ b/tests/pi-harness/hearth-tools-startup.test.ts
@@ -9,9 +9,15 @@ import {
   DEFAULT_HEARTH_TOOLS_CONFIG,
   parseHearthToolsConfig,
 } from "../../pi/extensions/hearth-tools/config";
-import { clearProcessEngineForTests } from "../../pi/extensions/hearth-tools/engine";
 import {
+  clearProcessEngineForTests,
+  HearthEngineGate,
+} from "../../pi/extensions/hearth-tools/engine";
+import {
+  COLLISION_ERROR,
+  CONFIG_ERROR,
   HEARTH_TOOL_NAMES,
+  RESTART_ERROR,
   setupHearthTools,
 } from "../../pi/extensions/hearth-tools/index";
 
@@ -24,25 +30,29 @@ interface FakeEngineOptions {
 
 class FakeEngine {
   static constructed: FakeEngineOptions[] = [];
+  static clearCount = 0;
   constructor(options: FakeEngineOptions = {}) {
     FakeEngine.constructed.push(options);
   }
   clearCaches() {
+    FakeEngine.clearCount += 1;
     return { filesInvalidated: 2, walksInvalidated: 1 };
   }
 }
 
-const fakePi = () => {
-  const sessionStart: Array<
-    (event: SessionStartEvent, ctx: Record<string, unknown>) => unknown
-  > = [];
+const fakePi = (competingTool?: string) => {
+  const handlers = new Map<string, Function[]>();
+  const sessionStart: Function[] = [];
+  handlers.set("session_start", sessionStart);
   const tools: ToolDefinition[] = [];
   const commands = new Map<string, { handler: Function }>();
   let active = ["read", "bash", "write", "edit"];
   const pi = {
     events: createEventBus(),
     on(event: string, handler: Function) {
-      if (event === "session_start") sessionStart.push(handler as never);
+      const registered = handlers.get(event) ?? [];
+      registered.push(handler);
+      handlers.set(event, registered);
     },
     registerTool(tool: ToolDefinition) {
       tools.push(tool);
@@ -54,21 +64,54 @@ const fakePi = () => {
     setActiveTools(names: string[]) {
       active = [...names];
     },
-    getAllTools: () =>
-      tools.map((tool) => ({
-        name: tool.name,
-        description: tool.description,
-        parameters: tool.parameters,
-        promptGuidelines: tool.promptGuidelines,
-        sourceInfo: {
-          path: `/repo/pi/extensions/hearth-tools/${tool.name}.ts`,
-          source: "extension",
-          scope: "user",
-          origin: "top-level",
-        },
-      })),
+    getAllTools: () => {
+      const winners = new Map<string, Record<string, unknown>>();
+      if (competingTool !== undefined) {
+        winners.set(competingTool, {
+          name: competingTool,
+          sourceInfo: {
+            path: `/project/extension/${competingTool}.ts`,
+            source: "project-extension",
+            scope: "project",
+            origin: "top-level",
+          },
+        });
+      }
+      for (const tool of tools) {
+        if (winners.has(tool.name)) continue;
+        winners.set(tool.name, {
+          name: tool.name,
+          description: tool.description,
+          parameters: tool.parameters,
+          promptGuidelines: tool.promptGuidelines,
+          sourceInfo: {
+            path: `/repo/pi/extensions/hearth-tools/${tool.name}.ts`,
+            source: "extension",
+            scope: "user",
+            origin: "top-level",
+          },
+        });
+      }
+      return [...winners.values()];
+    },
   } as unknown as ExtensionAPI;
-  return { pi, sessionStart, tools, commands, active: () => active };
+  const emit = async (
+    event: string,
+    payload: unknown = {},
+    eventContext: Record<string, unknown> = context,
+  ): Promise<void> => {
+    for (const handler of handlers.get(event) ?? []) {
+      await handler(payload, eventContext);
+    }
+  };
+  return {
+    pi,
+    emit,
+    sessionStart,
+    tools,
+    commands,
+    active: () => active,
+  };
 };
 
 const settings = {
@@ -86,6 +129,7 @@ const context = {
 afterEach(() => {
   clearProcessEngineForTests();
   FakeEngine.constructed = [];
+  FakeEngine.clearCount = 0;
 });
 
 describe("hearth-tools config", () => {
@@ -103,6 +147,44 @@ describe("hearth-tools config", () => {
     expect(() => parseHearthToolsConfig({ bashTimeoutMs: Infinity })).toThrow(
       "bashTimeoutMs",
     );
+    expect(() => parseHearthToolsConfig({ trustCaches: false })).toThrow(
+      "unknown hearth-tools config key: trustCaches",
+    );
+  });
+});
+
+describe("Hearth Engine access gate", () => {
+  test("an exclusive operation waits for readers and blocks later readers", async () => {
+    const gate = new HearthEngineGate();
+    const order: string[] = [];
+    let releaseReader: (() => void) | undefined;
+    const heldReader = new Promise<void>((resolve) => {
+      releaseReader = resolve;
+    });
+
+    const reader = gate.shared(async () => {
+      order.push("reader:start");
+      await heldReader;
+      order.push("reader:end");
+    });
+    await Promise.resolve();
+    const writer = gate.exclusive(async () => {
+      order.push("writer");
+    });
+    const laterReader = gate.shared(async () => {
+      order.push("reader:later");
+    });
+    await Promise.resolve();
+
+    expect(order).toEqual(["reader:start"]);
+    releaseReader?.();
+    await Promise.all([reader, writer, laterReader]);
+    expect(order).toEqual([
+      "reader:start",
+      "reader:end",
+      "writer",
+      "reader:later",
+    ]);
   });
 });
 
@@ -164,11 +246,101 @@ describe("hearth-tools startup", () => {
           throw new Error(message);
         },
       });
-      await fake.sessionStart[0]?.(
-        { reason: index === 0 ? "startup" : "reload" } as SessionStartEvent,
-        context,
-      );
+      await fake.emit("session_start", {
+        reason: index === 0 ? "startup" : "reload",
+      });
     }
     expect(FakeEngine.constructed).toHaveLength(1);
+  });
+
+  test("requires a restart when reload changes Engine options", async () => {
+    const first = fakePi();
+    await setupHearthTools(first.pi, {
+      loadModule: async () => ({ HearthEngine: FakeEngine as never }),
+      getAgentDir: () => "/agent",
+      loadConfig: () => ({ ...DEFAULT_HEARTH_TOOLS_CONFIG }),
+      createSettings: (() => settings) as never,
+      fatal: (message) => {
+        throw new Error(message);
+      },
+    });
+    await first.emit("session_start", { reason: "startup" });
+
+    const reloaded = fakePi();
+    await setupHearthTools(reloaded.pi, {
+      loadModule: async () => ({ HearthEngine: FakeEngine as never }),
+      getAgentDir: () => "/agent",
+      loadConfig: () => ({
+        ...DEFAULT_HEARTH_TOOLS_CONFIG,
+        trustCache: false,
+      }),
+      createSettings: (() => settings) as never,
+      fatal: (message) => {
+        throw new Error(message);
+      },
+    });
+    await expect(
+      reloaded.emit("session_start", { reason: "reload" }),
+    ).rejects.toThrow(RESTART_ERROR);
+    expect(FakeEngine.constructed).toHaveLength(1);
+  });
+
+  test("fails boundedly for invalid config and an effective override", async () => {
+    const invalid = fakePi();
+    await setupHearthTools(invalid.pi, {
+      loadModule: async () => ({ HearthEngine: FakeEngine as never }),
+      getAgentDir: () => "/agent",
+      loadConfig: () => {
+        throw new Error("sensitive parser detail");
+      },
+      createSettings: (() => settings) as never,
+      fatal: (message) => {
+        throw new Error(message);
+      },
+    });
+    await expect(
+      invalid.emit("session_start", { reason: "startup" }),
+    ).rejects.toThrow(CONFIG_ERROR);
+
+    const collision = fakePi("read");
+    await setupHearthTools(collision.pi, {
+      loadModule: async () => ({ HearthEngine: FakeEngine as never }),
+      getAgentDir: () => "/agent",
+      loadConfig: () => ({ ...DEFAULT_HEARTH_TOOLS_CONFIG }),
+      createSettings: (() => settings) as never,
+      fatal: (message) => {
+        throw new Error(message);
+      },
+    });
+    await expect(
+      collision.emit("session_start", { reason: "startup" }),
+    ).rejects.toThrow(COLLISION_ERROR);
+  });
+
+  test("clears caches after mutation hooks and child completion", async () => {
+    const fake = fakePi();
+    await setupHearthTools(fake.pi, {
+      loadModule: async () => ({ HearthEngine: FakeEngine as never }),
+      getAgentDir: () => "/agent",
+      loadConfig: () => ({ ...DEFAULT_HEARTH_TOOLS_CONFIG }),
+      createSettings: (() => settings) as never,
+      fatal: (message) => {
+        throw new Error(message);
+      },
+    });
+    await fake.emit("session_start", { reason: "startup" });
+
+    await fake.emit("message_end", {
+      message: { role: "toolResult", toolName: "edit" },
+    });
+    expect(FakeEngine.clearCount).toBe(1);
+
+    await fake.emit("message_start", {
+      message: {
+        role: "custom",
+        customType: "pi-harness/child-run-completion",
+      },
+    });
+    expect(FakeEngine.clearCount).toBe(2);
   });
 });

--- a/tests/pi-harness/hearth-tools-startup.test.ts
+++ b/tests/pi-harness/hearth-tools-startup.test.ts
@@ -50,6 +50,8 @@ const fakePi = (
   competingTool?: string,
   competingPath = "/project/extension/index.ts",
 ) => {
+  let competingName = competingTool;
+  let competingSourcePath = competingPath;
   const handlers = new Map<string, Function[]>();
   const sessionStart: Function[] = [];
   handlers.set("session_start", sessionStart);
@@ -75,11 +77,11 @@ const fakePi = (
     },
     getAllTools: () => {
       const winners = new Map<string, Record<string, unknown>>();
-      if (competingTool !== undefined) {
-        winners.set(competingTool, {
-          name: competingTool,
+      if (competingName !== undefined) {
+        winners.set(competingName, {
+          name: competingName,
           sourceInfo: {
-            path: competingPath,
+            path: competingSourcePath,
             source: "project-extension",
             scope: "project",
             origin: "top-level",
@@ -120,6 +122,10 @@ const fakePi = (
     tools,
     commands,
     active: () => active,
+    setCompetingTool(name: string, path = competingPath) {
+      competingName = name;
+      competingSourcePath = path;
+    },
   };
 };
 
@@ -340,6 +346,28 @@ describe("hearth-tools startup", () => {
     ).rejects.toThrow(COLLISION_ERROR);
   });
 
+  test("rechecks effective ownership at the tool-call boundary", async () => {
+    const fake = fakePi();
+    await setupHearthTools(fake.pi, {
+      loadModule: async () => ({ HearthEngine: FakeEngine as never }),
+      getAgentDir: () => "/agent",
+      loadConfig: () => ({ ...DEFAULT_HEARTH_TOOLS_CONFIG }),
+      createSettings: (() => settings) as never,
+      fatal: (message) => {
+        throw new Error(message);
+      },
+    });
+    await fake.emit("session_start", { reason: "startup" });
+    fake.pi.on("before_agent_start", () => {
+      fake.setCompetingTool("read");
+    });
+
+    await fake.emit("before_agent_start");
+    await expect(
+      fake.emit("tool_call", { toolName: "read", toolCallId: "late-read" }),
+    ).rejects.toThrow(COLLISION_ERROR);
+  });
+
   test("releases the legacy process slot before creating the gated runtime", async () => {
     const legacySlot = Symbol.for("ushironoko.pi-hearth-tools.engine.v1");
     Reflect.set(globalThis, legacySlot, { engine: {}, options: {} });
@@ -377,13 +405,18 @@ describe("hearth-tools startup", () => {
     });
     expect(FakeEngine.clearCount).toBe(1);
 
+    await fake.emit("message_end", {
+      message: { role: "toolResult", toolName: "worktree_create" },
+    });
+    expect(FakeEngine.clearCount).toBe(2);
+
     await fake.emit("message_start", {
       message: {
         role: "custom",
         customType: "pi-harness/child-run-completion",
       },
     });
-    expect(FakeEngine.clearCount).toBe(2);
+    expect(FakeEngine.clearCount).toBe(3);
 
     await fake.emit("session_shutdown");
     // Register the next extension revision without starting its session. The
@@ -404,7 +437,7 @@ describe("hearth-tools startup", () => {
       },
     });
     await Promise.all(pending);
-    expect(FakeEngine.clearCount).toBe(3);
+    expect(FakeEngine.clearCount).toBe(4);
 
     let finishWriter = (): void => {};
     const writerFinished = new Promise<void>((resolveWriter) => {
@@ -419,6 +452,22 @@ describe("hearth-tools startup", () => {
     });
     expect(lease).toBeDefined();
     await lease?.ready;
+
+    const acceptance = fake.emit("message_end", {
+      message: {
+        role: "toolResult",
+        toolName: "subagent",
+        details: { background: { status: "accepted" } },
+      },
+    });
+    const acceptanceSettled = await Promise.race([
+      acceptance.then(() => true),
+      new Promise<false>((resolveTimeout) => {
+        setTimeout(() => resolveTimeout(false), 25);
+      }),
+    ]);
+    expect(acceptanceSettled).toBe(true);
+    expect(FakeEngine.clearCount).toBe(4);
 
     let finishSecondWriter = (): void => {};
     const secondWriterFinished = new Promise<void>((resolveWriter) => {
@@ -447,6 +496,14 @@ describe("hearth-tools startup", () => {
     finishSecondWriter();
     await Promise.all([lease?.complete, secondLease?.complete]);
     expect(leaseCompleted).toBe(true);
-    expect(FakeEngine.clearCount).toBe(4);
+    expect(FakeEngine.clearCount).toBe(5);
+
+    await fake.emit("message_end", {
+      message: { role: "toolResult", toolName: "subagent" },
+    });
+    await fake.emit("message_end", {
+      message: { role: "toolResult", toolName: "worktree_remove" },
+    });
+    expect(FakeEngine.clearCount).toBe(7);
   });
 });

--- a/tests/pi-harness/hearth-tools-startup.test.ts
+++ b/tests/pi-harness/hearth-tools-startup.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
 import {
   createEventBus,
   type ExtensionAPI,
@@ -40,7 +41,15 @@ class FakeEngine {
   }
 }
 
-const fakePi = (competingTool?: string) => {
+const HEARTH_TEST_SOURCE = resolve(
+  import.meta.dir,
+  "../../pi/extensions/hearth-tools/index.ts",
+);
+
+const fakePi = (
+  competingTool?: string,
+  competingPath = "/project/extension/index.ts",
+) => {
   const handlers = new Map<string, Function[]>();
   const sessionStart: Function[] = [];
   handlers.set("session_start", sessionStart);
@@ -70,7 +79,7 @@ const fakePi = (competingTool?: string) => {
         winners.set(competingTool, {
           name: competingTool,
           sourceInfo: {
-            path: `/project/extension/${competingTool}.ts`,
+            path: competingPath,
             source: "project-extension",
             scope: "project",
             origin: "top-level",
@@ -85,7 +94,7 @@ const fakePi = (competingTool?: string) => {
           parameters: tool.parameters,
           promptGuidelines: tool.promptGuidelines,
           sourceInfo: {
-            path: `/repo/pi/extensions/hearth-tools/${tool.name}.ts`,
+            path: HEARTH_TEST_SOURCE,
             source: "extension",
             scope: "user",
             origin: "top-level",
@@ -315,6 +324,39 @@ describe("hearth-tools startup", () => {
     await expect(
       collision.emit("session_start", { reason: "startup" }),
     ).rejects.toThrow(COLLISION_ERROR);
+
+    const spoofed = fakePi("read", "/project/hearth-tools/index.ts");
+    await setupHearthTools(spoofed.pi, {
+      loadModule: async () => ({ HearthEngine: FakeEngine as never }),
+      getAgentDir: () => "/agent",
+      loadConfig: () => ({ ...DEFAULT_HEARTH_TOOLS_CONFIG }),
+      createSettings: (() => settings) as never,
+      fatal: (message) => {
+        throw new Error(message);
+      },
+    });
+    await expect(
+      spoofed.emit("session_start", { reason: "startup" }),
+    ).rejects.toThrow(COLLISION_ERROR);
+  });
+
+  test("releases the legacy process slot before creating the gated runtime", async () => {
+    const legacySlot = Symbol.for("ushironoko.pi-hearth-tools.engine.v1");
+    Reflect.set(globalThis, legacySlot, { engine: {}, options: {} });
+    const fake = fakePi();
+    await setupHearthTools(fake.pi, {
+      loadModule: async () => ({ HearthEngine: FakeEngine as never }),
+      getAgentDir: () => "/agent",
+      loadConfig: () => ({ ...DEFAULT_HEARTH_TOOLS_CONFIG }),
+      createSettings: (() => settings) as never,
+      fatal: (message) => {
+        throw new Error(message);
+      },
+    });
+    await fake.emit("session_start", { reason: "reload" });
+
+    expect(Reflect.has(globalThis, legacySlot)).toBe(false);
+    expect(FakeEngine.constructed).toHaveLength(1);
   });
 
   test("clears caches after mutation hooks and child completion", async () => {
@@ -342,5 +384,15 @@ describe("hearth-tools startup", () => {
       },
     });
     expect(FakeEngine.clearCount).toBe(2);
+
+    await fake.emit("session_shutdown");
+    const pending: Promise<void>[] = [];
+    fake.pi.events.emit("pi-hearth-tools:invalidate-request:v1", {
+      accept(operation: Promise<void>) {
+        pending.push(operation);
+      },
+    });
+    await Promise.all(pending);
+    expect(FakeEngine.clearCount).toBe(3);
   });
 });

--- a/tests/pi-harness/hearth-tools-startup.test.ts
+++ b/tests/pi-harness/hearth-tools-startup.test.ts
@@ -386,6 +386,17 @@ describe("hearth-tools startup", () => {
     expect(FakeEngine.clearCount).toBe(2);
 
     await fake.emit("session_shutdown");
+    // Register the next extension revision without starting its session. The
+    // old initialized broker must remain active throughout this reload gap.
+    await setupHearthTools(fake.pi, {
+      loadModule: async () => ({ HearthEngine: FakeEngine as never }),
+      getAgentDir: () => "/agent",
+      loadConfig: () => ({ ...DEFAULT_HEARTH_TOOLS_CONFIG }),
+      createSettings: (() => settings) as never,
+      fatal: (message) => {
+        throw new Error(message);
+      },
+    });
     const pending: Promise<void>[] = [];
     fake.pi.events.emit("pi-hearth-tools:invalidate-request:v1", {
       accept(operation: Promise<void>) {
@@ -394,5 +405,48 @@ describe("hearth-tools startup", () => {
     });
     await Promise.all(pending);
     expect(FakeEngine.clearCount).toBe(3);
+
+    let finishWriter = (): void => {};
+    const writerFinished = new Promise<void>((resolveWriter) => {
+      finishWriter = resolveWriter;
+    });
+    let lease: { ready: Promise<void>; complete: Promise<void> } | undefined;
+    fake.pi.events.emit("pi-hearth-tools:external-writer-request:v1", {
+      finished: writerFinished,
+      accept(value: { ready: Promise<void>; complete: Promise<void> }) {
+        lease = value;
+      },
+    });
+    expect(lease).toBeDefined();
+    await lease?.ready;
+
+    let finishSecondWriter = (): void => {};
+    const secondWriterFinished = new Promise<void>((resolveWriter) => {
+      finishSecondWriter = resolveWriter;
+    });
+    let secondLease:
+      | { ready: Promise<void>; complete: Promise<void> }
+      | undefined;
+    fake.pi.events.emit("pi-hearth-tools:external-writer-request:v1", {
+      finished: secondWriterFinished,
+      accept(value: { ready: Promise<void>; complete: Promise<void> }) {
+        secondLease = value;
+      },
+    });
+    expect(secondLease).toBeDefined();
+    await secondLease?.ready;
+
+    let leaseCompleted = false;
+    void lease?.complete.then(() => {
+      leaseCompleted = true;
+    });
+    finishWriter();
+    await Promise.resolve();
+    expect(leaseCompleted).toBe(false);
+
+    finishSecondWriter();
+    await Promise.all([lease?.complete, secondLease?.complete]);
+    expect(leaseCompleted).toBe(true);
+    expect(FakeEngine.clearCount).toBe(4);
   });
 });


### PR DESCRIPTION
## Summary

- replace pi built-in `read`, `write`, `edit`, `bash`, and `grep` execution with an in-process Hearth N-API engine while preserving pi schemas, renderers, active-tool state, streaming, and cancellation
- pin `@hearthdev/napi` to `0.1.0`, reuse one Engine across reloads, fail closed during startup, and keep caches coherent across tool and user Bash
- provide Hearth-backed BTW reads and add deployment, compatibility, RPC, native-addon, and startup coverage

## Testing

- `bun run run-all`
  - 1514 passed
  - 2 skipped
  - 0 failed