### PR TITLE
fix(pi): improve coordination browser readability

### DIFF
--- a/pi/extensions/pi-harness/features/child-runs/README.md
+++ b/pi/extensions/pi-harness/features/child-runs/README.md
@@ -16,7 +16,9 @@ uses one `belowEditor` widget and one focus owner for both sources.
   stealing editor focus. Closed issues are never listed.
 - The header reports `Child sessions: N | Open bit issues: M`. One scrollable
   list places child rows first when present, followed by issue rows sorted by
-  `updated_at` descending and stable issue id.
+  `updated_at` descending and stable issue id. Child status icons use the
+  active theme's semantic status colors (`success`, `error`, and the existing
+  warning/dim mappings), and overlong rows end with a width-safe ellipsis.
 - The browser receives the full terminal content width and remains in normal
   layout flow, so it does not cover chat or editor content.
 - Its height is approximately one quarter of the terminal, clamped to 4–10
@@ -45,10 +47,12 @@ uses one `belowEditor` widget and one focus owner for both sources.
 - In the resident list, Up/Down, `j`/`k`, and PageUp/PageDown select across both
   row kinds. Enter or Right opens the selected child or issue. `r` refreshes
   open issues without polling or relay-backed watch behavior.
-- Child and issue details use the same focused near-full-screen overlay.
-  PageUp/PageDown move by a viewport, Home/End jump to the ends, and Escape,
-  Left, `b`, or `q` closes the overlay and returns to the list. Child details
-  retain live-follow behavior.
+- Child and issue details use the same focused, zero-margin full-terminal
+  overlay, covering the resident panes in both dimensions. PageUp/PageDown move
+  by a viewport, Home/End jump to the ends, and Escape, Left, `b`, or `q` closes
+  the overlay and returns to the list. Child details retain live-follow
+  behavior. Transcript text, issue bodies, and comments use the theme's primary
+  `text` color rather than the secondary tool-output color.
 - Issue detail is loaded lazily with `bit issue get <id> --format json`, then
   bounded raw output from `bit issue comment list <id>`. It shows metadata,
   labels, body, and comments read-only. Human-readable comment output is not
@@ -152,8 +156,8 @@ raw source data.
    statusline without taking editor focus.
 3. In a multi-line draft, press Down and confirm native cursor movement still
    works; at the bottom boundary, press Down again and confirm list focus.
-4. Select a running child, press Enter, and confirm its near-full-screen detail
-   overlay opens with live updates.
+4. Select a running child, press Enter, and confirm its full-terminal detail
+   overlay covers the panes behind it and opens with live updates.
 5. Press Up/PageUp and confirm the transcript scrolls while the selected run
    remains fixed; press End and confirm live-follow resumes.
 6. Press Escape and confirm focus returns to the resident list, then Escape

--- a/pi/extensions/pi-harness/features/child-runs/ui.ts
+++ b/pi/extensions/pi-harness/features/child-runs/ui.ts
@@ -127,11 +127,11 @@ const resolveTheme = (value: unknown): ChildRunTheme => {
 
 const safeBlock = (value: string): string => stripTerminalControls(value);
 
-const styledLine = (value: string, width: number): string => {
+const styledLine = (value: string, width: number, suffix = ""): string => {
   const safeWidth = Math.max(1, width);
   return value.includes("\u001b")
-    ? truncateStyledToWidth(value, safeWidth, "")
-    : truncateToWidth(value, safeWidth, "");
+    ? truncateStyledToWidth(value, safeWidth, suffix)
+    : truncateToWidth(value, safeWidth, suffix);
 };
 
 const statusColors: Record<ChildRunStatus, ThemeColor> = {
@@ -156,7 +156,7 @@ const transcriptComponent = (
       new Text(theme.fg("accent", theme.bold("assistant")), 0, 0),
     );
     const body = new Box(1, 0);
-    body.addChild(new Text(theme.fg("toolOutput", safeBlock(item.text)), 0, 0));
+    body.addChild(new Text(theme.fg("text", safeBlock(item.text)), 0, 0));
     assistant.addChild(body);
     return assistant;
   }
@@ -207,6 +207,7 @@ const issueIcon = (issue: BitIssueSummary): string => {
 
 export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
   focused = false;
+  private readonly theme: ChildRunTheme;
   private selection: BrowserSelection | undefined;
   private pendingPreference: BrowserSelection["kind"] | undefined;
   private selectedIndexHint = 0;
@@ -222,7 +223,9 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
     private readonly onUnfocus: () => void,
     private readonly onHide: () => void,
     private readonly bitIssues?: BitIssueBrowserBindings,
+    theme?: unknown,
   ) {
+    this.theme = resolveTheme(theme);
     this.unsubscribeChild = registry.subscribe(() => this.requestRender());
     this.unsubscribeIssues = bitIssues?.registry.subscribe(() =>
       this.requestRender(),
@@ -447,9 +450,13 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
             kind: "child",
             id: run.runId,
           };
+          const icon = this.theme.fg(
+            statusColor(run.status),
+            statusIcon(run.status),
+          );
           rendered.push({
             selection,
-            text: `${this.isCursorVisible(selection) ? ">" : " "} ${statusIcon(run.status)} ${stage} ${run.agent} — ${taskOneLine(run.task)}`,
+            text: `${this.isCursorVisible(selection) ? ">" : " "} ${icon} ${stage} ${run.agent} — ${taskOneLine(run.task)}`,
           });
         }
       }
@@ -495,7 +502,7 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
     }
     return rendered
       .slice(this.listOffset, this.listOffset + viewport)
