### PR TITLE
style(pi): apply prettier formatting to pi-harness sources and tests

### DIFF
--- a/pi/extensions/pi-harness/features/permission-policy/context.ts
+++ b/pi/extensions/pi-harness/features/permission-policy/context.ts
@@ -311,7 +311,8 @@ const sessionMessage = (entry: unknown): Record<string, unknown> | undefined =>
     : undefined;
 
 const assistantTextBlocks = (message: Record<string, unknown>): string[] => {
-  if (message.role !== "assistant" || !Array.isArray(message.content)) return [];
+  if (message.role !== "assistant" || !Array.isArray(message.content))
+    return [];
   return message.content.flatMap((block) =>
     isRecord(block) && block.type === "text" && typeof block.text === "string"
       ? [block.text]
@@ -327,9 +328,7 @@ const containsToolCall = (
   Array.isArray(message.content) &&
   message.content.some(
     (block) =>
-      isRecord(block) &&
-      block.type === "toolCall" &&
-      block.id === toolCallId,
+      isRecord(block) && block.type === "toolCall" && block.id === toolCallId,
   );
 
 const truncateUtf8Tail = (value: string, maxBytes: number): string => {
@@ -342,7 +341,7 @@ const truncateUtf8Tail = (value: string, maxBytes: number): string => {
   while (
     start < encoded.byteLength &&
     (encoded[start] ?? 0) >= 0x80 &&
-    (encoded[start] ?? 0) < 0xC0
+    (encoded[start] ?? 0) < 0xc0
   ) {
     start += 1;
   }
@@ -396,7 +395,10 @@ export const derivePermissionRunEvidence = (
     if (message.isError === true) status = "error";
     else if (message.isError === false) status = "ok";
     allToolResults.push({
-      toolName: truncateUtf8(sanitizeTaskText(rawToolName), MAX_TOOL_NAME_BYTES),
+      toolName: truncateUtf8(
+        sanitizeTaskText(rawToolName),
+        MAX_TOOL_NAME_BYTES,
+      ),
       status,
     });
     fingerprintParts.push("tool-result", rawToolName, status);

--- a/pi/skills/plan-review/SKILL.md
+++ b/pi/skills/plan-review/SKILL.md
@@ -83,11 +83,11 @@ reviewer by itself.
 
 #### Reviewer matching rules
 
-| Condition                         | Agent to launch  |
-| --------------------------------- | ---------------- |
-| Rust project                      | `rust-reviewer`  |
-| codex CLI available               | `codex-reviewer` |
-| Test infrastructure exists        | `tdd-reviewer`   |
+| Condition                  | Agent to launch  |
+| -------------------------- | ---------------- |
+| Rust project               | `rust-reviewer`  |
+| codex CLI available        | `codex-reviewer` |
+| Test infrastructure exists | `tdd-reviewer`   |
 
 - Select every matching reviewer.
 - Never add `similarity` to a read-only roster; worktree isolation does not
@@ -364,18 +364,18 @@ Reviewing... (background workflow invocation accepted)
 
 ## Error Handling
 
-| Situation                                        | Response                                                                                   |
-| ------------------------------------------------ | ------------------------------------------------------------------------------------------ |
-| No plan file found                               | Report that `plans/` has no files                                                          |
-| `workflow` unavailable                           | Stop; never fall back to `subagent`                                                        |
-| Auto-selection matched no reviewer               | Show available agents and ask for manual specification                                     |
-| Codex missing but specialists matched            | Ask separately; set `codexSkip` only after explicit approval                               |
-| Manual agent definition not found                | Show available agents and stop                                                             |
-| Manual `similarity` / `codex-poc` / `codex-runner` requested | Report the read-only incompatibility and stop without spawning                  |
-| Workflow validation or preflight failed          | Report that no review ran and stop                                                         |
-| Invocation only accepted                         | Wait for its automatic background-completion message; do not aggregate the acceptance text |
-| Task failed, reported inability, or empty output | Keep usable reviews and report a reviewer-specific coverage gap                            |
-| Workflow output truncated                        | Synthesize available text and disclose the coverage limitation                             |
+| Situation                                                    | Response                                                                                   |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| No plan file found                                           | Report that `plans/` has no files                                                          |
+| `workflow` unavailable                                       | Stop; never fall back to `subagent`                                                        |
+| Auto-selection matched no reviewer                           | Show available agents and ask for manual specification                                     |
+| Codex missing but specialists matched                        | Ask separately; set `codexSkip` only after explicit approval                               |
+| Manual agent definition not found                            | Show available agents and stop                                                             |
+| Manual `similarity` / `codex-poc` / `codex-runner` requested | Report the read-only incompatibility and stop without spawning                             |
+| Workflow validation or preflight failed                      | Report that no review ran and stop                                                         |
+| Invocation only accepted                                     | Wait for its automatic background-completion message; do not aggregate the acceptance text |
+| Task failed, reported inability, or empty output             | Keep usable reviews and report a reviewer-specific coverage gap                            |
+| Workflow output truncated                                    | Synthesize available text and disclose the coverage limitation                             |
 
 ## Notes
 

--- a/tests/pi-harness/child-run-integration.test.ts
+++ b/tests/pi-harness/child-run-integration.test.ts
@@ -490,9 +490,13 @@ const writeAgent = async (
   for (const name of names) {
     await fs.writeFile(
       join(dir, `${name}.md`),
-      ["---", `name: ${name}`, `description: ${name}`, "---", "Work safely."].join(
-        "\n",
-      ),
+      [
+        "---",
+        `name: ${name}`,
+        `description: ${name}`,
+        "---",
+        "Work safely.",
+      ].join("\n"),
     );
   }
 };
@@ -1160,7 +1164,9 @@ describe("child-run subagent integration", () => {
   });
 
   test("retains every reviewer identity in an oversized four-task background result", async () => {
-    const home = await setupTestDirectory("pi-child-background-workflow-budget");
+    const home = await setupTestDirectory(
+      "pi-child-background-workflow-budget",
+    );
     tempDirectories.push(home);
     const reviewers = [
       "codex-reviewer",
@@ -1176,9 +1182,9 @@ describe("child-run subagent integration", () => {
       const reviewer = task.replace(/^Task: lens /, "");
       // Every byte after the lens expands to two bytes in JSON. This catches a
       // second prefix truncation at the notification framing boundary.
-      return scriptedSpawn(
-        `LENS-${reviewer}-${'"\\\n'.repeat(20_000)}`,
-      )(...args);
+      return scriptedSpawn(`LENS-${reviewer}-${'"\\\n'.repeat(20_000)}`)(
+        ...args,
+      );
     };
     setupWorkflow(runtime.pi, makeConfig(home), {
       childRuns,
@@ -1235,9 +1241,9 @@ describe("child-run subagent integration", () => {
     expect(typeof report).toBe("string");
     for (const [index, reviewer] of reviewers.entries()) {
       const next = reviewers[index + 1];
-      const section = String(report).split(`### [${reviewer}]`)[1]?.split(
-        next === undefined ? "\u0000" : `### [${next}]`,
-      )[0];
+      const section = String(report)
+        .split(`### [${reviewer}]`)[1]
+        ?.split(next === undefined ? "\u0000" : `### [${next}]`)[0];
       expect(section).toContain(`LENS-${reviewer}-`);
     }
     expect(report).toContain("Workflow completed: 4/4");

--- a/tests/pi-harness/permission-judge-context.test.ts
+++ b/tests/pi-harness/permission-judge-context.test.ts
@@ -429,9 +429,9 @@ describe("current permission run evidence", () => {
       message: { content: Array<{ text: string }> };
     };
     assistantEntry.message.content[0]!.text = `${"b".repeat(3_000)}TAIL`;
-    expect(derivePermissionRunEvidence(changed, "current")?.fingerprint).not.toBe(
-      first?.fingerprint,
-    );
+    expect(
+      derivePermissionRunEvidence(changed, "current")?.fingerprint,
+    ).not.toBe(first?.fingerprint);
   });
 });
 

--- a/tests/pi-harness/plan-review-skill.test.ts
+++ b/tests/pi-harness/plan-review-skill.test.ts
@@ -77,7 +77,9 @@ const expectCompleteReviewPrompt = (stage: Record<string, unknown>): void => {
       String(task.task).match(/^Plan Review Transport: path-base64-v1$/gm),
     ).toHaveLength(1);
     expect(task.task).toContain("Plan Path Encoding: base64 (UTF-8)");
-    expect(task.task).toContain("Plan Safe Path Transport: restricted-ascii-v1");
+    expect(task.task).toContain(
+      "Plan Safe Path Transport: restricted-ascii-v1",
+    );
     expect(task.task).toContain("<validated-plan-path>");
     expect(task.task).toContain("<base64-plan-path>");
     expect(task.task).toContain("read the exact file from disk");
@@ -190,9 +192,7 @@ describe("pi plan-review skill workflow contract", () => {
     const manual = firstStage(expectValidWorkflowExample("plan-review-manual"));
     const [manualTask] = manual.tasks as Record<string, unknown>[];
     expect(manualTask?.readOnly).toBe(true);
-    expect(skill).toContain(
-      "For `codex-reviewer` only, omit `readOnly`",
-    );
+    expect(skill).toContain("For `codex-reviewer` only, omit `readOnly`");
   });
 
   test("keeps synthesis with the parent and classifies incomplete coverage", () => {


### PR DESCRIPTION
Reformat permission-policy context, the pi plan-review skill doc, and the related pi-harness tests to match prettier output. No behavior change.


Claude-Session: https://claude.ai/code/session_017wzqqTzPTWH5rP4xyd72Rs