### PR TITLE
feat(pi): harden sandboxed agent delegation

### DIFF
--- a/claude/.claude/agents/codex-poc.md
+++ b/claude/.claude/agents/codex-poc.md
@@ -1,6 +1,7 @@
 ---
 name: codex-poc
 description: Cross-model implementation PoC via OpenAI Codex CLI (headless, workspace-write). Lets codex write a competing implementation inside an isolated git worktree. Use as a Workflow agentType ('codex-poc', pair with isolation:'worktree') in ultracode implementation phases, or via the Agent tool with an explicit worktree path.
+pi-codex-stage-modes: poc
 ---
 
 You are a PoC orchestrator that delegates implementation work to OpenAI Codex CLI
@@ -25,35 +26,64 @@ by pointing at another directory; report it instead.
 
 ### Phase 1: Preflight
 
+Run these as separate commands and copy the canonical toplevel printed by the
+first command into later tool arguments. Never capture it in a shell variable
+or command substitution.
+
 ```bash
-WT=$(git rev-parse --show-toplevel)   # or the path given in the task prompt
-git -C "$WT" status --porcelain        # record the pre-run state
+git rev-parse --show-toplevel
+git status --porcelain
 ```
 
 ### Phase 2: Codex Invocation
 
 Run codex through the shared wrapper — the single permission/safety boundary
-(auth preflight, portable timeout, `--ephemeral`, never `-m`). Always use the
-literal `~/.claude/hooks/lib/codex-stage.sh` prefix so the allowlist matches:
+(auth preflight, portable timeout, `--ephemeral`, never `-m`). Keep the full
+spec out of Bash by staging it in the sandbox-managed private scratch root:
 
-```bash
-~/.claude/hooks/lib/codex-stage.sh poc --worktree "$WT" --timeout 600 << 'SPEC_EOF'
-<implementation spec: goal, constraints, files to create/modify, how to verify>
-SPEC_EOF
-```
+1. Allocate one exclusive private prompt file directly in the controlled
+   temporary root and copy the printed path literally; never use a shell
+   variable or command substitution.
 
-- Add `--network` only when the spec requires installing dependencies or
-  running network-bound builds/tests.
+   ```bash
+   bun -e 'const { open } = await import("node:fs/promises"); const { randomUUID } = await import("node:crypto"); const { tmpdir } = await import("node:os"); const { join } = await import("node:path"); const path = join(tmpdir(), "codex-poc-" + randomUUID() + ".md"); const file = await open(path, "wx", 0o600); await file.close(); console.log(path);'
+   ```
+
+2. Use the `write` tool to replace the empty printed file with the complete
+   implementation spec. Keep it directly under the printed temporary root;
+   never move it into a nested directory. Then paste the printed prompt path
+   and the canonical active worktree from Phase 1 into this literal pipeline:
+
+   ```bash
+   printf '%s' 'Read /PRINTED_PRIVATE_PROMPT_FILE completely and follow it exactly.' |
+     ~/.claude/hooks/lib/codex-stage.sh poc --worktree '/literal/active/worktree' --timeout 600
+   ```
+
+   Never use a heredoc, input redirection, shell variable, or command
+   substitution for this invocation. Add `--network` only when the spec
+   requires installing dependencies or running network-bound builds/tests.
+
+3. After the wrapper returns or fails, remove only the printed private prompt
+   file with its concrete literal path:
+
+   ```bash
+   bun -e 'const { rm } = await import("node:fs/promises"); await rm("/PRINTED_PRIVATE_PROMPT_FILE", { force: true });'
+   ```
+
 - Set a generous Bash timeout for the wrapper call (up to 600000 ms); raise
   `--timeout` for large specs.
-- The wrapper runs `codex -a never exec --sandbox workspace-write -C <worktree
-toplevel>` under the hood: codex edits files directly in the worktree; `.git`,
+- The wrapper pins the validated worktree with `cd -P`, verifies the expected
+  directory identity, then runs `codex -a never exec --sandbox workspace-write`
+  from that cwd: codex edits files directly in the worktree; `.git`,
   `.codex` and `.agents` stay read-only by codex policy.
 - codex needs network and a local app-server. Under pi, if ordinary Bash blocks
   the wrapper at the effect boundary, retry that exact wrapper call with the
-  explicit `bash_escalated` tool; it performs a fresh local classification.
-  If escalation is unavailable or not approved, report the PoC as blocked.
-  Never disable the sandbox implicitly or invoke `codex` directly.
+  explicit `bash_escalated` tool. Pi grants only this agent's declared `poc`
+  mode after it verifies the literal wrapper, a scratch-local staged prompt,
+  and that `--worktree` equals the child process's active linked worktree. Any
+  changed form still gets a fresh local classification. If escalation remains
+  blocked, report the PoC as blocked. Never disable the sandbox implicitly or
+  invoke `codex` directly.
 
 ### Phase 3: Report
 

--- a/claude/.claude/agents/codex-reviewer.md
+++ b/claude/.claude/agents/codex-reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: codex-reviewer
 description: Cross-model review via OpenAI Codex CLI (headless). Reviews plans, designs, diffs, and findings from a non-Claude model family. Usable directly via the Agent tool or as a Workflow agentType ('codex-reviewer') in ultracode review/verification stages; composes with JSON-schema structured output.
+pi-codex-stage-modes: prompt,review
 ---
 
 You are a review orchestrator that delegates review work to OpenAI Codex CLI in headless mode.
@@ -72,21 +73,23 @@ report reviewer inability; do not review the envelope text as a substitute.
 For an inline plan, design, or findings review, stage the extracted artifact
 content with the standard review prompt shown below.
 
-1. Allocate an exclusive private temporary directory with this explicitly
-   allowed command:
+1. Allocate one exclusive private prompt file directly in the controlled
+   temporary root with this explicitly allowed command:
 
    ```bash
-   bun -e 'const { mkdtemp } = await import("node:fs/promises"); console.log(await mkdtemp("/tmp/codex-reviewer-"));'
+   bun -e 'const { open } = await import("node:fs/promises"); const { randomUUID } = await import("node:crypto"); const { tmpdir } = await import("node:os"); const { join } = await import("node:path"); const path = join(tmpdir(), "codex-reviewer-" + randomUUID() + ".md"); const file = await open(path, "wx", 0o600); await file.close(); console.log(path);'
    ```
 
-   Copy the concrete absolute directory printed by the command (for example,
-   `/tmp/codex-reviewer-a1B2C3`) into every following tool argument and command.
-   Do not capture it with a shell variable or command substitution. The
-   generated directory is mode `0700`, so concurrent reviewers cannot collide
-   and other local accounts cannot read the staged artifact.
+   This resolves `node:os.tmpdir()` from the controlled child environment, so
+   under pi the file is a direct child of the pinned sandbox scratch root. Copy
+   the concrete absolute file path printed by the command into every following
+   tool argument and command. Do not capture it with a shell variable or
+   command substitution. Exclusive creation and the random name prevent
+   reviewer collisions; mode `0600` protects the staged artifact.
 
-   Use the `write` tool to create `<printed-directory>/prompt.md`; never write
-   the prompt directly into shared `/tmp`.
+   Use the `write` tool to replace the empty printed file with the complete
+   prompt; never move it into a nested directory or replace its parent with
+   `/tmp` or another temporary root.
 
    For an encoded path-only Plan review, write this complete prompt with the
    validated payload substituted as file content, never as shell text:
@@ -163,7 +166,7 @@ content with the standard review prompt shown below.
    the wrapper's `DIR=$PWD` default. This is the preferred command:
 
    ```bash
-   printf '%s' 'Read /tmp/codex-reviewer-a1B2C3/prompt.md completely and follow it exactly.' |
+   printf '%s' 'Read /PRINTED_PRIVATE_PROMPT_FILE completely and follow it exactly.' |
      ~/.claude/hooks/lib/codex-stage.sh prompt --timeout 600
    ```
 
@@ -171,7 +174,7 @@ content with the standard review prompt shown below.
    one properly shell-quoted literal argument after `--dir`:
 
    ```bash
-   printf '%s' 'Read /tmp/codex-reviewer-a1B2C3/prompt.md completely and follow it exactly.' |
+   printf '%s' 'Read /PRINTED_PRIVATE_PROMPT_FILE completely and follow it exactly.' |
      ~/.claude/hooks/lib/codex-stage.sh prompt --dir '/literal/absolute path' --timeout 600
    ```
 
@@ -179,11 +182,11 @@ content with the standard review prompt shown below.
    variable, or command substitution for these child invocations. Those forms
    do not match the deterministic explicit-allow contract.
 
-3. After the wrapper returns (success or failure), remove the private directory
-   with its concrete literal path through the explicitly allowed `bun` command:
+3. After the wrapper returns (success or failure), remove the private prompt
+   file with its concrete literal path through the explicitly allowed command:
 
    ```bash
-   bun -e 'const { rm } = await import("node:fs/promises"); await rm("/tmp/codex-reviewer-a1B2C3", { recursive: true, force: true });'
+   bun -e 'const { rm } = await import("node:fs/promises"); await rm("/PRINTED_PRIVATE_PROMPT_FILE", { force: true });'
    ```
 
 **Diff review** (uncommitted changes, a branch, or a single commit): use the
@@ -225,8 +228,10 @@ gap), 124 = timed out.
 - Review runs are read-only (`--sandbox read-only` / the review subcommand)
 - codex needs network and a local app-server. Under pi, if ordinary Bash blocks
   the wrapper at the effect boundary, retry that exact wrapper call with the
-  explicit `bash_escalated` tool; it performs a fresh local classification.
-  If escalation is unavailable or not approved, report the wrapper as blocked.
+  explicit `bash_escalated` tool. Pi grants only this agent's declared
+  `prompt,review` modes after it verifies the literal wrapper, the scratch-local
+  staged prompt, and the active-worktree directory. Any changed form still gets
+  a fresh local classification. If escalation remains blocked, report it.
   Never disable the sandbox implicitly or invoke `codex` directly.
 - Never pass `-m` — `~/.codex/config.toml` owns model selection
 - Privacy: the artifact and any repo files codex reads are sent to OpenAI

--- a/claude/.claude/agents/codex-runner.md
+++ b/claude/.claude/agents/codex-runner.md
@@ -1,6 +1,7 @@
 ---
 name: codex-runner
 description: Cross-model write-capable worker via OpenAI Codex CLI (headless, workspace-write). Runs a codex edit/implementation task in a directory the orchestrator chooses — the main checkout or any subdirectory — WITHOUT the isolated-worktree requirement that codex-poc enforces. Use as a Workflow agentType ('codex-runner') when the main agent launches several write-capable codex workers in parallel and owns their placement; use codex-poc instead for a competing PoC that must stay isolated, and codex-reviewer for read-only review.
+pi-codex-stage-modes: run
 ---
 
 You are a run orchestrator that delegates a write-capable task to OpenAI Codex
@@ -49,42 +50,71 @@ NOT lock or partition the tree. So:
 
 ### Phase 1: Preflight
 
+Run direct commands from the assigned directory. If the task names a narrower
+absolute subdirectory, paste that concrete path into separate `git -C` commands;
+never capture it in a shell variable or command substitution.
+
 ```bash
-DIR="<abs --dir from the task prompt, or $PWD>"
-git -C "$DIR" rev-parse --is-inside-work-tree >/dev/null   # must be a git work tree
-git -C "$DIR" status --porcelain                            # record the pre-run state
+git rev-parse --show-toplevel
+git status --porcelain
 ```
 
 ### Phase 2: Codex Invocation
 
 Run codex through the shared wrapper — the single permission/safety boundary
-(auth preflight, portable timeout, `--ephemeral`, `-a never`, never `-m`). Always
-use the literal `~/.claude/hooks/lib/codex-stage.sh` prefix so the allowlist
-matches:
+(auth preflight, portable timeout, `--ephemeral`, `-a never`, never `-m`). Keep
+all task text out of Bash by staging it in the sandbox-managed private scratch
+root:
 
-```bash
-~/.claude/hooks/lib/codex-stage.sh run --dir "$DIR" --timeout 600 << 'TASK_EOF'
-<task: goal, constraints, exact files to create/modify, how to verify>
-TASK_EOF
-```
+1. Allocate one exclusive private prompt file directly in the controlled
+   temporary root and copy the printed path literally; never use a shell
+   variable or command substitution.
 
-- Add `--network` only when the task requires installing dependencies or running
-  network-bound builds/tests.
+   ```bash
+   bun -e 'const { open } = await import("node:fs/promises"); const { randomUUID } = await import("node:crypto"); const { tmpdir } = await import("node:os"); const { join } = await import("node:path"); const path = join(tmpdir(), "codex-runner-" + randomUUID() + ".md"); const file = await open(path, "wx", 0o600); await file.close(); console.log(path);'
+   ```
+
+2. Use the `write` tool to replace the empty printed file with the full task,
+   constraints, exact write scope, and verification. Keep it directly under
+   the printed temporary root; never move it into a nested directory. Paste
+   the printed prompt path and assigned active-worktree directory into this
+   literal pipeline:
+
+   ```bash
+   printf '%s' 'Read /PRINTED_PRIVATE_PROMPT_FILE completely and follow it exactly.' |
+     ~/.claude/hooks/lib/codex-stage.sh run --dir '/literal/assigned/directory' --timeout 600
+   ```
+
+   Never use a heredoc, input redirection, shell variable, or command
+   substitution for this invocation. Add `--network` only when the task
+   requires installing dependencies or running network-bound builds/tests.
+
+3. After the wrapper returns or fails, remove only the printed private prompt
+   file with its concrete literal path:
+
+   ```bash
+   bun -e 'const { rm } = await import("node:fs/promises"); await rm("/PRINTED_PRIVATE_PROMPT_FILE", { force: true });'
+   ```
+
 - Set a generous Bash timeout for the wrapper call (up to 600000 ms); raise
   `--timeout` for large tasks.
-- The wrapper runs `codex -a never exec --sandbox workspace-write -C <dir>` under
-  the hood: codex edits files within `<dir>`. The wrapper does NOT widen the
-  writable boundary with `--add-dir`, but which paths stay protected (`.git`,
-  etc.) is whatever codex's own workspace-write sandbox policy enforces — not a
-  wrapper guarantee. That confinement to `<dir>` is codex-sandbox-enforced
-  (writable root = the `-C` dir), so it depends on `~/.codex/config.toml` not
-  widening `sandbox_workspace_write.writable_roots`; a codex config/version
+- The wrapper pins `<dir>` with `cd -P`, verifies the expected directory
+  identity, then runs `codex -a never exec --sandbox workspace-write` from that
+  cwd. Codex edits files within `<dir>`. The wrapper does NOT widen the writable
+  boundary with `--add-dir`, but which paths stay protected (`.git`, etc.) is
+  whatever codex's own workspace-write sandbox policy enforces — not a wrapper
+  guarantee. That confinement to the inherited cwd is codex-sandbox-enforced,
+  so it depends on `~/.codex/config.toml` not widening
+  `sandbox_workspace_write.writable_roots`; a codex config/version
   change, not a wrapper change, is the failure mode to watch.
 - codex needs network and a local app-server. Under pi, if ordinary Bash blocks
   the wrapper at the effect boundary, retry that exact wrapper call with the
-  explicit `bash_escalated` tool; it performs a fresh local classification.
-  If escalation is unavailable or not approved, report the run as blocked.
-  Never disable the sandbox implicitly or invoke `codex` directly.
+  explicit `bash_escalated` tool. Pi grants only this agent's declared `run`
+  mode after it verifies the literal wrapper, a scratch-local staged prompt,
+  and that `--dir` remains inside the child process's active worktree. Any
+  changed form still gets a fresh local classification. If escalation remains
+  blocked, report the run as blocked. Never disable the sandbox implicitly or
+  invoke `codex` directly.
 
 ### Phase 3: Report
 