-      .map((item) => line(item.text, width));
+      .map((item) => styledLine(item.text, width, "…"));
   }
 
   private isCursorVisible(selection: BrowserSelection): boolean {
@@ -583,9 +590,7 @@ const detailContentLines = (
       new Text(theme.fg("warning", theme.bold("assistant LIVE")), 0, 0),
     );
     const draft = new Box(1, 0);
-    draft.addChild(
-      new Text(theme.fg("toolOutput", safeBlock(run.liveDraft)), 0, 0),
-    );
+    draft.addChild(new Text(theme.fg("text", safeBlock(run.liveDraft)), 0, 0));
     transcript.addChild(draft);
   }
   if (run.transcript.length === 0 && !run.liveDraft) {
@@ -644,11 +649,9 @@ export class ChildRunDetailComponent implements ComponentLike {
 
   render(width: number): string[] {
     const safeWidth = Math.max(1, width);
-    // The overlay uses a one-cell margin on each side, so rows - 2 fills the
-    // available height without competing with the resident editor-flow panel.
-    // On tiny terminals, drop the hint and then the title before reducing the
-    // transcript to zero visible rows.
-    const height = Math.max(1, this.tui.terminal.rows - 2);
+    // The zero-margin overlay owns the full terminal. On tiny terminals, drop
+    // the hint and then the title before reducing the transcript to zero rows.
+    const height = Math.max(1, this.tui.terminal.rows);
     const showTitle = height >= 2;
     const showHint = height >= 3;
     const chrome = Number(showTitle) + Number(showHint);
@@ -833,7 +836,7 @@ const issueDetailContentLines = (
   body.addChild(
     new Text(
       theme.fg(
-        "toolOutput",
+        "text",
         wrapPlainText(
           issue.body === "" ? "(empty body)" : safeBlock(issue.body),
           Math.max(1, width - 2),
@@ -863,7 +866,7 @@ const issueDetailContentLines = (
     commentBox.addChild(
       new Text(
         theme.fg(
-          comments.truncated ? "warning" : "toolOutput",
+          comments.truncated ? "warning" : "text",
           wrapPlainText(safeBlock(comments.text), Math.max(1, width - 2)).join(
             "\n",
           ),
@@ -899,7 +902,7 @@ export class BitIssueDetailComponent implements ComponentLike {
 
   render(width: number): string[] {
     const safeWidth = Math.max(1, width);
-    const height = Math.max(1, this.tui.terminal.rows - 2);
+    const height = Math.max(1, this.tui.terminal.rows);
     const showTitle = height >= 2;
     const showHint = height >= 3;
     const chrome = Number(showTitle) + Number(showHint);
@@ -1201,7 +1204,7 @@ export class ChildRunsPanelController {
     try {
       ui.setWidget(
         CHILD_RUNS_WIDGET_KEY,
-        (tui) => {
+        (tui, theme) => {
           this.tui = tui;
           this.captureCurrentFocus();
           const component = new ChildRunsBrowserComponent(
@@ -1212,6 +1215,7 @@ export class ChildRunsPanelController {
             () => this.restoreFocus(),
             () => this.hide(),
             this.bitIssueBindings(),
+            theme,
           );
           if (preferred !== undefined) component.prefer(preferred);
           this.component = component;
@@ -1256,7 +1260,7 @@ export class ChildRunsPanelController {
     let fallbackPromise: Promise<void>;
     try {
       fallbackPromise = ui.custom<void>(
-        (tui, _theme, keybindings, done) => {
+        (tui, theme, keybindings, done) => {
           let closed = false;
           const close = () => {
             if (closed) return;
@@ -1275,6 +1279,7 @@ export class ChildRunsPanelController {
               close();
             },
             this.bitIssueBindings(),
+            theme,
           );
           if (preferred !== undefined) component.prefer(preferred);
           if (refreshOnFocus) void this.options.refreshBitIssues?.();
@@ -1286,7 +1291,7 @@ export class ChildRunsPanelController {
             width: "100%",
             maxHeight: "100%",
             anchor: "center",
-            margin: 1,
+            margin: 0,
           },
         },
       );
@@ -1350,7 +1355,7 @@ export class ChildRunsPanelController {
             width: "100%",
             maxHeight: "100%",
             anchor: "center",
-            margin: 1,
+            margin: 0,
           },
         },
       );
@@ -1419,7 +1424,7 @@ export class ChildRunsPanelController {
             width: "100%",
             maxHeight: "100%",
             anchor: "center",
-            margin: 1,
+            margin: 0,
           },
         },
       );

--- a/tests/pi-harness/child-run-integration.test.ts
+++ b/tests/pi-harness/child-run-integration.test.ts
@@ -1689,7 +1689,7 @@ describe("child-run subagent integration", () => {
     expect(runtime.getCustomCalls()).toBe(1);
     expect(runtime.getCustomOptions()).toMatchObject({
       overlay: true,
-      overlayOptions: { width: "100%", maxHeight: "100%", margin: 1 },
+      overlayOptions: { width: "100%", maxHeight: "100%", margin: 0 },
     });
     expect(runtime.tui.focusedComponent).toBe(detail);
     expect(detail.render(80)[0]).toContain("LIVE");

--- a/tests/pi-harness/child-run-ui.test.ts
+++ b/tests/pi-harness/child-run-ui.test.ts
@@ -83,7 +83,27 @@ describe("child-session private focus capability", () => {
   });
 });
 
-const setup = (rows = 20) => {
+const semanticFgCodes: Readonly<Record<string, number>> = {
+  success: 32,
+  error: 31,
+  text: 37,
+  toolOutput: 90,
+};
+
+const semanticTheme = {
+  fg(color: string, text: string) {
+    const code = semanticFgCodes[color] ?? 36;
+    return `\u001b[${code}m${text}\u001b[39m`;
+  },
+  bg(_color: string, text: string) {
+    return `\u001b[48;5;236m${text}\u001b[49m`;
+  },
+  bold(text: string) {
+    return `\u001b[1m${text}\u001b[22m`;
+  },
+};
+
+const setup = (rows = 20, theme?: unknown) => {
   let id = 0;
   const registry = new ChildRunRegistry({
     idFactory: () => `id-${++id}`,
@@ -121,6 +141,8 @@ const setup = (rows = 20) => {
     (runId) => inspected.push(runId),
     () => unfocused++,
     () => hidden++,
+    undefined,
+    theme,
   );
   return {
     registry,
@@ -245,6 +267,51 @@ describe("child-session browser component", () => {
     expect(component.getSelectedRunId()).toBe(started.runIds[1]);
   });
 
+  test("themes status icons and ellipsizes overlong run titles", () => {
+    const { registry, component } = setup(20, semanticTheme);
+    const { runIds } = registry.beginInvocation({
+      toolCallId: "themed-browser",
+      source: "workflow",
+      label: "workflow",
+      runs: [
+        {
+          agent: "successful-reviewer",
+          task: `successful ${"title ".repeat(20)}SUCCESS-END`,
+          taskIndex: 0,
+          stageIndex: 0,
+        },
+        {
+          agent: "failed-reviewer",
+          task: `failed ${"title ".repeat(20)}FAIL-END`,
+          taskIndex: 1,
+          stageIndex: 0,
+        },
+      ],
+    });
+    registry.finishRun(runAt(runIds, 0), {
+      status: "succeeded",
+      reason: "completed",
+      endedAt: 101,
+    });
+    registry.finishRun(runAt(runIds, 1), {
+      status: "failed",
+      reason: "model-error",
+      endedAt: 102,
+    });
+
+    const lines = component.render(32);
+    const rendered = lines.join("\n");
+    const plain = lines.map((item) => stripTerminalControls(item));
+    const runRows = plain.filter((item) => item.includes("reviewer"));
+    expect(rendered).toContain("\u001b[32m✓\u001b[39m");
+    expect(rendered).toContain("\u001b[31m✗\u001b[39m");
+    expect(runRows).toHaveLength(2);
+    expect(runRows.every((item) => item.endsWith("…"))).toBe(true);
+    expect(plain.every((item) => visibleWidth(item) <= 32)).toBe(true);
+    expect(rendered).not.toContain("SUCCESS-END");
+    expect(rendered).not.toContain("FAIL-END");
+  });
+
   test("Escape unfocuses and q hides without changing run state", () => {
     const { registry, component, getUnfocused, getHidden } = setup();
     const { runIds } = registry.beginInvocation({
@@ -301,24 +368,13 @@ describe("child-session detail component", () => {
       at: 4,
     });
 
-    const theme = {
-      fg(_color: string, text: string) {
-        return `\u001b[36m${text}\u001b[39m`;
-      },
-      bg(_color: string, text: string) {
-        return `\u001b[48;5;236m${text}\u001b[49m`;
-      },
-      bold(text: string) {
-        return `\u001b[1m${text}\u001b[22m`;
-      },
-    };
     const detail = new ChildRunDetailComponent(
       registry,
       runId,
       tui,
       keybindings,
       () => {},
-      theme,
+      semanticTheme,
     );
 
     const lines = detail.render(64);
@@ -332,10 +388,13 @@ describe("child-session detail component", () => {
     expect(rendered).toContain("Transcript");
     expect(rendered).toContain("✗ tool-1 read (failed)");
     expect(rendered).toContain("Found one actionable issue.");
+    expect(lines.join("\n")).toContain(
+      "\u001b[37mFound one actionable issue.\u001b[39m",
+    );
     expect(lines.every((item) => visibleWidth(item) <= 64)).toBe(true);
   });
 
-  test("uses the near-full terminal height and starts completed output at the top", () => {
+  test("uses the full terminal height and starts completed output at the top", () => {
     const { registry, tui, keybindings } = setup(24);
     const [runId] = addRuns(registry, 1);
     if (runId === undefined) throw new Error("run did not initialize");
@@ -354,7 +413,7 @@ describe("child-session detail component", () => {
     );
 
     const lines = detail.render(80);
-    expect(lines).toHaveLength(22);
+    expect(lines).toHaveLength(24);
     expect(lines[0]).toContain("Child session");
     expect(lines[1]).toContain("agent-0");
     expect(lines.at(-1)).toContain("Home/End");
@@ -382,8 +441,8 @@ describe("child-session detail component", () => {
 
   test("keeps the last transcript line reachable on tiny terminals", () => {
     for (const [rows, expectedHeight] of [
-      [4, 2],
-      [3, 1],
+      [4, 4],
+      [3, 3],
     ] as const) {
       const { registry, tui, keybindings } = setup(rows);
       const [runId] = addRuns(registry, 1);
@@ -750,12 +809,14 @@ describe("bit issue detail component", () => {
       tui,
       keybindings,
       () => {},
+      semanticTheme,
     );
     expect(detail.render(32).join("\n")).toContain("Loading bit issue");
 
     await registry.loadDetail("issue-a");
     const lines = detail.render(32);
     expect(lines.join("\n")).toContain("Body");
+    expect(lines.join("\n")).toContain("\u001b[37mBody for issue-a");
     expect(lines.join("\n")).toContain("Comments");
     expect(lines.join("\n")).not.toContain("spoof");
     expect(lines.every((item) => visibleWidth(item) <= 32)).toBe(true);
@@ -767,8 +828,8 @@ describe("bit issue detail component", () => {
 
   test("keeps the final comment state reachable on tiny terminals", async () => {
     for (const [rows, expectedHeight] of [
-      [4, 2],
-      [3, 1],
+      [4, 4],
+      [3, 3],
     ] as const) {
       const { tui, keybindings } = setup(rows);
       const source: BitIssueDataSource = {


### PR DESCRIPTION
## Summary

- apply semantic theme colors to child-session status icons and ellipsize overlong rows
- make child and bit-issue detail overlays cover the full terminal without margins
- render transcripts, issue bodies, and comments with the primary text color
- document the behavior and add focused UI/integration regressions

## Testing

- `bun test` (1542 passed, 2 gated skips)
- `bun run tsc`
- `bun run lint` (passes with 9 unrelated existing warnings)
- `git diff --check`