### PR TITLE
feat(pi): allow GitHub network in Bash sandbox

### DIFF
--- a/pi/README.md
+++ b/pi/README.md
@@ -104,14 +104,17 @@ failures block ordinary Bash; there is no unsandboxed fallback.
 The default writable scope is the active verified worktree, its canonical Git
 common directory, and session scratch. The common directory's Git config and
 hooks remain explicitly denied even for linked worktrees. Credential stores are
-denied for reads; harness settings/hooks and agent configuration are denied for writes. Network
-is deny-by-default: an empty `allowedDomains` list means no network. An unknown
-host can be approved or denied once for the current interactive session and is
-denied without UI. `/sandbox` shows the active mode, write-root count, network
-mode, and a short profile fingerprint without exposing private paths.
+denied for reads; harness settings/hooks and agent configuration are denied for
+writes. Network is allowlist-only. The checked-in global profile permits
+`api.github.com` and `github.com`; this applies to every ordinary sandboxed
+command, not only `gh`. Any other host can be approved or denied once for the
+current interactive session and is denied without UI. `/sandbox` shows the
+active mode, write-root count, network mode, and a short profile fingerprint
+without exposing private paths.
 
 Only the machine-local `~/.pi/agent/pi-harness.local.json` can add trusted
-paths or domains; repository configuration cannot widen this boundary:
+paths or additional domains; repository configuration cannot otherwise widen
+this boundary:
 
 ```json
 {

--- a/pi/extensions/pi-harness/config.ts
+++ b/pi/extensions/pi-harness/config.ts
@@ -77,7 +77,10 @@ export interface BashSandboxConfig {
 }
 
 export const DEFAULT_BASH_SANDBOX_CONFIG: Readonly<BashSandboxConfig> = {
-  network: { allowedDomains: [], deniedDomains: [] },
+  network: {
+    allowedDomains: ["api.github.com", "github.com"],
+    deniedDomains: [],
+  },
   filesystem: {
     denyRead: [
       "~/.ssh",

--- a/tests/pi-harness/bash-sandbox-config.test.ts
+++ b/tests/pi-harness/bash-sandbox-config.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test";
+import { loadConfig } from "../../pi/extensions/pi-harness/config";
+import { resolvePaths } from "../../pi/extensions/pi-harness/lib/paths";
+import {
+  cleanupTestDirectory,
+  createTestFile,
+  setupTestDirectory,
+} from "../test-helpers";
+
+test("ships the GitHub network allowlist as a global default", async () => {
+  const home = await setupTestDirectory("pi-bash-sandbox-config");
+  const paths = resolvePaths(home);
+
+  try {
+    expect(loadConfig({}, paths).bashSandbox?.network.allowedDomains).toEqual([
+      "api.github.com",
+      "github.com",
+    ]);
+
+    await createTestFile(
+      paths.localConfigFile,
+      JSON.stringify({
+        bashSandbox: {
+          network: { allowedDomains: ["uploads.github.com"] },
+        },
+      }),
+    );
+
+    expect(loadConfig({}, paths).bashSandbox?.network.allowedDomains).toEqual([
+      "api.github.com",
+      "github.com",
+      "uploads.github.com",
+    ]);
+  } finally {
+    await cleanupTestDirectory(home);
+  }
+});

--- a/tests/pi-harness/permission-rules.test.ts
+++ b/tests/pi-harness/permission-rules.test.ts
@@ -1013,7 +1013,7 @@ describe("bash sandbox config", () => {
     try {
       const sandbox = loadConfig({}, paths, "darwin").bashSandbox;
       expect(sandbox?.network).toEqual({
-        allowedDomains: ["api.github.com"],
+        allowedDomains: ["api.github.com", "github.com"],
         deniedDomains: ["malicious.example"],
       });
       expect(sandbox?.filesystem.denyRead).toContain("~/.ssh");


### PR DESCRIPTION
## Summary

- allow `api.github.com` and `github.com` in the checked-in Bash sandbox defaults
- document that the global allowlist applies to every ordinary sandboxed command
- preserve additive machine-local domains and cover the behavior with regression tests

## Testing

- `bun test ./tests/pi-harness/bash-sandbox-config.test.ts ./tests/pi-harness/permission-rules.test.ts`
- `bun run lint` (passes with existing warnings)
- `bun run tsc`
- `bun test` (one unrelated existing failure: `tests/config/pi-theme.test.ts` expects the previous `userMsgBg` value)