### PR TITLE
feat(pi): add autonomous execution guidance

### DIFF
--- a/dotfiles.config.ts
+++ b/dotfiles.config.ts
@@ -146,6 +146,13 @@ export default defineConfig({
       include: sharedAgentSkills,
     },
     {
+      // Pi appends this file to its built-in system prompt. Publish only the
+      // child file so machine-local auth, settings, and sessions stay intact.
+      source: "./pi/APPEND_SYSTEM.md",
+      target: "~/.pi/agent/APPEND_SYSTEM.md",
+      type: "file",
+    },
+    {
       // pi auto-discovers ~/.pi/agent/extensions/*/index.ts. Only child
       // directories are linked — ~/.pi/agent itself stays machine-local
       // (auth.json, settings.json, sessions are rewritten by pi at runtime).

--- a/pi/APPEND_SYSTEM.md
+++ b/pi/APPEND_SYSTEM.md
@@ -1,0 +1,7 @@
+# Execution and reporting policy
+
+- Assume the user is not monitoring live task progress. Do not pause to ask the user for decisions that can be made from available evidence. Use available workflows and subagents autonomously to investigate, decide, execute, and verify.
+- Before ending a turn, inspect the final paragraph you are about to send. If it merely promises an action that remains unperformed, perform that action now and report the result instead of deferring it.
+- Stop and ask the user only when progress depends on information, authorization, or a decision that only the user can provide. Otherwise, diagnose failures and retry, changing the approach when needed.
+- Work outcome-first. Prefer readable, well-structured communication over terseness. In the final response, account for every completed deliverable and verification result, and state any unresolved blocker or limitation.
+- Treat these instructions as controlling whenever they do not conflict with higher-priority platform, system, developer, safety, or permission constraints. They override conflicting lower-priority guidance, not higher-priority instructions.

--- a/pi/README.md
+++ b/pi/README.md
@@ -13,6 +13,7 @@ child-process behavior): `tests/fixtures/pi-harness/raw/`.
 
 | Repo path                         | Deployed to                                | Mechanism                                     |
 | --------------------------------- | ------------------------------------------ | --------------------------------------------- |
+| `pi/APPEND_SYSTEM.md`             | `~/.pi/agent/APPEND_SYSTEM.md`             | dotfiles file symlink                         |
 | `pi/extensions/pi-harness`        | `~/.pi/agent/extensions/pi-harness`        | dotfiles directory symlink                    |
 | `pi/extensions/hearth-tools`      | `~/.pi/agent/extensions/hearth-tools`      | dotfiles directory symlink                    |
 | `pi/extensions/codex-web`         | `~/.pi/agent/extensions/codex-web`         | dotfiles directory symlink                    |

--- a/tests/config/pi-system-prompt.test.ts
+++ b/tests/config/pi-system-prompt.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import config from "../../dotfiles.config";
+
+const PROMPT_PATH = resolve(import.meta.dir, "../../pi/APPEND_SYSTEM.md");
+
+describe("global pi appended system prompt", () => {
+  test("is deployed as a child file without replacing the agent directory", () => {
+    expect(config.mappings).toContainEqual({
+      source: "./pi/APPEND_SYSTEM.md",
+      target: "~/.pi/agent/APPEND_SYSTEM.md",
+      type: "file",
+    });
+  });
+
+  test("requires autonomous execution, retry, and complete reporting", async () => {
+    const prompt = await readFile(PROMPT_PATH, "utf8");
+
+    expect(prompt).toContain("the user is not monitoring live task progress");
+    expect(prompt).toContain(
+      "Use available workflows and subagents autonomously",
+    );
+    expect(prompt).toContain("perform that action now");
+    expect(prompt).toContain(
+      "Stop and ask the user only when progress depends",
+    );
+    expect(prompt).toContain("diagnose failures and retry");
+    expect(prompt).toContain("Work outcome-first");
+    expect(prompt).toContain("Prefer readable, well-structured communication");
+    expect(prompt).toContain(
+      "every completed deliverable and verification result",
+    );
+  });
+
+  test("preserves the actual prompt hierarchy", async () => {
+    const prompt = await readFile(PROMPT_PATH, "utf8");
+
+    expect(prompt).toContain("higher-priority platform, system, developer");
+    expect(prompt).toContain(
+      "They override conflicting lower-priority guidance, not higher-priority instructions.",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- append global Pi guidance for autonomous workflow and subagent use, immediate follow-through, retries, and outcome-first reporting
- deploy only `APPEND_SYSTEM.md` so machine-local Pi authentication, settings, and sessions remain intact
- preserve the real prompt hierarchy by overriding only lower-priority guidance
- document and test the global prompt mapping and required behaviors

## Validation

- `bun test tests/config/pi-system-prompt.test.ts tests/config/mappings-integrity.test.ts` — 5 passed
- `bun run lint` — 0 errors; 9 pre-existing warnings
- `bun run tsc` — passed
- `bun run src/index.ts install -d` — expected `~/.pi/agent/APPEND_SYSTEM.md` link confirmed
- full `bun test` outside the effect sandbox — 1574 passed, 2 skipped, 1 unrelated pre-existing Pi theme color assertion failed