### PR TITLE
feat(pi): manage live settings with a scrub filter

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,3 +14,9 @@ codex/config.toml filter=codex-scrub
 # `git add` time while the working tree keeps the live value. Driver is
 # registered per-checkout by scripts/setup-git-filters.sh.
 claude/.claude/settings.json filter=claude-scrub
+
+# pi/settings.json is also a live settings file. Pi writes runtime state into
+# it, while users may add machine-local paths, proxy credentials, or account
+# identifiers. The required pi-scrub clean filter removes those values from the
+# staged blob without changing the working-tree file.
+pi/settings.json filter=pi-scrub

--- a/dotfiles.config.ts
+++ b/dotfiles.config.ts
@@ -138,8 +138,7 @@ export default defineConfig({
       // Codex discovers personal skills under ~/.agents/skills and follows
       // symlinked skill directories. Reuse the Claude skill source so both
       // harnesses stay in sync without replacing Codex's bundled skills.
-      // pi also auto-discovers this path (verified on 0.80.6), so the same
-      // link serves three harnesses.
+      // Pi excludes this shared location and uses its dedicated skills below.
       source: "./claude/.claude/skills",
       target: "~/.agents/skills",
       type: "selective",
@@ -147,9 +146,17 @@ export default defineConfig({
     },
     {
       // Pi appends this file to its built-in system prompt. Publish only the
-      // child file so machine-local auth, settings, and sessions stay intact.
+      // child file so machine-local auth and sessions stay intact.
       source: "./pi/APPEND_SYSTEM.md",
       target: "~/.pi/agent/APPEND_SYSTEM.md",
+      type: "file",
+    },
+    {
+      // Pi rewrites this live file at runtime. The pi-scrub Git clean filter
+      // removes machine/account-local values from staged content while the
+      // working tree retains the complete settings file.
+      source: "./pi/settings.json",
+      target: "~/.pi/agent/settings.json",
       type: "file",
     },
     {

--- a/pi/scrub-settings.ts
+++ b/pi/scrub-settings.ts
@@ -1,0 +1,88 @@
+#!/usr/bin/env bun
+/**
+ * Git clean filter for the live, symlinked Pi settings file.
+ *
+ * Pi rewrites settings.json at runtime. Keep the working-tree file complete,
+ * but omit machine/account-local state and credential-bearing values from the
+ * blob staged by Git. The required filter fails closed on malformed input.
+ */
+const input = await Bun.stdin.text();
+
+let parsed: unknown;
+try {
+  parsed = JSON.parse(input);
+} catch (error) {
+  console.error(
+    `pi-scrub: settings.json is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+  );
+  process.exit(1);
+}
+
+if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+  console.error("pi-scrub: settings.json must be a JSON object");
+  process.exit(1);
+}
+
+const OMIT = Symbol("omit");
+const OMIT_TOP_LEVEL = new Set([
+  "httpProxy",
+  "lastChangelogVersion",
+  "trackingId",
+]);
+const PORTABLE_ABSOLUTE_VALUES = new Set([
+  "!/Users/ushironoko/.agents/skills/**",
+]);
+const CREDENTIAL_URL = /\b[a-z][a-z0-9+.-]*:\/\/[^\s/:@]+:[^\s/@]+@/i;
+const ABSOLUTE_PATH = /(^|[\s"'(=><])!?\/(?!\/)/;
+const SENSITIVE_KEY_SUFFIXES = [
+  "apikey",
+  "authorization",
+  "credential",
+  "password",
+  "secret",
+  "token",
+];
+
+const hasSensitiveKey = (key: string): boolean => {
+  const normalized = key.replaceAll(/[^a-z0-9]/gi, "").toLowerCase();
+  return SENSITIVE_KEY_SUFFIXES.some((suffix) => normalized.endsWith(suffix));
+};
+
+const hasSensitiveString = (value: string): boolean => {
+  if (PORTABLE_ABSOLUTE_VALUES.has(value)) return false;
+  if (CREDENTIAL_URL.test(value)) return true;
+  return value.startsWith("file:/") || ABSOLUTE_PATH.test(value);
+};
+
+const scrub = (value: unknown): unknown | typeof OMIT => {
+  if (typeof value === "string") {
+    return hasSensitiveString(value) ? OMIT : value;
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => {
+      const scrubbed = scrub(item);
+      return scrubbed === OMIT ? [] : [scrubbed];
+    });
+  }
+  if (value !== null && typeof value === "object") {
+    const scrubbed: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(value)) {
+      if (hasSensitiveKey(key)) continue;
+      const scrubbedChild = scrub(child);
+      if (scrubbedChild !== OMIT) scrubbed[key] = scrubbedChild;
+    }
+    return scrubbed;
+  }
+  return value;
+};
+
+const portable: Record<string, unknown> = {};
+for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+  if (OMIT_TOP_LEVEL.has(key) || hasSensitiveKey(key)) continue;
+  const scrubbed = scrub(value);
+  if (scrubbed !== OMIT) portable[key] = scrubbed;
+}
+
+process.stdout.write(`${JSON.stringify(portable, null, 2)}\n`);
+
+export {};

--- a/pi/settings.json
+++ b/pi/settings.json
@@ -1,0 +1,10 @@
+{
+  "theme": "transparent-dark",
+  "defaultProvider": "openai-codex",
+  "defaultModel": "gpt-5.6-sol",
+  "defaultThinkingLevel": "xhigh",
+  "hideThinkingBlock": false,
+  "skills": [
+    "!/Users/ushironoko/.agents/skills/**"
+  ]
+}

--- a/scripts/setup-git-filters.sh
+++ b/scripts/setup-git-filters.sh
@@ -13,6 +13,8 @@
 #   claude-scrub : drop the machine/account-local top-level "remote" key that
 #                  Claude Code writes into claude/.claude/settings.json
 #                  (claude/scrub-settings.ts).
+#   pi-scrub     : drop machine/account-local fields, credentials, and unmanaged
+#                  absolute paths from pi/settings.json (pi/scrub-settings.ts).
 #   smudge       : identity (cat) — checkout writes the committed content verbatim.
 #   required     : true — if a scrubber ever errors, git fails the operation
 #                  loudly instead of silently staging unscrubbed content.
@@ -29,4 +31,8 @@ git config filter.claude-scrub.clean "bun claude/scrub-settings.ts"
 git config filter.claude-scrub.smudge "cat"
 git config filter.claude-scrub.required true
 
-echo "codex-scrub and claude-scrub git filters configured for $repo_root"
+git config filter.pi-scrub.clean "bun pi/scrub-settings.ts"
+git config filter.pi-scrub.smudge "cat"
+git config filter.pi-scrub.required true
+
+echo "codex-scrub, claude-scrub, and pi-scrub git filters configured for $repo_root"

--- a/tests/config/pi-settings.test.ts
+++ b/tests/config/pi-settings.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import config from "../../dotfiles.config";
+import settings from "../../pi/settings.json";
+
+const REPO_ROOT = resolve(import.meta.dir, "../..");
+const MANAGED_SKILL_EXCLUSION = "!/Users/ushironoko/.agents/skills/**";
+
+describe("Pi settings management", () => {
+  test("installs the complete tracked settings file as a child symlink", () => {
+    expect(
+      config.mappings.find(
+        (mapping) => mapping.target === "~/.pi/agent/settings.json",
+      ),
+    ).toEqual({
+      source: "./pi/settings.json",
+      target: "~/.pi/agent/settings.json",
+      type: "file",
+    });
+  });
+
+  test("excludes the shared Agent Skills location", () => {
+    expect(settings.skills).toContain(MANAGED_SKILL_EXCLUSION);
+  });
+
+  test("requires the Pi clean filter for the live settings file", async () => {
+    const [attributes, setup] = await Promise.all([
+      readFile(resolve(REPO_ROOT, ".gitattributes"), "utf8"),
+      readFile(resolve(REPO_ROOT, "scripts/setup-git-filters.sh"), "utf8"),
+    ]);
+
+    expect(attributes).toContain("pi/settings.json filter=pi-scrub");
+    expect(setup).toContain(
+      'git config filter.pi-scrub.clean "bun pi/scrub-settings.ts"',
+    );
+    expect(setup).toContain("git config filter.pi-scrub.required true");
+  });
+});

--- a/tests/pi/scrub-settings.test.ts
+++ b/tests/pi/scrub-settings.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+
+const SCRUBBER = resolve(import.meta.dir, "../../pi/scrub-settings.ts");
+const MANAGED_SKILL_EXCLUSION = "!/Users/ushironoko/.agents/skills/**";
+
+interface ScrubResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+const scrub = async (input: string): Promise<ScrubResult> => {
+  const proc = Bun.spawn(["bun", SCRUBBER], {
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  proc.stdin.write(input);
+  proc.stdin.end();
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, exitCode };
+};
+
+describe("Pi settings scrubber", () => {
+  test("keeps portable settings and the managed skill exclusion", async () => {
+    const input = `${JSON.stringify(
+      {
+        theme: "transparent-dark",
+        defaultProvider: "openai-codex",
+        skills: [MANAGED_SKILL_EXCLUSION, "relative-skill"],
+      },
+      null,
+      2,
+    )}\n`;
+
+    const result = await scrub(input);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe(input);
+  });
+
+  test("drops runtime state, credentials, and unmanaged absolute paths", async () => {
+    const input = `${JSON.stringify(
+      {
+        lastChangelogVersion: "0.80.7",
+        trackingId: "machine-account-id",
+        httpProxy: "https://user:password@proxy.example",
+        theme: "transparent-dark",
+        sessionDir: "/Users/example/private-client/sessions",
+        skills: [
+          MANAGED_SKILL_EXCLUSION,
+          "/Users/example/private-client/skills",
+          "relative-skill",
+        ],
+        provider: {
+          apiKey: "secret-api-key",
+          nested: {
+            accessToken: "secret-access-token",
+            transport: "sse",
+          },
+        },
+        endpoint: "https://user:password@example.test/api",
+      },
+      null,
+      2,
+    )}\n`;
+
+    const result = await scrub(input);
+    const parsed = JSON.parse(result.stdout);
+
+    expect(result.exitCode).toBe(0);
+    expect(parsed).toEqual({
+      theme: "transparent-dark",
+      skills: [MANAGED_SKILL_EXCLUSION, "relative-skill"],
+      provider: { nested: { transport: "sse" } },
+    });
+    expect(result.stdout).not.toContain("private-client");
+    expect(result.stdout).not.toContain("password");
+    expect(result.stdout).not.toContain("secret-api-key");
+  });
+
+  test("is idempotent after sensitive values are removed", async () => {
+    const input = `${JSON.stringify(
+      {
+        lastChangelogVersion: "0.80.7",
+        theme: "transparent-dark",
+        skills: [MANAGED_SKILL_EXCLUSION],
+      },
+      null,
+      2,
+    )}\n`;
+
+    const first = await scrub(input);
+    const second = await scrub(first.stdout);
+
+    expect(first.exitCode).toBe(0);
+    expect(second.exitCode).toBe(0);
+    expect(second.stdout).toBe(first.stdout);
+  });
+
+  test("fails loudly on invalid JSON", async () => {
+    const result = await scrub("{ not json");
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("not valid JSON");
+  });
+
+  test("fails loudly on a non-object top level", async () => {
+    const result = await scrub('["array"]');
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("must be a JSON object");
+  });
+});


### PR DESCRIPTION
## Summary

- manage the complete live Pi settings file as a child symlink
- exclude the shared `~/.agents/skills` location so Pi uses its dedicated skills
- add a required Git clean filter that removes runtime, credential-bearing, and unmanaged absolute-path values from staged content
- cover the mapping, filter registration, sensitive-value scrubbing, and fail-closed parsing behavior

## Verification

- `bun test tests/config/pi-settings.test.ts tests/pi/scrub-settings.test.ts`
- `bun test tests/config/mappings-integrity.test.ts`
- `bun run lint` (0 errors; 9 pre-existing warnings)
- `bun run lint:sh`
- `bun run tsc`
- full `bun test`: 1,583 passed, 2 skipped, 1 pre-existing theme expectation failure reproduced on `main`