--- a/claude/.claude/hooks/lib/codex-stage.sh
+++ b/claude/.claude/hooks/lib/codex-stage.sh
@@ -19,12 +19,12 @@
 #       Default selector: --uncommitted. Read-only by nature.
 #
 #   codex-stage.sh prompt [--dir <path>] [--timeout <sec>] [--out <file>] [--schema <file>]
-#       Read-only analysis/review with a custom prompt read from stdin
-#       (codex exec --sandbox read-only -C <dir> -).
+#       Read-only analysis/review with a custom prompt read from stdin.
+#       The wrapper pins <dir> with cd before running codex from that cwd.
 #
 #   codex-stage.sh poc --worktree <abs-path> [--timeout <sec>] [--network] [--out <file>]
 #       Implementation PoC read from stdin, confined to an isolated linked git
-#       worktree (codex -a never exec --sandbox workspace-write -C <worktree> -).
+#       worktree (codex -a never exec --sandbox workspace-write from <worktree>).
 #       Prints `git status --porcelain` + `git diff --stat` of the worktree after
 #       the run so callers get a machine-checkable change summary.
 #
@@ -36,8 +36,8 @@
 #       launches in parallel and places itself — the orchestrator owns
 #       collision-avoidance across concurrent runs (partition files/dirs so two
 #       runs never touch the same path). Same rails as poc (codex -a never exec
-#       --sandbox workspace-write -C <dir> -; no danger flags, no --add-dir, no
-#       -m). Prints a repo-wide `git status --porcelain` + `git diff --stat`
+#       --sandbox workspace-write from the pinned <dir>; no danger flags, no
+#       --add-dir, no -m). Prints a repo-wide `git status --porcelain` + `git diff --stat`
 #       after the run. Changes stay uncommitted for review. run does not accept
 #       --out (its output is returned on stdout) and uses exit 13, not poc's 14,
 #       for a non-git-work-tree target. Note: confinement of codex's edits to
@@ -73,6 +73,36 @@ die() {
   exit "${2:-13}"
 }
 
+directory_identity() {
+  local path=$1 identity
+  if identity=$(stat -c '%d:%i' -- "$path" 2>/dev/null); then
+    printf '%s' "$identity"
+    return 0
+  fi
+  if identity=$(stat -f '%d:%i' "$path" 2>/dev/null); then
+    printf '%s' "$identity"
+    return 0
+  fi
+  return 1
+}
+
+pin_directory() {
+  local path=$1 actual_path
+  cd -P -- "$path" || die "cannot enter directory: $path" 13
+  actual_path=$(pwd -P) || die "cannot resolve directory after entry: $path" 13
+  if [ -n "$EXPECTED_DIR_PATH" ]; then
+    [ "$actual_path" = "$EXPECTED_DIR_PATH" ] \
+      || die "directory path changed before execution: $path" 13
+  fi
+  if [ -n "$EXPECTED_DIR_IDENTITY" ]; then
+    local actual_identity
+    actual_identity=$(directory_identity .) \
+      || die "cannot verify directory identity: $path" 13
+    [ "$actual_identity" = "$EXPECTED_DIR_IDENTITY" ] \
+      || die "directory identity changed before execution: $path" 13
+  fi
+}
+
 # Portable timeout: background the command, kill it from a watchdog.
 # Background jobs get stdin rewired to /dev/null by the shell, so the prompt
 # is buffered to a temp file and redirected explicitly inside the job.
@@ -83,27 +113,36 @@ run_with_timeout() {
   local mark
   mark=$(mktemp "${TMPDIR:-/tmp}/codex-stage-timeout.XXXXXX")
   rm -f "$mark"
+  local monitor_was_enabled=0
+  case $- in *m*) monitor_was_enabled=1 ;; esac
+  set -m
   "$@" < "${stdin_file:-/dev/null}" &
-  local cmd_pid=$!
+  local cmd_pid=$! kill_target="-$!"
+  [ "$monitor_was_enabled" -eq 1 ] || set +m
   (
     sleep "$secs"
-    # Mark a timeout only when the process is still alive at the deadline: a
-    # command that finished right at the deadline stays a success, and a
-    # command that traps TERM and exits 0 is still classified as timed out.
-    # The mark is written BEFORE the kill so the parent (woken by the kill)
-    # can never observe the death without the mark.
-    if kill -0 "$cmd_pid" 2>/dev/null; then
+    # Mark a timeout only when the process group is still alive at the
+    # deadline. The mark is written BEFORE TERM so the parent, woken by the
+    # leader's exit, waits for the watchdog's group-wide KILL.
+    if kill -0 -- "$kill_target" 2>/dev/null; then
       touch "$mark"
-      kill -TERM "$cmd_pid" 2>/dev/null
+      kill -TERM -- "$kill_target" 2>/dev/null
       sleep 5
-      kill -KILL "$cmd_pid" 2>/dev/null
+      kill -KILL -- "$kill_target" 2>/dev/null
     fi
   ) &
   local watchdog_pid=$!
   local rc=0
   wait "$cmd_pid" || rc=$?
-  kill "$watchdog_pid" 2>/dev/null || true
-  wait "$watchdog_pid" 2>/dev/null || true
+  # A command leader may exit while a background descendant keeps the job's
+  # process group alive. In that case retain the watchdog through its deadline
+  # so TERM/KILL still reaches the whole group instead of returning early.
+  if kill -0 -- "$kill_target" 2>/dev/null; then
+    wait "$watchdog_pid" 2>/dev/null || true
+  else
+    kill "$watchdog_pid" 2>/dev/null || true
+    wait "$watchdog_pid" 2>/dev/null || true
+  fi
   if [ -e "$mark" ]; then
     rm -f "$mark"
     return 124
@@ -193,6 +232,8 @@ SCHEMA=""
 TITLE=""
 WORKTREE=""
 NETWORK=0
+EXPECTED_DIR_IDENTITY=""
+EXPECTED_DIR_PATH=""
 SELECTOR=()
 
 while [ $# -gt 0 ]; do
@@ -209,11 +250,20 @@ while [ $# -gt 0 ]; do
     --schema) SCHEMA=${2:?--schema needs a file}; shift ;;
     --worktree) WORKTREE=${2:?--worktree needs an absolute path}; shift ;;
     --network) NETWORK=1 ;;
+    --expected-dir-identity) EXPECTED_DIR_IDENTITY=${2:?--expected-dir-identity needs device:inode}; shift ;;
+    --expected-dir-path) EXPECTED_DIR_PATH=${2:?--expected-dir-path needs an absolute path}; shift ;;
     -h|--help) usage ;;
     *) die "unknown argument: $1" 13 ;;
   esac
   shift
 done
+
+if [ -n "$EXPECTED_DIR_IDENTITY" ] && [ -z "$EXPECTED_DIR_PATH" ]; then
+  die "--expected-dir-identity requires --expected-dir-path" 13
+fi
+if [ -n "$EXPECTED_DIR_PATH" ] && [ -z "$EXPECTED_DIR_IDENTITY" ]; then
+  die "--expected-dir-path requires --expected-dir-identity" 13
+fi
 
 preflight
 
