### PR TITLE
fix(pi): show coordination cursor only when focused

### DIFF
--- a/pi/extensions/pi-harness/features/child-runs/ui.ts
+++ b/pi/extensions/pi-harness/features/child-runs/ui.ts
@@ -3,6 +3,7 @@ import {
   Box,
   Container,
   Text,
+  type Focusable,
   truncateToWidth as truncateStyledToWidth,
 } from "@earendil-works/pi-tui";
 import type { CtxLike } from "../../lib/pi-like";
@@ -204,7 +205,8 @@ const issueIcon = (issue: BitIssueSummary): string => {
   return "○";
 };
 
-export class ChildRunsBrowserComponent implements ComponentLike {
+export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
+  focused = false;
   private selection: BrowserSelection | undefined;
   private pendingPreference: BrowserSelection["kind"] | undefined;
   private selectedIndexHint = 0;
@@ -447,7 +449,7 @@ export class ChildRunsBrowserComponent implements ComponentLike {
           };
           rendered.push({
             selection,
-            text: `${this.isSelected(selection) ? ">" : " "} ${statusIcon(run.status)} ${stage} ${run.agent} — ${taskOneLine(run.task)}`,
+            text: `${this.isCursorVisible(selection) ? ">" : " "} ${statusIcon(run.status)} ${stage} ${run.agent} — ${taskOneLine(run.task)}`,
           });
         }
       }
@@ -458,7 +460,7 @@ export class ChildRunsBrowserComponent implements ComponentLike {
         const selection: BrowserSelection = { kind: "issue", id: issue.id };
         rendered.push({
           selection,
-          text: `${this.isSelected(selection) ? ">" : " "} ${issueIcon(issue)} #${issue.id.slice(0, 8)} ${taskOneLine(issue.title)}`,
+          text: `${this.isCursorVisible(selection) ? ">" : " "} ${issueIcon(issue)} #${issue.id.slice(0, 8)} ${taskOneLine(issue.title)}`,
         });
       }
       if (issueSnapshot?.truncated === true) {
@@ -496,8 +498,9 @@ export class ChildRunsBrowserComponent implements ComponentLike {
       .map((item) => line(item.text, width));
   }
 
-  private isSelected(selection: BrowserSelection): boolean {
+  private isCursorVisible(selection: BrowserSelection): boolean {
     return (
+      this.focused &&
       this.selection !== undefined &&
       selectionToken(this.selection) === selectionToken(selection)
     );

--- a/tests/pi-harness/child-run-integration.test.ts
+++ b/tests/pi-harness/child-run-integration.test.ts
@@ -39,6 +39,7 @@ const makeConfig = (home: string): HarnessConfig => ({
 });
 
 interface RuntimeComponent {
+  focused?: boolean;
   render(width: number): string[];
   invalidate(): void;
   handleInput?(data: string): void;
@@ -76,8 +77,11 @@ const createRuntime = (cwd: string, options: { background?: boolean } = {}) => {
     getCursor(): { line: number; col: number };
     isShowingAutocomplete(): boolean;
   } = {
+    focused: true,
     keybindings,
-    render: () => ["editor"],
+    render() {
+      return [this.focused ? "editor cursor" : "editor"];
+    },
     invalidate() {},
     getText: () => editorLines.join("\n"),
     getCursor: () => ({ ...editorCursor }),
@@ -100,7 +104,17 @@ const createRuntime = (cwd: string, options: { background?: boolean } = {}) => {
     requestRender: () => {},
     focusedComponent: editor as RuntimeComponent | null,
     setFocus(next: RuntimeComponent | null) {
+      if (
+        this.focusedComponent !== null &&
+        this.focusedComponent !== undefined &&
+        "focused" in this.focusedComponent
+      ) {
+        this.focusedComponent.focused = false;
+      }
       this.focusedComponent = next;
+      if (next !== null && next !== undefined && "focused" in next) {
+        next.focused = true;
+      }
     },
   };
   let widgetCalls = 0;
@@ -1676,13 +1690,25 @@ describe("child-run subagent integration", () => {
     expect(panel.getSelectedRunId()).toBe(selectedRunId);
   });
 
-  test("Down transfers focus only after native editor navigation reaches its bottom boundary", () => {
+  test("Down and Escape move the visible cursor between input and browser", () => {
     const home = "/tmp/pi-child-down-focus";
     const runtime = createRuntime(home);
     const childRuns = setupChildRuns(runtime.pi);
+    childRuns.registry.beginInvocation({
+      toolCallId: "cursor-parent",
+      source: "subagent",
+      mode: "single",
+      label: "subagent",
+      runs: [{ agent: "worker", task: "inspect", taskIndex: 0 }],
+    });
     childRuns.ensureVisible(runtime.ctx);
     const panel = runtime.getComponent();
     if (panel === undefined) throw new Error("child-run panel did not mount");
+
+    expect(runtime.editor.focused).toBe(true);
+    expect(runtime.editor.render(80)).toEqual(["editor cursor"]);
+    expect(panel.focused).toBe(false);
+    expect(panel.render(80).some((line) => line.startsWith("> "))).toBe(false);
 
     runtime.setEditorState(["first", "second"], 0, 0);
     runtime.dispatchInput("down");
@@ -1695,9 +1721,17 @@ describe("child-run subagent integration", () => {
 
     runtime.dispatchInput("down");
     expect(runtime.tui.focusedComponent).toBe(panel);
+    expect(runtime.editor.focused).toBe(false);
+    expect(runtime.editor.render(80)).toEqual(["editor"]);
+    expect(panel.focused).toBe(true);
+    expect(panel.render(80).some((line) => line.startsWith("> "))).toBe(true);
 
     panel.handleInput?.("\u001b");
     expect(runtime.tui.focusedComponent).toBe(runtime.editor);
+    expect(runtime.editor.focused).toBe(true);
+    expect(runtime.editor.render(80)).toEqual(["editor cursor"]);
+    expect(panel.focused).toBe(false);
+    expect(panel.render(80).some((line) => line.startsWith("> "))).toBe(false);
   });
 
   test("custom editors without cursor capability retain native Down handling", () => {

--- a/tests/pi-harness/child-run-ui.test.ts
+++ b/tests/pi-harness/child-run-ui.test.ts
@@ -192,6 +192,25 @@ describe("child-session browser component", () => {
     }
   });
 
+  test("shows the selection cursor only while the browser is focused", () => {
+    const { registry, component } = setup();
+    addRuns(registry, 1);
+
+    expect(component.render(80).some((item) => item.startsWith("> "))).toBe(
+      false,
+    );
+
+    component.focused = true;
+    expect(component.render(80).some((item) => item.startsWith("> "))).toBe(
+      true,
+    );
+
+    component.focused = false;
+    expect(component.render(80).some((item) => item.startsWith("> "))).toBe(
+      false,
+    );
+  });
+
   test("routes raw Enter to the selected run", () => {
     const { registry, component, inspected } = setup();
     const runIds = addRuns(registry, 2);


### PR DESCRIPTION
## Summary

- track focus on the coordination browser through the TUI Focusable contract
- render the child-session selection cursor only while the browser owns focus
- verify that Down transfers the visible cursor to the browser and Escape restores it to the input editor

## Verification

- `bun test tests/pi-harness/child-run-ui.test.ts tests/pi-harness/child-run-integration.test.ts` (52 passed)
- `bun run tsc`
- `bun run lint` (0 errors; existing warnings only)
- `bun test` (1532 passed, 2 skipped)