@@ -229,7 +279,8 @@ case $MODE in
   review)
     [ -d "$DIR" ] || die "no such directory: $DIR" 13
     [ ${#SELECTOR[@]} -gt 0 ] || SELECTOR=(--uncommitted)
-    cd "$DIR"
+    pin_directory "$DIR"
+    DIR=$PWD
     git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
       || die "review mode requires a git repository: $DIR" 13
     rc=0
@@ -242,11 +293,12 @@ case $MODE in
 
   prompt)
     [ -d "$DIR" ] || die "no such directory: $DIR" 13
+    pin_directory "$DIR"
+    DIR=$PWD
     buffer_stdin
     rc=0
     run_codex "$PROMPT_FILE" codex exec \
       --sandbox read-only \
-      -C "$DIR" \
       --ephemeral \
       --skip-git-repo-check \
       ${OUT:+-o "$OUT"} \
@@ -264,6 +316,8 @@ case $MODE in
     git -C "$WORKTREE" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
       || die "not a git work tree: $WORKTREE" 14
     TOPLEVEL=$(git -C "$WORKTREE" rev-parse --show-toplevel)
+    pin_directory "$TOPLEVEL"
+    TOPLEVEL=$PWD
     # A linked worktree has its own git-dir under <main>/.git/worktrees/<name>;
     # in a main checkout git-dir == git-common-dir. Refuse main checkouts so a
     # workspace-write codex run can never touch the primary working copy.
@@ -271,8 +325,8 @@ case $MODE in
     # handling: deriving one via --absolute-git-dir (canonicalized) and the
     # other via cd+pwd (not canonicalized) let a main checkout reached through
     # a symlinked path (e.g. macOS /tmp -> /private/tmp) pass as a worktree.
-    GIT_DIR=$(git -C "$WORKTREE" rev-parse --git-dir)
-    GIT_COMMON_DIR=$(git -C "$WORKTREE" rev-parse --git-common-dir)
+    GIT_DIR=$(git rev-parse --git-dir)
+    GIT_COMMON_DIR=$(git rev-parse --git-common-dir)
     [ "$GIT_DIR" != "$GIT_COMMON_DIR" ] \
       || die "refusing: $TOPLEVEL is a main repository checkout, not an isolated linked worktree" 14
     buffer_stdin
@@ -281,7 +335,6 @@ case $MODE in
     rc=0
     run_codex "$PROMPT_FILE" codex -a never exec \
       --sandbox workspace-write \
-      -C "$TOPLEVEL" \
       --ephemeral \
       ${NETWORK_OPT:+-c "$NETWORK_OPT"} \
       ${OUT:+-o "$OUT"} \
@@ -300,9 +353,11 @@ case $MODE in
     # Require a git work tree so writes stay reviewable — but, UNLIKE poc, the
     # main repository checkout is allowed: run mode deliberately drops the
     # isolated-linked-worktree refusal. Placement/isolation is the caller's job.
-    git -C "$DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+    pin_directory "$DIR"
+    DIR=$PWD
+    git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
       || die "run mode requires a git work tree (for reviewability): $DIR" 13
-    TOPLEVEL=$(git -C "$DIR" rev-parse --show-toplevel)
+    TOPLEVEL=$(git rev-parse --show-toplevel)
     # run's write surface is strictly --dir. --out/-o would let codex write its
     # output file to a path absolutized against the caller's $PWD, outside that
     # boundary — so run does not accept it. The caller captures codex's output
@@ -315,7 +370,6 @@ case $MODE in
     rc=0
     run_codex "$PROMPT_FILE" codex -a never exec \
       --sandbox workspace-write \
-      -C "$DIR" \
       --ephemeral \
       ${NETWORK_OPT:+-c "$NETWORK_OPT"} \
       - || rc=$?

--- a/pi/extensions/pi-harness/features/bash-sandbox/index.ts
+++ b/pi/extensions/pi-harness/features/bash-sandbox/index.ts
@@ -1,5 +1,5 @@
 import { constants } from "node:fs";
-import { access, chmod, mkdtemp, rm } from "node:fs/promises";
+import { access, chmod, lstat, mkdtemp, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -53,6 +53,11 @@ export interface BashExecutionBoundary {
   readonly profileFingerprint: string;
 }
 
+export interface BashScratchBoundary {
+  readonly path: string;
+  readonly identity: string;
+}
+
 export const BASH_SANDBOX_PROVIDER_EVENT = "pi-harness:bash-sandbox-provider";
 
 export interface BashSandboxOperationsProvider {
@@ -63,6 +68,8 @@ export interface BashSandboxOperationsProvider {
 
 export interface BashSandboxController {
   boundaryFor(toolName: string): BashExecutionBoundary | undefined;
+  scratchDirectoryFor(toolName: string): string | undefined;
+  scratchBoundaryFor(toolName: string): BashScratchBoundary | undefined;
   registerExecutionBoundary(options: {
     blockToolCall: (reason: string) => PermissionBlockResult;
     permissionAudit?: PermissionAuditIntegration;
@@ -72,6 +79,7 @@ export interface BashSandboxController {
 interface BashSandboxState {
   readonly kind: "starting" | "ready" | "failed" | "stopped";
   readonly scratchDirectory?: string;
+  readonly scratchBoundary?: BashScratchBoundary;
   readonly manager?: SandboxManagerLike;
   readonly profile?: BashSandboxProfile;
   readonly reason?: string;
@@ -87,6 +95,7 @@ interface SetupBashSandboxOptions {
     options: { recursive: boolean; force: boolean },
   ) => Promise<void>;
   readonly accessPath?: (path: string, mode?: number) => Promise<void>;
+  readonly pinScratchDirectory?: (path: string) => Promise<BashScratchBoundary>;
   readonly spawnFn?: SpawnFunction;
   readonly baseEnv?: NodeJS.ProcessEnv;
 }
@@ -109,6 +118,20 @@ const cloneDefaultConfig = (): BashSandboxConfig => ({
 const failureReason = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
 
+const pinScratchDirectory = async (
+  path: string,
+): Promise<BashScratchBoundary> => {
+  const canonicalPath = await realpath(path);
+  const stat = await lstat(canonicalPath);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error("bash sandbox scratch is not a safe directory");
+  }
+  return {
+    path: canonicalPath,
+    identity: `${stat.dev}:${stat.ino}`,
+  };
+};
+
 export const setupBashSandbox = (
   pi: PiLike,
   config: HarnessConfig,
@@ -120,6 +143,7 @@ export const setupBashSandbox = (
   const setMode = options.chmodPath ?? chmod;
   const remove = options.removePath ?? rm;
   const checkAccess = options.accessPath ?? access;
+  const pinScratch = options.pinScratchDirectory ?? pinScratchDirectory;
   let state: BashSandboxState = { kind: "stopped" };
   const approvedHosts = new Set<string>();
   const deniedHosts = new Set<string>();
@@ -201,7 +225,13 @@ export const setupBashSandbox = (
     try {
       scratch = await createTemp(join(tmpdir(), "pi-bash-sandbox-"));
       await setMode(scratch, 0o700);
-      state = { kind: "starting", scratchDirectory: scratch };
+      const scratchBoundary = await pinScratch(scratch);
+      scratch = scratchBoundary.path;
+      state = {
+        kind: "starting",
+        scratchDirectory: scratch,
+        scratchBoundary,
+      };
       await checkAccess(CONTROLLED_BASH_PATH, constants.X_OK);
       const runtime = await loadRuntime();
       const profile = await createProfile(
@@ -236,6 +266,7 @@ export const setupBashSandbox = (
       state = {
         kind: "ready",
         scratchDirectory: scratch,
+        scratchBoundary,
         manager: runtime.SandboxManager,
         profile,
       };
@@ -319,6 +350,24 @@ export const setupBashSandbox = (
         network: networkMode(),
         profileFingerprint: profile?.fingerprint ?? "unavailable",
       };
+    },
+    scratchDirectoryFor(toolName) {
+      if (
+        (toolName !== "bash" && toolName !== "bash_escalated") ||
+        state.kind !== "ready"
+      ) {
+        return undefined;
+      }
+      return state.scratchBoundary?.path;
+    },
+    scratchBoundaryFor(toolName) {
+      if (
+        (toolName !== "bash" && toolName !== "bash_escalated") ||
+        state.kind !== "ready"
+      ) {
+        return undefined;
+      }
+      return state.scratchBoundary;
     },
     registerExecutionBoundary({ blockToolCall, permissionAudit }) {
       pi.on("tool_call", async (event, ctx) => {

--- a/pi/extensions/pi-harness/features/bash-sandbox/profile.ts
+++ b/pi/extensions/pi-harness/features/bash-sandbox/profile.ts
@@ -9,6 +9,8 @@ import {
   runGitCommonDir,
 } from "../permission-policy/context";
 
+export const BASH_SANDBOX_PROJECT_DISCOVERY_TIMEOUT_MS = 5_000;
+
 export interface BashSandboxProfile {
   readonly cwd: string;
   readonly writableRoots: readonly string[];
@@ -45,7 +47,11 @@ export const buildBashSandboxProfile = async (
   const canonicalize = options.canonicalize ?? realpath;
   const canonicalCwd = await canonicalize(cwd);
   const discover = options.discoverProject ?? discoverProjectContext;
-  const project = await discover(canonicalCwd, {}, signal);
+  const project = await discover(
+    canonicalCwd,
+    { timeoutMs: BASH_SANDBOX_PROJECT_DISCOVERY_TIMEOUT_MS },
+    signal,
+  );
   if (project.kind === "unavailable") {
     throw new Error(`project boundary unavailable: ${project.reason}`);
   }
@@ -57,6 +63,7 @@ export const buildBashSandboxProfile = async (
     gitCommonDir = await (options.discoverGitCommonDir ?? runGitCommonDir)(
       project.cwd,
       signal,
+      { timeoutMs: BASH_SANDBOX_PROJECT_DISCOVERY_TIMEOUT_MS },
     );
     if (gitCommonDir === undefined) {
       throw new Error("Git common directory unavailable");

--- a/pi/extensions/pi-harness/features/permission-policy/codex-stage-capability.ts
+++ b/pi/extensions/pi-harness/features/permission-policy/codex-stage-capability.ts
@@ -1,0 +1,699 @@
+import {
+  chmodSync,
+  closeSync,
+  constants,
+  fstatSync,
+  lstatSync,
+  mkdtempSync,
+  openSync,
+  readSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import {
+  chmod,
+  lstat,
+  mkdtemp,
+  open,
+  realpath,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, dirname, isAbsolute, join } from "node:path";
+import { CODEX_STAGE_MODES, type CodexStageMode } from "../../lib/agent-md";
+import { isPathWithin } from "../../lib/trust";
+import type { BashScratchBoundary } from "../bash-sandbox";
+import type { PermissionProjectContext } from "./context";
+import { scanCommand, type Segment } from "./scan";
+
+export const CODEX_STAGE_CAPABILITY_ENV = "PI_HARNESS_CODEX_STAGE_CAPABILITY";
+
+const CODEX_STAGE_WRAPPER = "~/.claude/hooks/lib/codex-stage.sh";
+const PROMPT_PREFIX = "Read ";
+const PROMPT_SUFFIX = " completely and follow it exactly.";
+const EXPECTED_DIRECTORY_IDENTITY_FLAG = "--expected-dir-identity";
+const EXPECTED_DIRECTORY_PATH_FLAG = "--expected-dir-path";
+const SAFE_GIT_SELECTOR = /^[A-Za-z0-9._/@{}~^:+-]+$/;
+const POSITIVE_INTEGER = /^[1-9][0-9]*$/;
+const NON_NEGATIVE_INTEGER = /^(?:0|[1-9][0-9]*)$/;
+const SAFE_STAGED_FILE_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]{0,159}$/;
+const MAX_WRAPPER_BYTES = 512 * 1024;
+const MAX_STAGED_ARTIFACT_BYTES = 8 * 1024 * 1024;
+const MAX_PRIVATE_ARTIFACT_BYTES = 32 * 1024 * 1024;
+const MAX_PRIVATE_ARTIFACTS = 16;
+
+export const consumeCodexStageCapability = (
+  isChild: boolean,
+  env: NodeJS.ProcessEnv = process.env,
+): ReadonlySet<CodexStageMode> => {
+  const raw = env[CODEX_STAGE_CAPABILITY_ENV];
+  delete env[CODEX_STAGE_CAPABILITY_ENV];
+  if (!isChild || raw === undefined || raw.length > 64) return new Set();
+
+  const modes = raw.split(",");
+  const knownModes = new Set<string>(CODEX_STAGE_MODES);
+  if (
+    modes.length === 0 ||
+    modes.some((mode) => !knownModes.has(mode)) ||
+    new Set(modes).size !== modes.length
+  ) {
+    return new Set();
+  }
+  return new Set(modes as CodexStageMode[]);
+};
+
+export interface CodexStageCapabilityRuntime {
+  readonly executablePath: string;
+  stageFile(
+    sourcePath: string,
+    scratchBoundary: BashScratchBoundary,
+    fileName: "prompt.md" | "schema.json",
+  ): Promise<string | undefined>;
+  releaseFiles(paths: readonly string[]): void;
+  dispose(): void;
+}
+
+interface CreateCodexStageCapabilityRuntimeOptions {
+  readonly temporaryDirectory?: string;
+}
+
+interface PrivateArtifact {
+  readonly directory: string;
+  readonly bytes: number;
+}
+
+const removePrivateDirectory = (directory: string): void => {
+  try {
+    chmodSync(directory, 0o700);
+  } catch {
+    // A missing or already-cleaned directory needs no further preparation.
+  }
+  try {
+    rmSync(directory, { recursive: true, force: true });
+  } catch {
+    // Session cleanup is best-effort; capability files are non-writable and
+    // live only in a private temporary directory.
+  }
+};
+
+const hasExpectedOwner = (uid: number): boolean =>
+  typeof process.getuid !== "function" || uid === process.getuid();
+
+const scratchIdentityMatches = async (
+  boundary: BashScratchBoundary,
+): Promise<boolean> => {
+  if (!isAbsolute(boundary.path)) return false;
+  try {
+    const stat = await lstat(boundary.path);
+    return (
+      stat.isDirectory() &&
+      !stat.isSymbolicLink() &&
+      `${stat.dev}:${stat.ino}` === boundary.identity
+    );
+  } catch {
+    return false;
+  }
+};
+
+const readBoundedFile = async (
+  handle: Awaited<ReturnType<typeof open>>,
+  expectedBytes: number,
+): Promise<Buffer | undefined> => {
+  const buffer = Buffer.alloc(expectedBytes + 1);
+  let offset = 0;
+  while (offset < buffer.byteLength) {
+    const { bytesRead } = await handle.read(
+      buffer,
+      offset,
+      buffer.byteLength - offset,
+      null,
+    );
+    if (bytesRead === 0) break;
+    offset += bytesRead;
+  }
+  return offset === expectedBytes ? buffer.subarray(0, offset) : undefined;
+};
+
+const readTrustedExecutable = (source: string): Buffer => {
+  const descriptor = openSync(
+    source,
+    constants.O_RDONLY |
+      (constants.O_NOFOLLOW ?? 0) |
+      (constants.O_NONBLOCK ?? 0),
+  );
+  try {
+    const initialStat = fstatSync(descriptor);
+    if (
+      !initialStat.isFile() ||
+      initialStat.nlink !== 1 ||
+      initialStat.size <= 0 ||
+      initialStat.size > MAX_WRAPPER_BYTES ||
+      !hasExpectedOwner(initialStat.uid)
+    ) {
+      throw new Error("trusted codex-stage wrapper is not a safe regular file");
+    }
+    const contents = Buffer.alloc(initialStat.size + 1);
+    let offset = 0;
+    while (offset < contents.byteLength) {
+      const bytesRead = readSync(
+        descriptor,
+        contents,
+        offset,
+        contents.byteLength - offset,
+        null,
+      );
+      if (bytesRead === 0) break;
+      offset += bytesRead;
+    }
+    const finalStat = fstatSync(descriptor);
+    const currentStat = lstatSync(source);
+    if (
+      offset !== initialStat.size ||
+      finalStat.dev !== initialStat.dev ||
+      finalStat.ino !== initialStat.ino ||
+      finalStat.size !== initialStat.size ||
+      currentStat.isSymbolicLink() ||
+      currentStat.dev !== initialStat.dev ||
+      currentStat.ino !== initialStat.ino
+    ) {
+      throw new Error("trusted codex-stage wrapper changed while being pinned");
+    }
+    return contents.subarray(0, offset);
+  } finally {
+    closeSync(descriptor);
+  }
+};
+
+export const createCodexStageCapabilityRuntime = (
+  sourceExecutable: string,
+  options: CreateCodexStageCapabilityRuntimeOptions = {},
+): CodexStageCapabilityRuntime => {
+  const temporaryDirectory = options.temporaryDirectory ?? tmpdir();
+  const source = realpathSync(sourceExecutable);
+  const executableContents = readTrustedExecutable(source);
+  const executableDirectory = mkdtempSync(
+    join(temporaryDirectory, "pi-codex-stage-bin-"),
+  );
+  const executablePath = join(executableDirectory, "codex-stage.sh");
+  try {
+    writeFileSync(executablePath, executableContents, {
+      flag: "wx",
+      mode: 0o500,
+    });
+    chmodSync(executableDirectory, 0o500);
+  } catch (error) {
+    removePrivateDirectory(executableDirectory);
+    throw error;
+  }
+
+  const artifacts = new Map<string, PrivateArtifact>();
+  let artifactBytes = 0;
+  let inFlightArtifacts = 0;
+  let inFlightBytes = 0;
+  let disposed = false;
+  const releaseFiles = (paths: readonly string[]): void => {
+    for (const path of paths) {
+      const artifact = artifacts.get(path);
+      if (artifact === undefined) continue;
+      artifacts.delete(path);
+      artifactBytes -= artifact.bytes;
+      removePrivateDirectory(artifact.directory);
+    }
+  };
+  return {
+    executablePath,
+    async stageFile(sourcePath, scratchBoundary, fileName) {
+      if (
+        disposed ||
+        !isAbsolute(sourcePath) ||
+        dirname(sourcePath) !== scratchBoundary.path ||
+        !SAFE_STAGED_FILE_NAME.test(basename(sourcePath)) ||
+        !(await scratchIdentityMatches(scratchBoundary))
+      ) {
+        return undefined;
+      }
+      let handle: Awaited<ReturnType<typeof open>> | undefined;
+      let artifactDirectory: string | undefined;
+      let reserved = false;
+      let reservedBytes = 0;
+      let registered = false;
+      try {
+        handle = await open(
+          sourcePath,
+          constants.O_RDONLY |
+            (constants.O_NOFOLLOW ?? 0) |
+            (constants.O_NONBLOCK ?? 0),
+        );
+        const openedStat = await handle.stat();
+        if (
+          disposed ||
+          !openedStat.isFile() ||
+          openedStat.nlink !== 1 ||
+          openedStat.size > MAX_STAGED_ARTIFACT_BYTES ||
+          !hasExpectedOwner(openedStat.uid) ||
+          artifacts.size + inFlightArtifacts >= MAX_PRIVATE_ARTIFACTS ||
+          artifactBytes + inFlightBytes + openedStat.size >
+            MAX_PRIVATE_ARTIFACT_BYTES
+        ) {
+          return undefined;
+        }
+        inFlightArtifacts += 1;
+        inFlightBytes += openedStat.size;
+        reserved = true;
+        reservedBytes = openedStat.size;
+
+        const currentStat = await lstat(sourcePath);
+        if (
+          disposed ||
+          currentStat.isSymbolicLink() ||
+          !currentStat.isFile() ||
+          currentStat.dev !== openedStat.dev ||
+          currentStat.ino !== openedStat.ino
+        ) {
+          return undefined;
+        }
+
+        const contents = await readBoundedFile(handle, openedStat.size);
+        if (disposed || contents === undefined) return undefined;
+        const finalOpenedStat = await handle.stat();
+        const finalCurrentStat = await lstat(sourcePath);
+        if (
+          disposed ||
+          finalOpenedStat.dev !== openedStat.dev ||
+          finalOpenedStat.ino !== openedStat.ino ||
+          finalOpenedStat.size !== openedStat.size ||
+          finalOpenedStat.nlink !== 1 ||
+          !hasExpectedOwner(finalOpenedStat.uid) ||
+          finalCurrentStat.isSymbolicLink() ||
+          !finalCurrentStat.isFile() ||
+          finalCurrentStat.dev !== openedStat.dev ||
+          finalCurrentStat.ino !== openedStat.ino ||
+          !(await scratchIdentityMatches(scratchBoundary))
+        ) {
+          return undefined;
+        }
+        artifactDirectory = await mkdtemp(
+          join(temporaryDirectory, "pi-codex-stage-artifact-"),
+        );
+        if (disposed) return undefined;
+        const artifactPath = join(artifactDirectory, fileName);
+        await writeFile(artifactPath, contents, { flag: "wx", mode: 0o400 });
+        if (disposed) return undefined;
+        await chmod(artifactDirectory, 0o500);
+        if (disposed) return undefined;
+        artifacts.set(artifactPath, {
+          directory: artifactDirectory,
+          bytes: contents.byteLength,
+        });
+        artifactBytes += contents.byteLength;
+        registered = true;
+        return artifactPath;
+      } catch {
+        return undefined;
+      } finally {
+        if (reserved) {
+          inFlightArtifacts -= 1;
+          inFlightBytes -= reservedBytes;
+        }
+        await handle?.close().catch(() => {});
+        if (artifactDirectory !== undefined && !registered) {
+          removePrivateDirectory(artifactDirectory);
+        }
+      }
+    },
+    releaseFiles,
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      releaseFiles([...artifacts.keys()]);
+      removePrivateDirectory(executableDirectory);
+    },
+  };
+};
+
+const isLiteralSimpleSegment = (segment: Segment): boolean =>
+  segment.topLevel &&
+  segment.allowCandidate !== undefined &&
+  !segment.hasAnsiC &&
+  !segment.hasInputRedirection &&
+  !segment.hasOutputRedirection &&
+  segment.opaque.size === 0 &&
+  segment.literalGlobs.size === 0;
+
+interface CanonicalDirectory {
+  readonly path: string;
+  readonly identity: string;
+}
+
+const canonicalDirectory = async (
+  path: string,
+): Promise<CanonicalDirectory | undefined> => {
+  if (!isAbsolute(path)) return undefined;
+  try {
+    const initialStat = await lstat(path);
+    if (!initialStat.isDirectory() || initialStat.isSymbolicLink()) {
+      return undefined;
+    }
+    const canonicalPath = await realpath(path);
+    const canonicalStat = await lstat(canonicalPath);
+    const finalStat = await lstat(path);
+    if (
+      !canonicalStat.isDirectory() ||
+      canonicalStat.isSymbolicLink() ||
+      !finalStat.isDirectory() ||
+      finalStat.isSymbolicLink() ||
+      initialStat.dev !== canonicalStat.dev ||
+      initialStat.ino !== canonicalStat.ino ||
+      finalStat.dev !== canonicalStat.dev ||
+      finalStat.ino !== canonicalStat.ino
+    ) {
+      return undefined;
+    }
+    return {
+      path: canonicalPath,
+      identity: `${canonicalStat.dev}:${canonicalStat.ino}`,
+    };
+  } catch {
+    return undefined;
+  }
+};
+
+const stagedPromptSourcePath = (segment: Segment): string | undefined => {
+  const [head, format, instruction] = segment.words;
+  if (
+    segment.words.length !== 3 ||
+    head !== "printf" ||
+    format !== "%s" ||
+    instruction === undefined ||
+    !instruction.startsWith(PROMPT_PREFIX) ||
+    !instruction.endsWith(PROMPT_SUFFIX)
+  ) {
+    return undefined;
+  }
+  const path = instruction.slice(PROMPT_PREFIX.length, -PROMPT_SUFFIX.length);
+  return path === "" || !isAbsolute(path) ? undefined : path;
+};
+
+interface ParsedWrapperCall {
+  readonly mode: CodexStageMode;
+  readonly args: readonly string[];
+  readonly directory?: string;
+  readonly directoryValueIndex?: number;
+  readonly worktree?: string;
+  readonly worktreeValueIndex?: number;
+  readonly schema?: string;
+  readonly schemaValueIndex?: number;
+}
+
+const consumeValue = (
+  words: readonly string[],
+  index: number,
+): string | undefined => words[index + 1];
+
+const parseWrapperCall = (segment: Segment): ParsedWrapperCall | undefined => {
+  const [wrapper, rawMode, ...args] = segment.words;
+  if (
+    wrapper !== CODEX_STAGE_WRAPPER ||
+    rawMode === undefined ||
+    !CODEX_STAGE_MODES.includes(rawMode as CodexStageMode)
+  ) {
+    return undefined;
+  }
+  const mode = rawMode as CodexStageMode;
+  let directory: string | undefined;
+  let directoryValueIndex: number | undefined;
+  let worktree: string | undefined;
+  let worktreeValueIndex: number | undefined;
+  let schema: string | undefined;
+  let schemaValueIndex: number | undefined;
+  let selectorCount = 0;
+  const seen = new Set<string>();
+
+  for (let index = 0; index < args.length; index += 1) {
+    const flag = args[index];
+    if (flag === undefined || seen.has(flag)) return undefined;
+    seen.add(flag);
+    switch (flag) {
+      case "--timeout": {
+        const value = consumeValue(args, index);
+        if (
+          value === undefined ||
+          !POSITIVE_INTEGER.test(value) ||
+          Number(value) > 3_600
+        ) {
+          return undefined;
+        }
+        index += 1;
+        break;
+      }
+      case "--retry": {
+        const value = consumeValue(args, index);
+        if (
+          value === undefined ||
+          !NON_NEGATIVE_INTEGER.test(value) ||
+          Number(value) > 10
+        ) {
+          return undefined;
+        }
+        index += 1;
+        break;
+      }
+      case "--retry-wait": {
+        const value = consumeValue(args, index);
+        if (
+          value === undefined ||
+          !NON_NEGATIVE_INTEGER.test(value) ||
+          Number(value) > 300
+        ) {
+          return undefined;
+        }
+        index += 1;
+        break;
+      }
+      case "--dir": {
+        if (mode !== "prompt" && mode !== "review" && mode !== "run") {
+          return undefined;
+        }
+        directory = consumeValue(args, index);
+        if (directory === undefined) return undefined;
+        directoryValueIndex = index + 1;
+        index += 1;
+        break;
+      }
+      case "--worktree": {
+        if (mode !== "poc") return undefined;
+        worktree = consumeValue(args, index);
+        if (worktree === undefined) return undefined;
+        worktreeValueIndex = index + 1;
+        index += 1;
+        break;
+      }
+      case "--schema": {
+        if (mode !== "prompt") return undefined;
+        schema = consumeValue(args, index);
+        if (schema === undefined) return undefined;
+        schemaValueIndex = index + 1;
+        index += 1;
+        break;
+      }
+      case "--uncommitted": {
+        if (mode !== "review") return undefined;
+        selectorCount += 1;
+        break;
+      }
+      case "--base":
+      case "--commit": {
+        if (mode !== "review") return undefined;
+        const value = consumeValue(args, index);
+        if (
+          value === undefined ||
+          value.startsWith("-") ||
+          !SAFE_GIT_SELECTOR.test(value)
+        ) {
+          return undefined;
+        }
+        selectorCount += 1;
+        index += 1;
+        break;
+      }
+      case "--network": {
+        if (mode !== "poc" && mode !== "run") return undefined;
+        break;
+      }
+      default: {
+        return undefined;
+      }
+    }
+  }
+
+  if (selectorCount > 1) return undefined;
+  if (mode === "poc" && worktree === undefined) return undefined;
+  if (mode === "run" && directory === undefined) return undefined;
+  return {
+    mode,
+    args,
+    ...(directory === undefined ? {} : { directory, directoryValueIndex }),
+    ...(worktree === undefined ? {} : { worktree, worktreeValueIndex }),
+    ...(schema === undefined ? {} : { schema, schemaValueIndex }),
+  };
+};
+
+const shellQuote = (value: string): string =>
+  `'${value.replaceAll("'", `'"'"'`)}'`;
+
+export interface CodexStageCapabilityContext {
+  readonly modes: ReadonlySet<CodexStageMode>;
+  readonly cwd: string;
+  readonly scratchBoundary?: BashScratchBoundary;
+  readonly project: PermissionProjectContext;
+  readonly runtime?: CodexStageCapabilityRuntime;
+}
+
+export interface AuthorizedCodexStageEscalation {
+  readonly command: string;
+  readonly artifacts: readonly string[];
+}
+
+export const authorizeCodexStageEscalation = async (
+  command: string,
+  context: CodexStageCapabilityContext,
+): Promise<AuthorizedCodexStageEscalation | undefined> => {
+  if (
+    context.modes.size === 0 ||
+    context.scratchBoundary === undefined ||
+    context.project.kind !== "git" ||
+    context.runtime === undefined
+  ) {
+    return undefined;
+  }
+
+  const { runtime, scratchBoundary } = context;
+  const stagedArtifacts: string[] = [];
+  const releaseStagedArtifacts = (): undefined => {
+    runtime.releaseFiles(stagedArtifacts);
+    return undefined;
+  };
+  const scan = scanCommand(command);
+  if (
+    !scan.ok ||
+    scan.subs.length !== 0 ||
+    scan.segments.length < 1 ||
+    scan.segments.length > 2 ||
+    scan.segments.some((segment) => !isLiteralSimpleSegment(segment))
+  ) {
+    return undefined;
+  }
+
+  const wrapperSegment = scan.segments.at(-1);
+  if (wrapperSegment === undefined) return undefined;
+  const parsed = parseWrapperCall(wrapperSegment);
+  if (parsed === undefined || !context.modes.has(parsed.mode)) return undefined;
+
+  const activeWorktree = await canonicalDirectory(
+    context.project.activeWorktree,
+  );
+  if (activeWorktree === undefined) return undefined;
+
+  let targetDirectory: CanonicalDirectory;
+  let canonicalWorktree: CanonicalDirectory | undefined;
+  if (parsed.mode === "poc") {
+    canonicalWorktree =
+      parsed.worktree === undefined
+        ? undefined
+        : await canonicalDirectory(parsed.worktree);
+    if (
+      canonicalWorktree === undefined ||
+      canonicalWorktree.path !== activeWorktree.path
+    ) {
+      return undefined;
+    }
+    targetDirectory = canonicalWorktree;
+  } else {
+    const effectiveDirectory = parsed.directory ?? context.cwd;
+    const canonicalTarget = await canonicalDirectory(effectiveDirectory);
+    if (
+      canonicalTarget === undefined ||
+      !isPathWithin(canonicalTarget.path, activeWorktree.path)
+    ) {
+      return undefined;
+    }
+    targetDirectory = canonicalTarget;
+  }
+
+  if (parsed.mode === "review") {
+    if (
+      scan.segments.length !== 1 ||
+      wrapperSegment.followedByAnd ||
+      wrapperSegment.followedByPipe
+    ) {
+      return undefined;
+    }
+  } else {
+    if (
+      scan.segments.length !== 2 ||
+      wrapperSegment.followedByAnd ||
+      wrapperSegment.followedByPipe
+    ) {
+      return undefined;
+    }
+    const promptSegment = scan.segments[0] as Segment;
+    if (!promptSegment.followedByPipe) return undefined;
+  }
+
+  const sanitizedArgs = [...parsed.args];
+  if (parsed.directoryValueIndex !== undefined) {
+    sanitizedArgs[parsed.directoryValueIndex] = targetDirectory.path;
+  }
+  if (
+    parsed.worktreeValueIndex !== undefined &&
+    canonicalWorktree !== undefined
+  ) {
+    sanitizedArgs[parsed.worktreeValueIndex] = canonicalWorktree.path;
+  }
+  if (parsed.schema !== undefined) {
+    const privateSchema = await runtime.stageFile(
+      parsed.schema,
+      scratchBoundary,
+      "schema.json",
+    );
+    if (privateSchema === undefined) return undefined;
+    stagedArtifacts.push(privateSchema);
+    if (parsed.schemaValueIndex === undefined) {
+      return releaseStagedArtifacts();
+    }
+    sanitizedArgs[parsed.schemaValueIndex] = privateSchema;
+  }
+  sanitizedArgs.push(
+    EXPECTED_DIRECTORY_IDENTITY_FLAG,
+    targetDirectory.identity,
+    EXPECTED_DIRECTORY_PATH_FLAG,
+    targetDirectory.path,
+  );
+  const wrapperCommand = [
+    context.runtime.executablePath,
+    parsed.mode,
+    ...sanitizedArgs,
+  ]
+    .map(shellQuote)
+    .join(" ");
+
+  if (parsed.mode === "review") {
+    return { command: wrapperCommand, artifacts: stagedArtifacts };
+  }
+  const promptSegment = scan.segments[0] as Segment;
+  const promptSource = stagedPromptSourcePath(promptSegment);
+  if (promptSource === undefined) return releaseStagedArtifacts();
+  const privatePrompt = await runtime.stageFile(
+    promptSource,
+    scratchBoundary,
+    "prompt.md",
+  );
+  if (privatePrompt === undefined) return releaseStagedArtifacts();
+  stagedArtifacts.push(privatePrompt);
+  const instruction = `${PROMPT_PREFIX}${privatePrompt}${PROMPT_SUFFIX}`;
+  return {
+    command: `printf '%s' ${shellQuote(instruction)} | ${wrapperCommand}`,
+    artifacts: stagedArtifacts,
+  };
+};

--- a/pi/extensions/pi-harness/features/permission-policy/command-hygiene.ts
+++ b/pi/extensions/pi-harness/features/permission-policy/command-hygiene.ts
@@ -1,20 +1,31 @@
-const COMMAND_HYGIENE_GUIDANCE = `## Bash command hygiene (preference, not a hard constraint)
+const COMMAND_HYGIENE_GUIDANCE = `## Bash command hygiene and permission-aware execution
 
-The Bash tool already captures stdout and stderr. Do not create a temporary file merely to inspect, filter, summarize, or pass command output to another command.
+### ALLOW-first command selection
 
-Before using Bash, prefer the first applicable option:
+The Bash tool already captures stdout and stderr and truncates oversized output. Do not create a temporary file merely to inspect, filter, summarize, or pass command output to another command.
+
+Before using Bash, prefer the first applicable option. When semantically equivalent shell forms exist, use the form expected to receive a deterministic ALLOW instead of one that may reach the local classifier or user confirmation. Do not use ASK or user confirmation as a convenience path.
 
 1. An available dedicated read, edit, or write tool that directly performs the task. Never assume a tool exists when it is not available.
 2. An existing repository script or the CLI's native --summary, --format, or --json mode.
 3. One directly executable literal command with project-relative arguments.
-4. A short transparent pipeline only when stdout is genuinely the next command's stdin.
+4. A short transparent pipeline only when stdout is genuinely the next command's stdin and no equally direct single-command form satisfies the task.
 5. A file only when the user requested a persistent artifact or the CLI requires native file input. Prefer the write tool or a native file option such as --body-file or --output, and keep the path project-bounded.
+
+For repository-scoped read-only investigation, prefer these narrow command forms when applicable:
+
+- Read a known text or JSON file with the read tool.
+- Search file contents with one literal rg command using --no-config, -n, a literal pattern, and explicit project-internal paths. Example: rg --no-config -n 'sandbox|judge' pi/extensions/pi-harness. Omit convenience options that are not required for the task.
+- Enumerate files with one literal project-relative find command. Example: find pi/extensions/pi-harness -maxdepth 3 -type f -name '*.ts' -print.
+- Enumerate symlinks separately before deciding whether their targets are needed. Example: find pi/extensions -type l -print. Inspect any required known target one path at a time; do not combine target lookup with discovery.
+- Do not append sort, head, or wc solely to reorder, limit, or count inspection output. Inspect the captured output directly and rely on the Bash tool's output limit when a bounded preview is sufficient.
+- Do not use find -exec, find -execdir, or xargs merely for convenience during repository inspection. Enumerate first, inspect the result, and use dedicated tools or separate literal calls for the specific known paths that still matter. If one is genuinely required and no equivalent deterministic-ALLOW form can satisfy the task, apply the scoped fallback below.
 
 - Treat one Bash call as one independently verifiable step by default. Run independent inspections or checks sequentially as separate Bash calls, inspect each result, and only then choose the next command. Do not batch unrelated work with ;, &&, or multiline command blocks merely to reduce tool calls.
 - Avoid >, >>, tee, $(<file), and /tmp intermediates when they only move data for agent-side inspection. Do not write command output merely to read or filter it in a later command.
 - Avoid long jq filters when a read tool or native summary answers the question. If jq is genuinely needed, use a literal filter and a project-relative input file; do not use jq options that load additional files.
 - For long or multiline content passed to a CLI, use a file only when the CLI has a native file-input option. Prefer the write tool and a project-bounded path instead of shell redirection, command substitution, or an ANSI-C-quoted or escaped payload. A data file is not an ad-hoc executable script.
-- Avoid convenience-only eval, sh -c, xargs, generated heredoc or temporary scripts, dynamic command assembly, and ad-hoc package execution through bun x, bunx, npx, or pnpm dlx. Existing package scripts such as bun run test are repository scripts, not this package-runner case.
+- Avoid convenience-only eval, sh -c, generated heredoc or temporary scripts, dynamic command assembly, and ad-hoc package execution through bun x, bunx, npx, or pnpm dlx. Existing package scripts such as bun run test are repository scripts, not this package-runner case.
 - For repository search, prefer rg --no-config with explicit project-internal paths.
 
 Preferred examples:
@@ -24,11 +35,15 @@ Preferred examples:
 - When a multiline bit issue body contains no single quote, keep it in one direct single-quoted --body argument; literal newlines are allowed. For example: bit issue create --title 'Task' --body 'line one
 line two'. Do not synthesize the body with a heredoc, command substitution, or temporary file.
 - Use the read tool for an existing JSON or text file.
-- Use rg --no-config ... | head -200 instead of writing search results and reading them back.
+- Use a direct rg --no-config search or project-relative find instead of piping through head, sort, or wc only for presentation.
 
-If dynamic shell, an ad-hoc script, or a less direct form is genuinely required for correctness or a requested artifact, first state briefly why it is needed and the exact target scope. Describe the command's concrete relationship to the current task instead of merely claiming that it is safe. Do not compress complex work into a fragile one-liner; use the necessary approach when a simpler command shape would reduce correctness or capability.`;
+If no equivalent deterministic-ALLOW form can satisfy the task, first state briefly why it is needed, the exact target scope, and why the safer forms above cannot provide the required result. Then use the narrowest literal command that preserves correctness. Describe the command's concrete relationship to the current task instead of merely claiming that it is safe. Do not compress complex work into a fragile one-liner; use the necessary approach when a simpler command shape would reduce correctness or capability.`;
 
-const appendCommandHygiene = (systemPrompt: string): string =>
-  `${systemPrompt.trimEnd()}\n\n${COMMAND_HYGIENE_GUIDANCE}`;
+const appendCommandHygiene = (systemPrompt: string): string => {
+  const basePrompt = systemPrompt.trimEnd();
+  return basePrompt === ""
+    ? COMMAND_HYGIENE_GUIDANCE
+    : `${basePrompt}\n\n${COMMAND_HYGIENE_GUIDANCE}`;
+};
 
 export { appendCommandHygiene, COMMAND_HYGIENE_GUIDANCE };

--- a/pi/extensions/pi-harness/features/permission-policy/index.ts
+++ b/pi/extensions/pi-harness/features/permission-policy/index.ts
@@ -1,11 +1,21 @@
 import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { InputEvent, PiLike } from "../../lib/pi-like";
 import type { HarnessConfig } from "../../config";
-import type { BashExecutionBoundary } from "../bash-sandbox";
+import type {
+  BashExecutionBoundary,
+  BashScratchBoundary,
+} from "../bash-sandbox";
 import { createPermissionBlocker, type PermissionBlockResult } from "./block";
 import { appendCommandHygiene } from "./command-hygiene";
+import {
+  authorizeCodexStageEscalation,
+  consumeCodexStageCapability,
+  createCodexStageCapabilityRuntime,
+  type CodexStageCapabilityRuntime,
+} from "./codex-stage-capability";
+import type { CodexStageMode } from "../../lib/agent-md";
 import {
   createPermissionTaskTracker,
   derivePermissionRunEvidence,
@@ -154,6 +164,9 @@ interface SetupPermissionPolicyOptions {
   taskTracker?: PermissionTaskTracker;
   permissionAudit?: PermissionAuditIntegration;
   executionBoundary?: (toolName: string) => BashExecutionBoundary | undefined;
+  scratchBoundaryFor?: (toolName: string) => BashScratchBoundary | undefined;
+  codexStageModes?: ReadonlySet<CodexStageMode>;
+  codexStageRuntime?: CodexStageCapabilityRuntime;
 }
 
 const setupPermissionPolicy = (
@@ -168,7 +181,22 @@ const setupPermissionPolicy = (
       ? createPermissionJudge(judgeConfig)
       : undefined;
   const taskTracker = options.taskTracker ?? createPermissionTaskTracker();
-  const { permissionAudit } = options;
+  const consumedCodexStageModes = consumeCodexStageCapability(config.isChild);
+  const codexStageModes = options.codexStageModes ?? consumedCodexStageModes;
+  const { codexStageRuntime: configuredCodexStageRuntime, permissionAudit } =
+    options;
+  let codexStageRuntime = configuredCodexStageRuntime;
+  const codexStageArtifacts = new Map<string, readonly string[]>();
+  if (codexStageRuntime === undefined && codexStageModes.size > 0) {
+    try {
+      codexStageRuntime = createCodexStageCapabilityRuntime(
+        join(config.paths.claudeHooksDir, "lib", "codex-stage.sh"),
+      );
+    } catch {
+      // A missing or unsafe trusted wrapper disables only the capability. The
+      // command still follows the ordinary live-judge escalation path.
+    }
+  }
   const discoverProject =
     options.discoverProject ??
     ((cwd: string, signal?: AbortSignal, leadingCdTarget?: string) =>
@@ -370,9 +398,11 @@ const setupPermissionPolicy = (
           ? []
           : resolveActiveSkillBashAllows(event.prompt, invocation),
     };
-    return typeof event.systemPrompt === "string"
-      ? { systemPrompt: appendCommandHygiene(event.systemPrompt) }
-      : undefined;
+    return {
+      systemPrompt: appendCommandHygiene(
+        typeof event.systemPrompt === "string" ? event.systemPrompt : "",
+      ),
+    };
   });
 
   pi.on("agent_settled", () => {
@@ -380,10 +410,21 @@ const setupPermissionPolicy = (
     clearSkillLifecycle();
   });
 
+  pi.on("tool_result", (event) => {
+    const { toolCallId } = event;
+    if (toolCallId === undefined) return;
+    const artifacts = codexStageArtifacts.get(toolCallId);
+    if (artifacts === undefined) return;
+    codexStageArtifacts.delete(toolCallId);
+    codexStageRuntime?.releaseFiles(artifacts);
+  });
+
   pi.on("session_shutdown", () => {
     taskTracker.clear();
     clearSkillLifecycle();
     judge?.clear();
+    codexStageArtifacts.clear();
+    codexStageRuntime?.dispose();
   });
 
   pi.on("tool_call", async (event, ctx) => {
@@ -791,6 +832,34 @@ const setupPermissionPolicy = (
           );
         }
         if (result.verdict === "allow" && !isEscalated) return undefined;
+      }
+      if (
+        isEscalated &&
+        result.verdict !== "ask" &&
+        ctx.cwd !== undefined &&
+        project !== undefined
+      ) {
+        const authorization = await authorizeCodexStageEscalation(command, {
+          modes: codexStageModes,
+          cwd: ctx.cwd,
+          scratchBoundary: options.scratchBoundaryFor?.(event.toolName),
+          project,
+          runtime: codexStageRuntime,
+        });
+        if (authorization !== undefined) {
+          event.input.command = authorization.command;
+          if (authorization.artifacts.length > 0) {
+            codexStageArtifacts.set(event.toolCallId, authorization.artifacts);
+          }
+          permissionAudit?.addStage(event.toolCallId, {
+            type: "deterministic",
+            phase: "codex-stage-capability",
+            verdict: "allow",
+            basis: "agent-capability",
+            reasonCode: "codex-stage-capability",
+          });
+          return undefined;
+        }
       }
       if (judge === undefined) {
         if (isEscalated) {

--- a/pi/extensions/pi-harness/features/permission-policy/scan.ts
+++ b/pi/extensions/pi-harness/features/permission-policy/scan.ts
@@ -95,6 +95,8 @@ export interface Segment {
   readonly topLevel: boolean;
   /** True only when the shell connector immediately after this segment is &&. */
   readonly followedByAnd: boolean;
+  /** True only when the shell connector immediately after this segment is |. */
+  readonly followedByPipe: boolean;
   /** Concrete pre-normalization command text, when safe for explicit allow. */
   readonly allowCandidate?: string;
 }
@@ -632,7 +634,10 @@ export const scanCommand = (command: string): ScanResult => {
     if (wordAnsiC) ansiC.add(index);
     resetWord();
   };
-  const flushSegment = (followedByAnd = false): void => {
+  const flushSegment = (
+    followedByAnd = false,
+    followedByPipe = false,
+  ): void => {
     flushWord();
     pendingRedirectTarget = false;
     pendingFdDuplicationTarget = false;
@@ -663,6 +668,7 @@ export const scanCommand = (command: string): ScanResult => {
         redirectionTargets,
         topLevel: groupDepth === 0,
         followedByAnd,
+        followedByPipe,
         ...(allowCandidate === undefined ? {} : { allowCandidate }),
       });
     }
@@ -900,7 +906,8 @@ export const scanCommand = (command: string): ScanResult => {
     }
 
     if (c === "|") {
-      flushSegment();
+      const followedByPipe = command[i + 1] !== "|" && command[i + 1] !== "&";
+      flushSegment(false, followedByPipe);
       i += 1;
       if (command[i] === "|" || command[i] === "&") i += 1;
       atWordStart = true;

--- a/pi/extensions/pi-harness/features/subagent/spawn.ts
+++ b/pi/extensions/pi-harness/features/subagent/spawn.ts
@@ -12,6 +12,7 @@ import {
   CHILD_PERMISSION_SIGNAL_ENV,
   formatChildPermissionSignal,
 } from "../permission-policy/block";
+import { CODEX_STAGE_CAPABILITY_ENV } from "../permission-policy/codex-stage-capability";
 
 const PER_TASK_OUTPUT_CAP = 50 * 1024;
 // Parser-protection ceiling: lines beyond this are dropped unparsed. Kept
@@ -277,6 +278,12 @@ const spawnAgent = async (
                 ...options.auditEnv,
                 PI_HARNESS_CHILD: "1",
                 [CHILD_PERMISSION_SIGNAL_ENV]: permissionSignalToken,
+                ...(agent.codexStageModes === undefined
+                  ? {}
+                  : {
+                      [CODEX_STAGE_CAPABILITY_ENV]:
+                        agent.codexStageModes.join(","),
+                    }),
               },
               { cwd: options.cwd },
             ),

--- a/pi/extensions/pi-harness/index.ts
+++ b/pi/extensions/pi-harness/index.ts
@@ -129,6 +129,7 @@ const setupHarness = (
     taskTracker: permissionTaskTracker,
     permissionAudit,
     executionBoundary: (toolName) => bashSandbox.boundaryFor(toolName),
+    scratchBoundaryFor: (toolName) => bashSandbox.scratchBoundaryFor(toolName),
   });
 
   if (bridgeRegistry?.remaining.length) {

--- a/pi/extensions/pi-harness/lib/agent-md.ts
+++ b/pi/extensions/pi-harness/lib/agent-md.ts
@@ -3,15 +3,20 @@
  *
  * Frontmatter is a single-level "key: value" block delimited by "---" lines;
  * the rest of the file is the agent's system prompt. Only name/description
- * are required (the repo's agent files carry no model/tools keys; pi defaults
- * apply when absent).
+ * are required. Optional pi-codex-stage-modes values are a trusted,
+ * harness-specific capability declaration and are rejected fail-closed when
+ * any mode is unknown or duplicated.
  */
+
+export const CODEX_STAGE_MODES = ["prompt", "review", "poc", "run"] as const;
+export type CodexStageMode = (typeof CODEX_STAGE_MODES)[number];
 
 export interface AgentDefinition {
   name: string;
   description: string;
   tools?: string[];
   model?: string;
+  codexStageModes?: CodexStageMode[];
   systemPrompt: string;
 }
 
@@ -64,6 +69,22 @@ export const parseAgentMarkdown = (
   }
   if (fields.model !== undefined && fields.model !== "") {
     definition.model = fields.model;
+  }
+  if (
+    fields["pi-codex-stage-modes"] !== undefined &&
+    fields["pi-codex-stage-modes"] !== ""
+  ) {
+    const modes = fields["pi-codex-stage-modes"]
+      .split(",")
+      .map((mode) => mode.trim());
+    const knownModes = new Set<string>(CODEX_STAGE_MODES);
+    if (
+      modes.some((mode) => !knownModes.has(mode)) ||
+      new Set(modes).size !== modes.length
+    ) {
+      return undefined;
+    }
+    definition.codexStageModes = modes as CodexStageMode[];
   }
   return definition;
 };

--- a/tests/config/plan-review-parity.test.ts
+++ b/tests/config/plan-review-parity.test.ts
@@ -554,7 +554,10 @@ describe("shared Claude/Codex plan-review workflow contract", () => {
       "validated payload substituted as file content, never as shell text",
       "at or below 6 KiB of UTF-8 text",
       "keep the large prompt and all dynamic data out of the Bash command",
-      "printf '%s' 'Read /tmp/codex-reviewer-a1B2C3/prompt.md completely and follow it exactly.'",
+      "pi-codex-stage-modes: prompt,review",
+      'open(path, "wx", 0o600)',
+      '"codex-reviewer-" + randomUUID() + ".md"',
+      "printf '%s' 'Read /PRINTED_PRIVATE_PROMPT_FILE completely and follow it exactly.'",
     ]) {
       expect(normalized).toContain(phrase);
     }

--- a/tests/hooks/claude-harness/codex-stage.test.ts
+++ b/tests/hooks/claude-harness/codex-stage.test.ts
@@ -1,0 +1,300 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import { join, resolve } from "node:path";
+import { cleanupTestDirectory, setupTestDirectory } from "../../test-helpers";
+
+const ROOT = resolve(import.meta.dir, "../../..");
+const WRAPPER = join(ROOT, "claude/.claude/hooks/lib/codex-stage.sh");
+const tempDirectories: string[] = [];
+
+const setupFixture = async () => {
+  const root = await setupTestDirectory("codex-stage-wrapper");
+  tempDirectories.push(root);
+  const target = join(root, "target");
+  const bin = join(root, "bin");
+  const temporaryDirectory = join(root, "tmp");
+  await fs.mkdir(target);
+  await fs.mkdir(bin);
+  await fs.mkdir(temporaryDirectory);
+  await fs.writeFile(
+    join(bin, "codex"),
+    [
+      "#!/bin/bash",
+      "set -euo pipefail",
+      `if [ "${"$"}{1:-} ${"$"}{2:-}" = "login status" ]; then exit 0; fi`,
+      "cat >/dev/null",
+      String.raw`printf 'PWD=%s\n' "$PWD"`,
+      "printf 'ARGS='",
+      "printf ' <%s>' \"$@\"",
+      String.raw`printf '\n'`,
+    ].join("\n"),
+    { mode: 0o700 },
+  );
+  return { root, target, bin, temporaryDirectory };
+};
+
+const directoryPin = async (
+  path: string,
+): Promise<{ path: string; identity: string }> => {
+  const canonicalPath = await fs.realpath(path);
+  const stat = await fs.stat(canonicalPath);
+  return {
+    path: canonicalPath,
+    identity: `${stat.dev}:${stat.ino}`,
+  };
+};
+
+const isProcessAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+};
+
+const waitForProcessExit = async (
+  pid: number,
+  timeoutMs = 2_000,
+): Promise<boolean> => {
+  const deadline = Date.now() + timeoutMs;
+  while (isProcessAlive(pid) && Date.now() < deadline) {
+    await Bun.sleep(20);
+  }
+  return !isProcessAlive(pid);
+};
+
+afterEach(async () => {
+  await Promise.all(tempDirectories.splice(0).map(cleanupTestDirectory));
+});
+
+describe("codex-stage pinned directory execution", () => {
+  test("validates the directory identity and runs Codex from the pinned cwd without -C", async () => {
+    const fixture = await setupFixture();
+    const pin = await directoryPin(fixture.target);
+    const result = Bun.spawnSync(
+      [
+        "bash",
+        WRAPPER,
+        "prompt",
+        "--dir",
+        fixture.target,
+        "--timeout",
+        "10",
+        "--expected-dir-identity",
+        pin.identity,
+        "--expected-dir-path",
+        pin.path,
+      ],
+      {
+        cwd: fixture.root,
+        env: {
+          HOME: fixture.root,
+          PATH: `${fixture.bin}:${process.env.PATH ?? ""}`,
+          TMPDIR: fixture.temporaryDirectory,
+        },
+        stdin: Buffer.from("Return a smoke result."),
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    const stdout = result.stdout.toString();
+    expect(stdout).toContain(`PWD=${pin.path}`);
+    expect(stdout).toContain("<exec> <--sandbox> <read-only>");
+    expect(stdout).not.toContain("<-C>");
+    expect(result.stderr.toString()).toBe("");
+  });
+
+  test("rejects a directory replaced after policy identity capture", async () => {
+    const fixture = await setupFixture();
+    const pin = await directoryPin(fixture.target);
+    await fs.rename(fixture.target, join(fixture.root, "original-target"));
+    await fs.mkdir(fixture.target);
+
+    const result = Bun.spawnSync(
+      [
+        "bash",
+        WRAPPER,
+        "prompt",
+        "--dir",
+        fixture.target,
+        "--timeout",
+        "10",
+        "--expected-dir-identity",
+        pin.identity,
+        "--expected-dir-path",
+        pin.path,
+      ],
+      {
+        cwd: fixture.root,
+        env: {
+          HOME: fixture.root,
+          PATH: `${fixture.bin}:${process.env.PATH ?? ""}`,
+          TMPDIR: fixture.temporaryDirectory,
+        },
+        stdin: Buffer.from("Must not reach Codex."),
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+
+    expect(result.exitCode).toBe(13);
+    expect(result.stdout.toString()).toBe("");
+    expect(result.stderr.toString()).toContain("directory identity changed");
+  });
+
+  test("rejects the same directory inode relocated behind a symlink", async () => {
+    const fixture = await setupFixture();
+    const pin = await directoryPin(fixture.target);
+    const relocatedTarget = join(
+      fixture.temporaryDirectory,
+      "relocated-target",
+    );
+    await fs.rename(fixture.target, relocatedTarget);
+    await fs.symlink(relocatedTarget, fixture.target);
+
+    const result = Bun.spawnSync(
+      [
+        "bash",
+        WRAPPER,
+        "prompt",
+        "--dir",
+        fixture.target,
+        "--timeout",
+        "10",
+        "--expected-dir-identity",
+        pin.identity,
+        "--expected-dir-path",
+        pin.path,
+      ],
+      {
+        cwd: fixture.root,
+        env: {
+          HOME: fixture.root,
+          PATH: `${fixture.bin}:${process.env.PATH ?? ""}`,
+          TMPDIR: fixture.temporaryDirectory,
+        },
+        stdin: Buffer.from("Must not follow the relocated inode."),
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+
+    expect(result.exitCode).toBe(13);
+    expect(result.stdout.toString()).toBe("");
+    expect(result.stderr.toString()).toContain("directory path changed");
+  });
+
+  test("kills a TERM-ignoring Codex grandchild process group on timeout", async () => {
+    const fixture = await setupFixture();
+    const pin = await directoryPin(fixture.target);
+    const grandchildPidFile = join(fixture.root, "grandchild.pid");
+    await fs.writeFile(
+      join(fixture.bin, "codex"),
+      [
+        "#!/bin/bash",
+        "set -euo pipefail",
+        `if [ "${"$"}{1:-} ${"$"}{2:-}" = "login status" ]; then exit 0; fi`,
+        "cat >/dev/null",
+        String.raw`bash -c 'trap "" TERM; printf "%s" "$$" > "$GRANDCHILD_PID_FILE"; while :; do sleep 1; done' &`,
+        "wait",
+      ].join("\n"),
+      { mode: 0o700 },
+    );
+
+    const result = Bun.spawnSync(
+      [
+        "bash",
+        WRAPPER,
+        "prompt",
+        "--dir",
+        fixture.target,
+        "--timeout",
+        "1",
+        "--expected-dir-identity",
+        pin.identity,
+        "--expected-dir-path",
+        pin.path,
+      ],
+      {
+        cwd: fixture.root,
+        env: {
+          GRANDCHILD_PID_FILE: grandchildPidFile,
+          HOME: fixture.root,
+          PATH: `${fixture.bin}:${process.env.PATH ?? ""}`,
+          TMPDIR: fixture.temporaryDirectory,
+        },
+        stdin: Buffer.from("Timeout this run."),
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+
+    expect(result.exitCode).toBe(124);
+    expect(result.stderr.toString()).toContain("codex timed out after 1s");
+    const grandchildPid = Number(await fs.readFile(grandchildPidFile, "utf8"));
+    expect(Number.isSafeInteger(grandchildPid)).toBe(true);
+    const exited = await waitForProcessExit(grandchildPid);
+    if (!exited) process.kill(grandchildPid, "SIGKILL");
+    expect(exited).toBe(true);
+  }, 10_000);
+
+  test("retains the watchdog when the Codex leader exits before its grandchild", async () => {
+    const fixture = await setupFixture();
+    const pin = await directoryPin(fixture.target);
+    const grandchildPidFile = join(fixture.root, "early-exit-grandchild.pid");
+    await fs.writeFile(
+      join(fixture.bin, "codex"),
+      [
+        "#!/bin/bash",
+        "set -euo pipefail",
+        `if [ "${"$"}{1:-} ${"$"}{2:-}" = "login status" ]; then exit 0; fi`,
+        "cat >/dev/null",
+        String.raw`bash -c 'trap "" TERM; printf "%s" "$$" > "$GRANDCHILD_PID_FILE"; while :; do sleep 1; done' &`,
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o700 },
+    );
+    await fs.writeFile(join(fixture.bin, "ps"), "#!/bin/bash\nexit 99\n", {
+      mode: 0o700,
+    });
+
+    const result = Bun.spawnSync(
+      [
+        "bash",
+        WRAPPER,
+        "prompt",
+        "--dir",
+        fixture.target,
+        "--timeout",
+        "1",
+        "--expected-dir-identity",
+        pin.identity,
+        "--expected-dir-path",
+        pin.path,
+      ],
+      {
+        cwd: fixture.root,
+        env: {
+          GRANDCHILD_PID_FILE: grandchildPidFile,
+          HOME: fixture.root,
+          PATH: `${fixture.bin}:${process.env.PATH ?? ""}`,
+          TMPDIR: fixture.temporaryDirectory,
+        },
+        stdin: Buffer.from("Leader exits before timeout."),
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+
+    expect(result.exitCode).toBe(124);
+    expect(result.stderr.toString()).toContain("codex timed out after 1s");
+    const grandchildPid = Number(await fs.readFile(grandchildPidFile, "utf8"));
+    expect(Number.isSafeInteger(grandchildPid)).toBe(true);
+    const exited = await waitForProcessExit(grandchildPid);
+    if (!exited) process.kill(grandchildPid, "SIGKILL");
+    expect(exited).toBe(true);
+  }, 10_000);
+});

--- a/tests/pi-harness/agent-loader.test.ts
+++ b/tests/pi-harness/agent-loader.test.ts
@@ -7,6 +7,11 @@ import {
   type HarnessConfig,
 } from "../../pi/extensions/pi-harness/config";
 import setupPermissionPolicy from "../../pi/extensions/pi-harness/features/permission-policy";
+import {
+  CODEX_STAGE_CAPABILITY_ENV,
+  consumeCodexStageCapability,
+  createCodexStageCapabilityRuntime,
+} from "../../pi/extensions/pi-harness/features/permission-policy/codex-stage-capability";
 import { ChildRunRegistry } from "../../pi/extensions/pi-harness/features/child-runs/registry";
 import type { PermissionAuditIntegration } from "../../pi/extensions/pi-harness/features/permission-audit/index";
 import setupSubagent from "../../pi/extensions/pi-harness/features/subagent/index";
@@ -267,8 +272,20 @@ describe("pi-harness subagent", () => {
         "description: Reviews a change",
         "tools: read, grep",
         "model: openai-codex/gpt-5.4-mini",
+        "pi-codex-stage-modes: prompt,review",
         "---",
         "Review carefully.",
+      ].join("\n"),
+    );
+    await fs.writeFile(
+      join(directory, "invalid-capability.md"),
+      [
+        "---",
+        "name: invalid-capability",
+        "description: Must not load with an unknown privileged mode",
+        "pi-codex-stage-modes: prompt,unknown",
+        "---",
+        "Do not load.",
       ].join("\n"),
     );
     await fs.writeFile(join(directory, "broken.md"), "not frontmatter");
@@ -280,6 +297,7 @@ describe("pi-harness subagent", () => {
         description: "Reviews a change",
         tools: ["read", "grep"],
         model: "openai-codex/gpt-5.4-mini",
+        codexStageModes: ["prompt", "review"],
         systemPrompt: "Review carefully.",
       },
     ]);
@@ -320,6 +338,7 @@ describe("pi-harness subagent", () => {
         "description: Reviews a change",
         "tools: read, grep",
         "model: openai-codex/gpt-5.4-mini",
+        "pi-codex-stage-modes: prompt,review",
         "---",
         "Review carefully.",
       ].join("\n"),
@@ -381,6 +400,7 @@ describe("pi-harness subagent", () => {
     expect(recordedArgs).toContain("openai-codex/gpt-5.4-mini");
     expect(recordedArgs).toContain("read,grep");
     expect(recordedEnv.PI_HARNESS_CHILD).toBe("1");
+    expect(recordedEnv[CODEX_STAGE_CAPABILITY_ENV]).toBe("prompt,review");
     expect(recordedEnv.PI_HARNESS_AUDIT_LINEAGE_ID).toBe(
       "123e4567-e89b-42d3-a456-426614174000",
     );
@@ -631,12 +651,18 @@ describe("pi-harness subagent", () => {
     const agentsDirectory = resolvePaths(home).claudeAgentsDir;
     const wrapperDirectory = join(home, ".claude", "hooks", "lib");
     const wrapperPath = join(wrapperDirectory, "codex-stage.sh");
-    const privatePromptDirectory = join(home, "codex-reviewer-a1B2C3");
-    const promptArtifact = join(privatePromptDirectory, "prompt.md");
+    const sandboxScratch = join(home, "sandbox-scratch");
     const receivedPrompt = join(home, "mock-codex-stdin.txt");
     await fs.mkdir(agentsDirectory, { recursive: true });
     await fs.mkdir(wrapperDirectory, { recursive: true });
-    await fs.mkdir(privatePromptDirectory, { mode: 0o700 });
+    await fs.mkdir(sandboxScratch, { mode: 0o700 });
+    const canonicalScratch = await fs.realpath(sandboxScratch);
+    const scratchStat = await fs.stat(canonicalScratch);
+    const scratchBoundary = {
+      path: canonicalScratch,
+      identity: `${scratchStat.dev}:${scratchStat.ino}`,
+    };
+    const promptArtifact = join(canonicalScratch, "codex-reviewer-a1B2C3.md");
     await fs.copyFile(
       join(import.meta.dir, "../../claude/.claude/agents/codex-reviewer.md"),
       join(agentsDirectory, "codex-reviewer.md"),
@@ -647,16 +673,23 @@ describe("pi-harness subagent", () => {
       [
         "#!/bin/bash",
         "set -euo pipefail",
+        "while [ $# -gt 0 ]; do shift; done",
         'cat > "$MOCK_CODEX_STDIN"',
         String.raw`printf '%s\n' 'mock codex reached'`,
       ].join("\n"),
       { mode: 0o755 },
     );
+    const codexStageRuntime = createCodexStageCapabilityRuntime(wrapperPath, {
+      temporaryDirectory: home,
+    });
 
     let policyDecision: Awaited<
       ReturnType<ReturnType<typeof createFakePi>["emitToolCall"]>
     > = undefined;
     const spawnFn: SpawnFunction = (_command, args, launchOptions) => {
+      expect(launchOptions.env[CODEX_STAGE_CAPABILITY_ENV]).toBe(
+        "prompt,review",
+      );
       const promptFlag = args.indexOf("--append-system-prompt");
       const instructions = readFileSync(args[promptFlag + 1] ?? "", "utf8");
       const wrapperExamples = [
@@ -668,14 +701,14 @@ describe("pi-harness subagent", () => {
       expect(wrapperExamples).not.toContain("<<");
       expect(wrapperExamples).not.toContain('--dir "$PWD"');
       const commandMatch =
-        /```bash\n[ \t]*(printf '%s' 'Read \/tmp\/codex-reviewer-a1B2C3\/prompt\.md completely and follow it exactly\.' \|\n[ \t]+~\/\.claude\/hooks\/lib\/codex-stage\.sh prompt --timeout 600)\n[ \t]*```/.exec(
+        /```bash\n[ \t]*(printf '%s' 'Read \/PRINTED_PRIVATE_PROMPT_FILE completely and follow it exactly\.' \|\n[ \t]+~\/\.claude\/hooks\/lib\/codex-stage\.sh prompt --timeout 600)\n[ \t]*```/.exec(
           instructions,
         );
       if (commandMatch?.[1] === undefined) {
         throw new Error("documented default-cwd reviewer pipeline not found");
       }
       const documentedCommand = commandMatch[1].replaceAll(
-        "/tmp/codex-reviewer-a1B2C3/prompt.md",
+        "/PRINTED_PRIVATE_PROMPT_FILE",
         promptArtifact,
       );
       const controller = createFakeProcess();
@@ -698,17 +731,37 @@ describe("pi-harness subagent", () => {
                 },
               },
               {
+                codexStageModes: consumeCodexStageCapability(true, {
+                  ...launchOptions.env,
+                }),
+                codexStageRuntime,
+                discoverProject: async () => ({
+                  kind: "git",
+                  cwd: home,
+                  activeWorktree: home,
+                  navigableRoots: [home],
+                  worktrees: [home],
+                  fingerprint: `project:${home}`,
+                }),
+                executionBoundary: (toolName) => ({
+                  mode:
+                    toolName === "bash_escalated" ? "escalated" : "sandboxed",
+                  network: "denied",
+                  profileFingerprint: "c".repeat(64),
+                }),
+                scratchBoundaryFor: () => scratchBoundary,
                 permissionSignalToken:
                   launchOptions.env[CHILD_PERMISSION_SIGNAL_ENV],
                 writePermissionSignal: (text) => controller.emitStderr(text),
               },
             );
-            policyDecision = await childPi.emitToolCall({
-              type: "tool_call",
-              toolName: "bash",
+            const toolCall = {
+              type: "tool_call" as const,
+              toolName: "bash_escalated",
               toolCallId: "codex-reviewer-pipeline",
               input: { command: documentedCommand },
-            });
+            };
+            policyDecision = await childPi.emitToolCall(toolCall);
             if (policyDecision !== undefined) {
               controller.emitStdout(
                 assistantEvent(`blocked: ${policyDecision.reason}`),
@@ -717,16 +770,19 @@ describe("pi-harness subagent", () => {
               return;
             }
 
-            const executed = Bun.spawnSync(["bash", "-c", documentedCommand], {
-              cwd: home,
-              env: {
-                ...launchOptions.env,
-                HOME: home,
-                MOCK_CODEX_STDIN: receivedPrompt,
+            const executed = Bun.spawnSync(
+              ["bash", "-c", toolCall.input.command],
+              {
+                cwd: home,
+                env: {
+                  ...launchOptions.env,
+                  HOME: home,
+                  MOCK_CODEX_STDIN: receivedPrompt,
+                },
+                stdout: "pipe",
+                stderr: "pipe",
               },
-              stdout: "pipe",
-              stderr: "pipe",
-            });
+            );
             const stderr = Buffer.from(executed.stderr).toString("utf8");
             if (stderr !== "") controller.emitStderr(stderr);
             controller.emitStdout(
@@ -763,9 +819,10 @@ describe("pi-harness subagent", () => {
     expect(result.permissionBlocked).toBeUndefined();
     expect(result.failed).toBe(false);
     expect(result.output).toContain("mock codex reached");
-    expect(await fs.readFile(receivedPrompt, "utf8")).toBe(
-      `Read ${promptArtifact} completely and follow it exactly.`,
+    expect(await fs.readFile(receivedPrompt, "utf8")).toMatch(
+      /^Read \/.*\/pi-codex-stage-artifact-.*\/prompt\.md completely and follow it exactly\.$/,
     );
+    codexStageRuntime.dispose();
   });
 
   test("treats a child permission block as failure even when pi exits zero", async () => {

--- a/tests/pi-harness/bash-sandbox.test.ts
+++ b/tests/pi-harness/bash-sandbox.test.ts
@@ -9,6 +9,7 @@ import {
   type SandboxManagerLike,
 } from "../../pi/extensions/pi-harness/features/bash-sandbox";
 import {
+  BASH_SANDBOX_PROJECT_DISCOVERY_TIMEOUT_MS,
   buildBashSandboxProfile,
   type BashSandboxProfile,
 } from "../../pi/extensions/pi-harness/features/bash-sandbox/profile";
@@ -138,6 +139,10 @@ const setup = (
     makeTempDirectory: async () => "/private/scratch",
     chmodPath: async () => {},
     accessPath: async () => {},
+    pinScratchDirectory: async (path) => ({
+      path,
+      identity: "10:20",
+    }),
     removePath: async (path) => {
       removed.push(path);
     },
@@ -164,6 +169,8 @@ describe("Bash sandbox profile", () => {
   test("allows only the active worktree, verified Git metadata, scratch, and trusted additions", async () => {
     const sandboxConfig = structuredClone(DEFAULT_BASH_SANDBOX_CONFIG);
     sandboxConfig.filesystem.allowWrite.push("~/trusted-output");
+    let discoveryTimeoutMs: number | undefined;
+    let commonDirectoryTimeoutMs: number | undefined;
     const result = await buildBashSandboxProfile(
       "/repo/active/subdir",
       "/private/scratch",
@@ -172,19 +179,29 @@ describe("Bash sandbox profile", () => {
       {
         home: "/home/test",
         canonicalize: async () => "/repo/active/subdir",
-        discoverProject: async () => ({
-          kind: "git",
-          name: "repo",
-          cwd: "/repo/active/subdir",
-          activeWorktree: "/repo/active",
-          navigableRoots: ["/repo/active", "/repo/other-worktree"],
-          worktrees: ["/repo/active", "/repo/other-worktree"],
-          fingerprint: "project-fingerprint",
-        }),
-        discoverGitCommonDir: async () => "/repo/common.git",
+        discoverProject: async (_cwd, options) => {
+          discoveryTimeoutMs = options?.timeoutMs;
+          return {
+            kind: "git",
+            name: "repo",
+            cwd: "/repo/active/subdir",
+            activeWorktree: "/repo/active",
+            navigableRoots: ["/repo/active", "/repo/other-worktree"],
+            worktrees: ["/repo/active", "/repo/other-worktree"],
+            fingerprint: "project-fingerprint",
+          };
+        },
+        discoverGitCommonDir: async (_cwd, _signal, options) => {
+          commonDirectoryTimeoutMs = options?.timeoutMs;
+          return "/repo/common.git";
+        },
       },
     );
 
+    expect(discoveryTimeoutMs).toBe(BASH_SANDBOX_PROJECT_DISCOVERY_TIMEOUT_MS);
+    expect(commonDirectoryTimeoutMs).toBe(
+      BASH_SANDBOX_PROJECT_DISCOVERY_TIMEOUT_MS,
+    );
     expect(result.writableRoots).toEqual([
       "/repo/active",
       "/repo/common.git",
@@ -267,6 +284,13 @@ describe("Bash effect sandbox lifecycle", () => {
       mode: "sandboxed",
       network: "denied",
       profileFingerprint: "a".repeat(64),
+    });
+    expect(runtime.controller.scratchDirectoryFor("bash_escalated")).toBe(
+      "/private/scratch",
+    );
+    expect(runtime.controller.scratchBoundaryFor("bash_escalated")).toEqual({
+      path: "/private/scratch",
+      identity: "10:20",
     });
     expect(runtime.pi.tools.map((tool) => tool.name)).toContain(
       "bash_escalated",
@@ -509,6 +533,7 @@ describe("controlled Bash launcher", () => {
         BASH_ENV: "/tmp/startup.sh",
         DYLD_INSERT_LIBRARIES: "/tmp/inject.dylib",
         GIT_CONFIG_GLOBAL: "/tmp/gitconfig",
+        PI_HARNESS_CODEX_STAGE_CAPABILITY: "prompt,review",
         GH_TOKEN: "secret",
         OPENAI_API_KEY: "secret",
         HTTPS_PROXY: "http://user:pass@example.test",
@@ -535,6 +560,7 @@ describe("controlled Bash launcher", () => {
       "BASH_ENV",
       "DYLD_INSERT_LIBRARIES",
       "GIT_CONFIG_GLOBAL",
+      "PI_HARNESS_CODEX_STAGE_CAPABILITY",
       "GH_TOKEN",
       "OPENAI_API_KEY",
       "HTTPS_PROXY",

--- a/tests/pi-harness/github-cli-reminder.test.ts
+++ b/tests/pi-harness/github-cli-reminder.test.ts
@@ -6,6 +6,7 @@ import setupGitHubCliReminder, {
   GITHUB_CLI_REMINDER,
   GITHUB_CLI_REMINDER_TYPE,
 } from "../../pi/extensions/pi-harness/features/github-cli-reminder/index";
+import { COMMAND_HYGIENE_GUIDANCE } from "../../pi/extensions/pi-harness/features/permission-policy/command-hygiene";
 import setupHookBridge from "../../pi/extensions/pi-harness/features/hook-bridge/index";
 import type { BridgeHookSpec } from "../../pi/extensions/pi-harness/features/hook-bridge/registry";
 import { setupHarness } from "../../pi/extensions/pi-harness/index";
@@ -147,12 +148,12 @@ describe("pi-harness GitHub CLI reminder", () => {
 
     const child = createFakePi({ cwd: directory, hasUI: false });
     setupHarness(child, makeConfig(directory, true));
-    expect(
-      await child.emitBeforeAgentStart({
-        type: "before_agent_start",
-        prompt: "inspect GitHub",
-      }),
-    ).toBeUndefined();
+    const childInjection = await child.emitBeforeAgentStart({
+      type: "before_agent_start",
+      prompt: "inspect GitHub",
+    });
+    expect(childInjection?.message).toBeUndefined();
+    expect(childInjection?.systemPrompt).toBe(COMMAND_HYGIENE_GUIDANCE);
   });
 
   test("coexists with a hook-bridge before_agent_start message", async () => {

--- a/tests/pi-harness/permission-ask-reminder.test.ts
+++ b/tests/pi-harness/permission-ask-reminder.test.ts
@@ -47,6 +47,11 @@ const setupReminderHarness = (
         network: "denied",
         profileFingerprint: "e".repeat(64),
       }),
+      scratchDirectoryFor: () => "/private/scratch",
+      scratchBoundaryFor: () => ({
+        path: "/private/scratch",
+        identity: "10:20",
+      }),
       registerExecutionBoundary() {},
     }),
   });

--- a/tests/pi-harness/permission-command-hygiene.test.ts
+++ b/tests/pi-harness/permission-command-hygiene.test.ts
@@ -25,11 +25,17 @@ const makeConfig = (isChild: boolean): HarnessConfig => ({
 });
 
 describe("permission command hygiene prompt", () => {
-  test("states a soft priority order with an explicit capability escape hatch", () => {
+  test("requires deterministic-ALLOW forms before confirmation-prone equivalents", () => {
     const prompt = appendCommandHygiene("BASE SYSTEM PROMPT\n");
 
     expect(prompt).toStartWith("BASE SYSTEM PROMPT\n\n");
-    expect(prompt).toContain("preference, not a hard constraint");
+    expect(prompt).toContain("ALLOW-first command selection");
+    expect(prompt).toContain(
+      "use the form expected to receive a deterministic ALLOW",
+    );
+    expect(prompt).toContain(
+      "Do not use ASK or user confirmation as a convenience path",
+    );
     expect(prompt).toContain("already captures stdout and stderr");
     expect(prompt).toContain(
       "Do not create a temporary file merely to inspect, filter, summarize",
@@ -78,13 +84,59 @@ describe("permission command hygiene prompt", () => {
     expect(prompt).toContain(
       "Do not synthesize the body with a heredoc, command substitution, or temporary file",
     );
-    expect(prompt).toContain("rg --no-config ... | head -200");
+    expect(prompt).toContain(
+      "rg --no-config -n 'sandbox|judge' pi/extensions/pi-harness",
+    );
+    expect(prompt).toContain(
+      "find pi/extensions/pi-harness -maxdepth 3 -type f -name '*.ts' -print",
+    );
+    expect(prompt).toContain("find pi/extensions -type l -print");
+    expect(prompt).toContain(
+      "Do not append sort, head, or wc solely to reorder, limit, or count inspection output",
+    );
+    expect(prompt).toContain(
+      "Do not use find -exec, find -execdir, or xargs merely for convenience during repository inspection",
+    );
+    expect(prompt).toContain(
+      "If one is genuinely required and no equivalent deterministic-ALLOW form can satisfy the task",
+    );
+    expect(COMMAND_HYGIENE_GUIDANCE).not.toContain("Never use find -exec");
+    expect(prompt).toContain(
+      "If no equivalent deterministic-ALLOW form can satisfy the task",
+    );
     expect(prompt).toContain("first state briefly why it is needed");
     expect(prompt).toContain("instead of merely claiming that it is safe");
     expect(prompt).toContain(
       "Do not compress complex work into a fragile one-liner",
     );
     expect(COMMAND_HYGIENE_GUIDANCE).not.toContain("never use Bash");
+  });
+
+  test("appends cleanly when the base system prompt is empty", () => {
+    expect(appendCommandHygiene("")).toBe(COMMAND_HYGIENE_GUIDANCE);
+  });
+
+  test("is reinjected into the system prompt on every agent start", async () => {
+    const pi = createFakePi();
+    setupPermissionPolicy(pi, makeConfig(false));
+
+    for (const prompt of ["Inspect files", "Continue the long task"]) {
+      const result = await pi.emitBeforeAgentStart({
+        type: "before_agent_start",
+        prompt,
+        systemPrompt: "BASE SYSTEM PROMPT",
+      });
+
+      expect(result?.message).toBeUndefined();
+      expect(result?.systemPrompt).toEndWith(COMMAND_HYGIENE_GUIDANCE);
+    }
+
+    const missingBase = await pi.emitBeforeAgentStart({
+      type: "before_agent_start",
+      prompt: "Start without a base prompt",
+    });
+    expect(missingBase?.message).toBeUndefined();
+    expect(missingBase?.systemPrompt).toBe(COMMAND_HYGIENE_GUIDANCE);
   });
 
   test.each([false, true])(

--- a/tests/pi-harness/permission-judge-policy.test.ts
+++ b/tests/pi-harness/permission-judge-policy.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { resolve } from "node:path";
+import { promises as fs } from "node:fs";
+import { join, resolve } from "node:path";
 import {
   DEFAULT_PERMISSION_JUDGE_CONFIG,
   type HarnessConfig,
@@ -12,14 +13,26 @@ import {
   CHILD_PERMISSION_SIGNAL_ENV,
   formatChildPermissionSignal,
 } from "../../pi/extensions/pi-harness/features/permission-policy/block";
+import {
+  CODEX_STAGE_CAPABILITY_ENV,
+  consumeCodexStageCapability,
+  createCodexStageCapabilityRuntime,
+  type CodexStageCapabilityRuntime,
+} from "../../pi/extensions/pi-harness/features/permission-policy/codex-stage-capability";
 import type { PermissionProjectContext } from "../../pi/extensions/pi-harness/features/permission-policy/context";
 import { loadRules } from "../../pi/extensions/pi-harness/features/permission-policy/rules";
 import { resolvePaths } from "../../pi/extensions/pi-harness/lib/paths";
 import type { ToolCallEvent } from "../../pi/extensions/pi-harness/lib/pi-like";
-import { startMockUpstream, type MockUpstream } from "../test-helpers";
+import {
+  cleanupTestDirectory,
+  setupTestDirectory,
+  startMockUpstream,
+  type MockUpstream,
+} from "../test-helpers";
 import { createFakePi } from "./fake-pi";
 
 const upstreams: MockUpstream[] = [];
+const tempDirectories: string[] = [];
 
 const start = async (
   chatHandler: Parameters<typeof startMockUpstream>[0],
@@ -50,6 +63,7 @@ const chatRequests = (upstream: MockUpstream) =>
 
 afterEach(async () => {
   await Promise.all(upstreams.splice(0).map((upstream) => upstream.close()));
+  await Promise.all(tempDirectories.splice(0).map(cleanupTestDirectory));
 });
 
 const ollamaResponse = (verdict: string): Response =>
@@ -147,6 +161,26 @@ const verifiedGitCwdProject = (cwd: string): PermissionProjectContext => ({
     sameRepository: true,
   },
 });
+
+const makeCodexStageRuntime =
+  async (): Promise<CodexStageCapabilityRuntime> => {
+    const directory = await setupTestDirectory("codex-stage-runtime");
+    tempDirectories.push(directory);
+    const source = join(directory, "codex-stage-source.sh");
+    await fs.writeFile(source, "#!/bin/bash\ncat\n", { mode: 0o700 });
+    return createCodexStageCapabilityRuntime(source, {
+      temporaryDirectory: directory,
+    });
+  };
+
+const makeScratchBoundary = async (path: string) => {
+  const canonicalPath = await fs.realpath(path);
+  const stat = await fs.stat(canonicalPath);
+  return {
+    path: canonicalPath,
+    identity: `${stat.dev}:${stat.ino}`,
+  };
+};
 
 const createTestAbortController = (): {
   signal: AbortSignal;
@@ -841,6 +875,374 @@ describe("permission policy local judge routing", () => {
       ).toEqual({ block: true, reason: expect.any(String) });
     }
     expect(upstream.received).toHaveLength(0);
+  });
+
+  test("consumes child codex-stage modes once and rejects untrusted values", () => {
+    const childEnv: NodeJS.ProcessEnv = {
+      [CODEX_STAGE_CAPABILITY_ENV]: "prompt,review",
+    };
+    expect(consumeCodexStageCapability(true, childEnv)).toEqual(
+      new Set(["prompt", "review"]),
+    );
+    expect(childEnv[CODEX_STAGE_CAPABILITY_ENV]).toBeUndefined();
+    expect(consumeCodexStageCapability(true, childEnv)).toEqual(new Set());
+
+    const parentEnv: NodeJS.ProcessEnv = {
+      [CODEX_STAGE_CAPABILITY_ENV]: "poc",
+    };
+    expect(consumeCodexStageCapability(false, parentEnv)).toEqual(new Set());
+    expect(parentEnv[CODEX_STAGE_CAPABILITY_ENV]).toBeUndefined();
+
+    const malformedEnv: NodeJS.ProcessEnv = {
+      [CODEX_STAGE_CAPABILITY_ENV]: "prompt,unknown",
+    };
+    expect(consumeCodexStageCapability(true, malformedEnv)).toEqual(new Set());
+    expect(malformedEnv[CODEX_STAGE_CAPABILITY_ENV]).toBeUndefined();
+  });
+
+  test("pins the trusted wrapper and staged artifacts into non-writable private copies", async () => {
+    const scratch = await setupTestDirectory("codex-stage-runtime-scratch");
+    tempDirectories.push(scratch);
+    const scratchBoundary = await makeScratchBoundary(scratch);
+    const prompt = join(scratchBoundary.path, "prompt.md");
+    await fs.writeFile(prompt, "private staged prompt");
+    const runtime = await makeCodexStageRuntime();
+
+    const staged = await runtime.stageFile(
+      prompt,
+      scratchBoundary,
+      "prompt.md",
+    );
+    expect(staged).toBeDefined();
+    if (staged === undefined) throw new Error("expected staged prompt copy");
+    expect(staged.startsWith(scratch)).toBe(false);
+    expect(await fs.readFile(staged, "utf8")).toBe("private staged prompt");
+    const stagedStat = await fs.stat(staged);
+    const { executablePath } = runtime;
+    const executableStat = await fs.stat(executablePath);
+    expect(stagedStat.mode & 0o222).toBe(0);
+    expect(executableStat.mode & 0o222).toBe(0);
+
+    const outsideDirectory = await setupTestDirectory(
+      "codex-stage-runtime-outside",
+    );
+    tempDirectories.push(outsideDirectory);
+    const outside = join(outsideDirectory, "outside-prompt.md");
+    await fs.writeFile(outside, "outside");
+    const symlink = join(scratchBoundary.path, "symlink.md");
+    await fs.symlink(outside, symlink);
+    expect(
+      await runtime.stageFile(symlink, scratchBoundary, "prompt.md"),
+    ).toBeUndefined();
+    const nestedDirectory = join(scratchBoundary.path, "nested");
+    await fs.mkdir(nestedDirectory);
+    const nestedPrompt = join(nestedDirectory, "prompt.md");
+    await fs.writeFile(nestedPrompt, "nested prompt");
+    expect(
+      await runtime.stageFile(nestedPrompt, scratchBoundary, "prompt.md"),
+    ).toBeUndefined();
+    const fifo = join(scratchBoundary.path, "prompt.fifo");
+    const mkfifo = Bun.spawnSync(["mkfifo", fifo]);
+    expect(mkfifo.exitCode).toBe(0);
+    const fifoStage = await Promise.race([
+      runtime.stageFile(fifo, scratchBoundary, "prompt.md"),
+      Bun.sleep(1_000).then(() => "timed out" as const),
+    ]);
+    expect(fifoStage).toBeUndefined();
+
+    const originalScratch = `${scratchBoundary.path}-original`;
+    await fs.rename(scratchBoundary.path, originalScratch);
+    await fs.symlink(outsideDirectory, scratchBoundary.path);
+    expect(
+      await runtime.stageFile(
+        join(scratchBoundary.path, "outside-prompt.md"),
+        scratchBoundary,
+        "prompt.md",
+      ),
+    ).toBeUndefined();
+    await fs.rm(scratchBoundary.path);
+    await fs.rename(originalScratch, scratchBoundary.path);
+
+    runtime.dispose();
+    await expect(fs.access(staged)).rejects.toThrow();
+    await expect(fs.access(executablePath)).rejects.toThrow();
+  });
+
+  test("reserves aggregate staging capacity before concurrent reads and cleans disposal races", async () => {
+    const scratch = await setupTestDirectory("codex-stage-runtime-cap");
+    tempDirectories.push(scratch);
+    const scratchBoundary = await makeScratchBoundary(scratch);
+    const runtime = await makeCodexStageRuntime();
+    const sources: string[] = [];
+    for (let index = 0; index < 5; index += 1) {
+      const source = join(scratchBoundary.path, `prompt-${index}.md`);
+      await fs.writeFile(source, Buffer.alloc(8 * 1024 * 1024, index));
+      sources.push(source);
+    }
+
+    const staged = await Promise.all(
+      sources.map((source) =>
+        runtime.stageFile(source, scratchBoundary, "prompt.md"),
+      ),
+    );
+    expect(staged.filter((path) => path !== undefined)).toHaveLength(4);
+    expect(staged.filter((path) => path === undefined)).toHaveLength(1);
+    runtime.dispose();
+
+    const disposingRuntime = await makeCodexStageRuntime();
+    const pending = disposingRuntime.stageFile(
+      sources[0] ?? "",
+      scratchBoundary,
+      "prompt.md",
+    );
+    const runtimeRoot = resolve(disposingRuntime.executablePath, "../..");
+    disposingRuntime.dispose();
+    expect(await pending).toBeUndefined();
+    const runtimeEntries = await fs.readdir(runtimeRoot);
+    expect(
+      runtimeEntries.filter((entry) =>
+        entry.startsWith("pi-codex-stage-artifact-"),
+      ),
+    ).toEqual([]);
+  });
+
+  test("allows only an agent-declared path-validated codex-stage escalation without the judge", async () => {
+    const upstream = await start(() => ollamaResponse("ASK"));
+    const cwd = await setupTestDirectory("codex-stage-capability");
+    tempDirectories.push(cwd);
+    const scratch = join(cwd, "sandbox-scratch");
+    await fs.mkdir(scratch, { recursive: true });
+    const scratchBoundary = await makeScratchBoundary(scratch);
+    const prompt = join(scratchBoundary.path, "codex-reviewer-a1B2C3.md");
+    await fs.writeFile(prompt, "Review the assigned artifact.");
+    const runtime = await makeCodexStageRuntime();
+
+    const pi = createFakePi({ cwd, hasUI: false });
+    setupPermissionPolicy(pi, makeConfig(judgeConfig(upstream), true), {
+      codexStageModes: new Set(["prompt", "review"]),
+      discoverProject: async () => verifiedProject(cwd),
+      executionBoundary,
+      scratchBoundaryFor: () => scratchBoundary,
+      codexStageRuntime: runtime,
+      permissionSignalToken: "123e4567-e89b-42d3-a456-426614174000",
+      writePermissionSignal: () => {},
+    });
+
+    const command = [
+      `printf '%s' 'Read ${prompt} completely and follow it exactly.' |`,
+      "  ~/.claude/hooks/lib/codex-stage.sh prompt --timeout 600",
+    ].join("\n");
+    const promptCall = escalatedCall(command, "codex-stage-capability");
+    expect(await pi.emitToolCall(promptCall)).toBeUndefined();
+    expect(promptCall.input.command).toContain(runtime.executablePath);
+    expect(promptCall.input.command).toContain("--expected-dir-identity");
+    expect(promptCall.input.command).toContain("--expected-dir-path");
+    expect(promptCall.input.command).not.toContain(
+      "~/.claude/hooks/lib/codex-stage.sh",
+    );
+    expect(promptCall.input.command).not.toContain(prompt);
+    const privatePromptMatch = /Read ([^ ]+) completely/.exec(
+      String(promptCall.input.command),
+    );
+    const privatePrompt = privatePromptMatch?.[1];
+    if (privatePrompt === undefined) {
+      throw new Error("rewritten private prompt path was not found");
+    }
+    await fs.access(privatePrompt);
+    await pi.emitToolResult({
+      type: "tool_result",
+      toolName: "bash_escalated",
+      toolCallId: "codex-stage-capability",
+      content: [],
+      isError: false,
+    });
+    await expect(fs.access(privatePrompt)).rejects.toThrow();
+
+    const reviewCall = escalatedCall(
+      `~/.claude/hooks/lib/codex-stage.sh review --uncommitted --dir '${cwd}' --timeout 600`,
+      "codex-stage-review-capability",
+    );
+    expect(await pi.emitToolCall(reviewCall)).toBeUndefined();
+    expect(reviewCall.input.command).toContain(runtime.executablePath);
+    expect(reviewCall.input.command).toContain("--expected-dir-identity");
+    expect(reviewCall.input.command).toContain("--expected-dir-path");
+
+    for (const [mode, wrapper] of [
+      [
+        "poc",
+        `~/.claude/hooks/lib/codex-stage.sh poc --worktree '${cwd}' --network --timeout 600`,
+      ],
+      [
+        "run",
+        `~/.claude/hooks/lib/codex-stage.sh run --dir '${cwd}' --network --timeout 600`,
+      ],
+    ] as const) {
+      const workerPi = createFakePi({ cwd, hasUI: false });
+      setupPermissionPolicy(workerPi, makeConfig(judgeConfig(upstream), true), {
+        codexStageModes: new Set([mode]),
+        discoverProject: async () => verifiedProject(cwd),
+        executionBoundary,
+        scratchBoundaryFor: () => scratchBoundary,
+        codexStageRuntime: runtime,
+        permissionSignalToken: "123e4567-e89b-42d3-a456-426614174000",
+        writePermissionSignal: () => {},
+      });
+      const workerCommand = [
+        `printf '%s' 'Read ${prompt} completely and follow it exactly.' |`,
+        `  ${wrapper}`,
+      ].join("\n");
+      expect(
+        await workerPi.emitToolCall(
+          escalatedCall(workerCommand, `codex-stage-${mode}-capability`),
+        ),
+      ).toBeUndefined();
+    }
+    expect(upstream.received).toHaveLength(0);
+    runtime.dispose();
+  });
+
+  test("keeps malformed, over-broad, and mode-mismatched codex-stage calls on the live judge route", async () => {
+    const upstream = await start(() => ollamaResponse("ASK"));
+    const cwd = await setupTestDirectory("codex-stage-holdouts");
+    tempDirectories.push(cwd);
+    const scratch = join(cwd, "sandbox-scratch");
+    const outsidePrompt = join(cwd, "outside-prompt.md");
+    await fs.mkdir(scratch, { recursive: true });
+    const scratchBoundary = await makeScratchBoundary(scratch);
+    const prompt = join(scratchBoundary.path, "codex-reviewer-a1B2C3.md");
+    await fs.writeFile(prompt, "Review the assigned artifact.");
+    await fs.writeFile(outsidePrompt, "Must not cross the staging boundary.");
+    const runtime = await makeCodexStageRuntime();
+
+    const pi = createFakePi({ cwd, hasUI: false });
+    setupPermissionPolicy(pi, makeConfig(judgeConfig(upstream), true), {
+      codexStageModes: new Set(["prompt", "review"]),
+      discoverProject: async () => verifiedProject(cwd),
+      executionBoundary,
+      scratchBoundaryFor: () => scratchBoundary,
+      codexStageRuntime: runtime,
+      permissionSignalToken: "123e4567-e89b-42d3-a456-426614174000",
+      writePermissionSignal: () => {},
+    });
+
+    const commands = [
+      `printf '%s' 'Read ${outsidePrompt} completely and follow it exactly.' | ~/.claude/hooks/lib/codex-stage.sh prompt --timeout 600`,
+      `printf '%s' 'Read ${prompt} completely and follow it exactly.' | ~/.claude/hooks/lib/codex-stage.sh poc --worktree '${cwd}' --timeout 600`,
+      `~/.claude/hooks/lib/codex-stage.sh review --uncommitted --dir '${cwd}' --out '${join(scratch, "review.md")}' --timeout 600`,
+      `printf '%s' 'Read ${prompt} completely and follow it exactly.' ; ~/.claude/hooks/lib/codex-stage.sh prompt --timeout 600`,
+      `printf '%s' 'Read ${prompt} completely and follow it exactly.' && ~/.claude/hooks/lib/codex-stage.sh prompt --timeout 600`,
+      `printf '%s' 'Read ${prompt} completely and follow it exactly.' |& ~/.claude/hooks/lib/codex-stage.sh prompt --timeout 600`,
+      `printf '%s' 'Read ${prompt} completely and follow it exactly.' | /tmp/codex-stage.sh prompt --timeout 600`,
+      `'~/.claude/hooks/lib/codex-stage.sh' review --uncommitted --dir '${cwd}'`,
+      `"~/.claude/hooks/lib/codex-stage.sh" review --uncommitted --dir '${cwd}'`,
+      String.raw`\~/.claude/hooks/lib/codex-stage.sh review --uncommitted --dir '${cwd}'`,
+      `~/.claude/hooks/lib/codex-stage.sh review --uncommitted --dir '${cwd}' |`,
+      "bun test",
+    ];
+    for (const [index, command] of commands.entries()) {
+      expect(
+        await pi.emitToolCall(
+          escalatedCall(command, `codex-stage-holdout-${index}`),
+        ),
+      ).toEqual({
+        block: true,
+        reason: "local judge requested user confirmation",
+      });
+    }
+    expect(chatRequests(upstream)).toHaveLength(commands.length);
+
+    const outsideDirectory = await setupTestDirectory("codex-stage-outside");
+    tempDirectories.push(outsideDirectory);
+    const allModesPi = createFakePi({ cwd, hasUI: false });
+    setupPermissionPolicy(allModesPi, makeConfig(judgeConfig(upstream), true), {
+      codexStageModes: new Set(["prompt", "review", "poc", "run"]),
+      discoverProject: async () => verifiedProject(cwd),
+      executionBoundary,
+      scratchBoundaryFor: () => scratchBoundary,
+      codexStageRuntime: runtime,
+      permissionSignalToken: "123e4567-e89b-42d3-a456-426614174000",
+      writePermissionSignal: () => {},
+    });
+    for (const [index, wrapper] of [
+      `~/.claude/hooks/lib/codex-stage.sh poc --worktree '${scratch}' --timeout 600`,
+      `~/.claude/hooks/lib/codex-stage.sh run --dir '${outsideDirectory}' --timeout 600`,
+    ].entries()) {
+      const command = `printf '%s' 'Read ${prompt} completely and follow it exactly.' | ${wrapper}`;
+      expect(
+        await allModesPi.emitToolCall(
+          escalatedCall(command, `codex-stage-path-holdout-${index}`),
+        ),
+      ).toEqual({
+        block: true,
+        reason: "local judge requested user confirmation",
+      });
+    }
+    expect(chatRequests(upstream)).toHaveLength(commands.length + 2);
+    runtime.dispose();
+  });
+
+  test("keeps configured ASK and DENY above the codex-stage capability", async () => {
+    const upstream = await start(() => ollamaResponse("ASK"));
+    const cwd = await setupTestDirectory("codex-stage-policy-floor");
+    tempDirectories.push(cwd);
+    const runtime = await makeCodexStageRuntime();
+    const command = `~/.claude/hooks/lib/codex-stage.sh review --uncommitted --dir '${cwd}'`;
+    const baseOptions = {
+      codexStageModes: new Set(["review"] as const),
+      discoverProject: async () => verifiedProject(cwd),
+      executionBoundary,
+      codexStageRuntime: runtime,
+      permissionSignalToken: "123e4567-e89b-42d3-a456-426614174000",
+      writePermissionSignal: () => {},
+    };
+
+    const askPi = createFakePi({ cwd, hasUI: false });
+    setupPermissionPolicy(askPi, makeConfig(judgeConfig(upstream), true), {
+      ...baseOptions,
+      rules: loadRules(
+        JSON.stringify({
+          deny: [],
+          allow: [],
+          ask: [
+            {
+              pattern: "^codex-stage\\.sh(?: |(?![\\s\\S]))",
+              reason: "configured codex-stage confirmation",
+            },
+          ],
+        }),
+      ),
+    });
+    expect(
+      await askPi.emitToolCall(escalatedCall(command, "codex-stage-ask-floor")),
+    ).toEqual({
+      block: true,
+      reason: "local judge requested user confirmation",
+    });
+    expect(chatRequests(upstream)).toHaveLength(1);
+
+    const denyPi = createFakePi({ cwd, hasUI: false });
+    setupPermissionPolicy(denyPi, makeConfig(judgeConfig(upstream), true), {
+      ...baseOptions,
+      rules: loadRules(
+        JSON.stringify({
+          deny: [
+            {
+              pattern: "^codex-stage\\.sh(?: |(?![\\s\\S]))",
+              reason: "configured codex-stage denial",
+            },
+          ],
+          allow: [],
+          ask: [],
+        }),
+      ),
+    });
+    expect(
+      await denyPi.emitToolCall(
+        escalatedCall(command, "codex-stage-deny-floor"),
+      ),
+    ).toEqual({ block: true, reason: expect.any(String) });
+    expect(chatRequests(upstream)).toHaveLength(1);
+    runtime.dispose();
   });
 
   test("requires a fresh live judge ALLOW for every escalated call", async () => {

--- a/tests/pi-harness/permission-rules.test.ts
+++ b/tests/pi-harness/permission-rules.test.ts
@@ -784,7 +784,7 @@ describe("explicit allow matching", () => {
 
   test("allows the documented codex-reviewer staging, prompt, and cleanup commands", () => {
     const instruction =
-      "printf '%s' 'Read /tmp/codex-reviewer-a1B2C3/prompt.md completely and follow it exactly.'";
+      "printf '%s' 'Read /PRINTED_PRIVATE_PROMPT_FILE completely and follow it exactly.'";
     for (const wrapper of [
       "~/.claude/hooks/lib/codex-stage.sh prompt --timeout 600",
       "~/.claude/hooks/lib/codex-stage.sh prompt --dir '/tmp/My Repo' --timeout 600",
@@ -796,9 +796,9 @@ describe("explicit allow matching", () => {
     }
 
     const staging =
-      'bun -e \'const { mkdtemp } = await import("node:fs/promises"); console.log(await mkdtemp("/tmp/codex-reviewer-"));\'';
+      'bun -e \'const { open } = await import("node:fs/promises"); const { randomUUID } = await import("node:crypto"); const { tmpdir } = await import("node:os"); const { join } = await import("node:path"); const path = join(tmpdir(), "codex-reviewer-" + randomUUID() + ".md"); const file = await open(path, "wx", 0o600); await file.close(); console.log(path);\'';
     const cleanup =
-      'bun -e \'const { rm } = await import("node:fs/promises"); await rm("/tmp/codex-reviewer-a1B2C3", { recursive: true, force: true });\'';
+      'bun -e \'const { rm } = await import("node:fs/promises"); await rm("/PRINTED_PRIVATE_PROMPT_FILE", { force: true });\'';
     expect(evaluateCommand(staging, productionRules).verdict).toBe("allow");
     expect(evaluateCommand(cleanup, productionRules).verdict).toBe("allow");
   });


### PR DESCRIPTION
## Summary

- inject ALLOW-first command guidance into every agent start
- restore mode-scoped Codex delegation through validated private staging
- harden scratch, worktree, artifact, timeout, and process-group boundaries
- update reviewer, PoC, and runner instructions to use exclusive scratch files

## Security

- pin canonical scratch and execution targets by path and device/inode identity
- reject nested, symlinked, relocated, oversized, or non-regular staged inputs
- cap concurrent private artifacts and clean them after each tool call
- terminate full Codex process groups, including early-exit leader cases
- preserve deterministic ASK and DENY decisions above capability authorization

## Verification

- TypeScript, Prettier, ShellCheck, and generated-agent sync pass
- lint passes with only 9 pre-existing warnings
- focused permission and wrapper security tests pass
- full suite: 1583 pass, 2 skip, 0 fail
- real read-only Codex smoke passes through the escalated boundary
- prompt tuning hold-out and final security review report no actionable findings