### PR TITLE
fix(pi): restore permission timeouts

### DIFF
--- a/pi/LOCAL_PERMISSION_JUDGE.md
+++ b/pi/LOCAL_PERMISSION_JUDGE.md
@@ -56,6 +56,7 @@ The judge is enabled by default. Override it in the machine-local
     "model": "granite4.1:3b",
     "expectedDigest": "6fd349357287c7ffc9e38189a93b48ea175d24fc566b38f09cfc564fb7f303eb",
     "timeoutMs": 10000,
+    "confirmTimeoutMs": 10000,
     "keepAlive": "30m"
   }
 }
@@ -77,8 +78,10 @@ properties. The response parser requires exactly that two-key object. Only
 `{"safety":"ALLOW","relevance":"ALLOW"}` approves. Either `ASK`, plain text,
 alternate casing, missing or extra keys, tool calls, truncation, and malformed
 JSON require confirmation or block.
-Interactive permission confirmations have no countdown: they remain open until
-the user responds or aborts the active pi operation (for example with Esc).
+Interactive permission confirmations default to a ten-second countdown and
+fail closed when it expires. Set `confirmTimeoutMs` from 1,000 through 300,000
+milliseconds to override that window; aborting the active pi operation (for
+example with Esc) also closes the dialog.
 
 The permission audit is mandatory and has no feature toggle. Disabling the
 local judge changes residual command routing but does not disable deterministic,
@@ -173,7 +176,7 @@ deterministic floor, explicit confirmation, or local judge.
     authenticated current-run assistant evidence to its agent run, then discover
     canonical cwd/project/worktree context locally. Async child-environment
     sanitization, Git probes, cwd/worktree/leading-target canonicalization, and
-    common-directory checks share one cumulative 250 ms deadline and abort
+    common-directory checks share one cumulative 1,000 ms deadline and abort
     signal.
 11. Reuse an unexpired completed `ALLOW` cache entry only when the command, raw
     cwd, complete raw-task fingerprint, complete current-run-evidence
@@ -279,7 +282,7 @@ worktree metadata. `/api/status` and `/api/tags` contain no command or context.
 Direct numeric-loopback TCP ignores ambient `HTTP_PROXY`/`HTTPS_PROXY`, and
 redirects are not followed.
 
-The complete permission-discovery phase has a separate cumulative 250 ms cap,
+The complete permission-discovery phase has a separate cumulative 1,000 ms cap,
 including async PATH sanitization, all Git processes, and every filesystem
 canonicalization; status, tags, and chat then share one `timeoutMs` budget. If
 preflight consumes that budget, chat is not started. Literal commands over

--- a/pi/README.md
+++ b/pi/README.md
@@ -187,7 +187,7 @@ task text, authenticated same-turn assistant text, preceding tool names plus
 success/failure status, and locally verified cwd/project/worktree context. It
 never receives assistant thinking, tool arguments, tool output content/details,
 expanded skills, prior-turn conversation, repository contents, remotes, or
-environment. One cumulative 250 ms local discovery deadline covers async child-
+environment. One cumulative 1,000 ms local discovery deadline covers async child-
 env sanitization, Git probing, per-root registered-worktree/common-dir
 validation, and path canonicalization before each fallback/cache lookup. Queued
 expanded inputs without an exact delivery match become uncorrelated and cannot

--- a/pi/extensions/pi-harness/config.ts
+++ b/pi/extensions/pi-harness/config.ts
@@ -48,6 +48,7 @@ export interface PermissionJudgeConfig {
   model: string;
   expectedDigest: string;
   timeoutMs: number;
+  confirmTimeoutMs: number;
   keepAlive: string;
   configurationError?: string;
 }
@@ -60,6 +61,7 @@ export const DEFAULT_PERMISSION_JUDGE_CONFIG: Readonly<PermissionJudgeConfig> =
     expectedDigest:
       "6fd349357287c7ffc9e38189a93b48ea175d24fc566b38f09cfc564fb7f303eb",
     timeoutMs: 10_000,
+    confirmTimeoutMs: 10_000,
     keepAlive: "30m",
   };
 
@@ -234,6 +236,10 @@ const readPermissionJudgeConfig = (
     value.timeoutMs === undefined
       ? DEFAULT_PERMISSION_JUDGE_CONFIG.timeoutMs
       : value.timeoutMs;
+  const confirmTimeoutMs =
+    value.confirmTimeoutMs === undefined
+      ? DEFAULT_PERMISSION_JUDGE_CONFIG.confirmTimeoutMs
+      : value.confirmTimeoutMs;
   const keepAlive =
     value.keepAlive === undefined
       ? DEFAULT_PERMISSION_JUDGE_CONFIG.keepAlive
@@ -252,6 +258,14 @@ const readPermissionJudgeConfig = (
     timeoutMs > 10_000
   ) {
     errors.push("timeoutMs");
+  }
+  if (
+    typeof confirmTimeoutMs !== "number" ||
+    !Number.isInteger(confirmTimeoutMs) ||
+    confirmTimeoutMs < 1_000 ||
+    confirmTimeoutMs > 300_000
+  ) {
+    errors.push("confirmTimeoutMs");
   }
   if (typeof keepAlive !== "string" || !validKeepAlive(keepAlive)) {
     errors.push("keepAlive");
@@ -281,6 +295,13 @@ const readPermissionJudgeConfig = (
       timeoutMs <= 10_000
         ? timeoutMs
         : DEFAULT_PERMISSION_JUDGE_CONFIG.timeoutMs,
+    confirmTimeoutMs:
+      typeof confirmTimeoutMs === "number" &&
+      Number.isInteger(confirmTimeoutMs) &&
+      confirmTimeoutMs >= 1_000 &&
+      confirmTimeoutMs <= 300_000
+        ? confirmTimeoutMs
+        : DEFAULT_PERMISSION_JUDGE_CONFIG.confirmTimeoutMs,
     keepAlive:
       typeof keepAlive === "string" && validKeepAlive(keepAlive)
         ? keepAlive

--- a/pi/extensions/pi-harness/features/permission-policy/context.ts
+++ b/pi/extensions/pi-harness/features/permission-policy/context.ts
@@ -13,7 +13,7 @@ const MAX_DISCOVERED_PATH_BYTES = 1_024;
 const MAX_VISIBLE_WORKTREES = 16;
 const MAX_VISIBLE_PATH_BYTES = 512;
 const MAX_VISIBLE_PROJECT_BYTES = 2_048;
-const DEFAULT_GIT_TIMEOUT_MS = 250;
+export const DEFAULT_GIT_TIMEOUT_MS = 1_000;
 
 const fingerprint = (...parts: readonly string[]): string => {
   const hash = createHash("sha256");

--- a/pi/extensions/pi-harness/features/permission-policy/index.ts
+++ b/pi/extensions/pi-harness/features/permission-policy/index.ts
@@ -2,7 +2,10 @@ import { readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { InputEvent, PiLike } from "../../lib/pi-like";
-import type { HarnessConfig } from "../../config";
+import {
+  DEFAULT_PERMISSION_JUDGE_CONFIG,
+  type HarnessConfig,
+} from "../../config";
 import type {
   BashExecutionBoundary,
   BashScratchBoundary,
@@ -544,6 +547,9 @@ const setupPermissionPolicy = (
           ctx.hasUI && !isAborted()
             ? await ctx.ui.confirm(title, `${reason}\n\n${command}`, {
                 signal,
+                timeout:
+                  judgeConfig?.confirmTimeoutMs ??
+                  DEFAULT_PERMISSION_JUDGE_CONFIG.confirmTimeoutMs,
               })
             : false;
         let status: "not-shown" | "aborted" | "accepted" | "rejected";

--- a/tests/pi-harness/permission-judge-context.test.ts
+++ b/tests/pi-harness/permission-judge-context.test.ts
@@ -15,6 +15,7 @@ import { promisify } from "node:util";
 import {
   boundTaskContext,
   createPermissionTaskTracker,
+  DEFAULT_GIT_TIMEOUT_MS,
   derivePermissionRunEvidence,
   discoverProjectContext,
   runGitWorktreeList,
@@ -438,6 +439,10 @@ describe("current permission run evidence", () => {
 });
 
 describe("permission judge project context", () => {
+  test("uses a one-second default Git probe timeout", () => {
+    expect(DEFAULT_GIT_TIMEOUT_MS).toBe(1_000);
+  });
+
   test("discovers the real active linked worktree", async () => {
     const repoRoot = await realpath(resolve(import.meta.dir, "../.."));
     const context = await discoverProjectContext(repoRoot);

--- a/tests/pi-harness/permission-judge-policy.test.ts
+++ b/tests/pi-harness/permission-judge-policy.test.ts
@@ -1446,13 +1446,19 @@ describe("permission policy local judge routing", () => {
     });
   });
 
-  test("keeps confirmation abortable without a timeout", async () => {
+  test("bounds confirmation with the active signal and configured timeout", async () => {
     const upstream = await start(() => ollamaResponse("ASK"));
     const pi = createFakePi();
     const controller = createTestAbortController();
     Object.assign(pi.ctx, { signal: controller.signal });
     pi.queueConfirm(false);
-    setupPermissionPolicy(pi, makeConfig(judgeConfig(upstream)));
+    setupPermissionPolicy(
+      pi,
+      makeConfig({
+        ...judgeConfig(upstream),
+        confirmTimeoutMs: 1_234,
+      }),
+    );
 
     expect(await pi.emitToolCall(bashCall("git rev-parse HEAD"))).toEqual({
       block: true,
@@ -1461,8 +1467,8 @@ describe("permission policy local judge routing", () => {
     expect(pi.confirmDialogs).toHaveLength(1);
     expect(pi.confirmDialogs[0]?.dialogOptions).toEqual({
       signal: controller.signal,
+      timeout: 1_234,
     });
-    expect(pi.confirmDialogs[0]?.dialogOptions).not.toHaveProperty("timeout");
   });
 
   test("blocks non-interactively when the judge does not allow", async () => {

--- a/tests/pi-harness/permission-rules.test.ts
+++ b/tests/pi-harness/permission-rules.test.ts
@@ -876,7 +876,7 @@ describe("permission judge config", () => {
     );
   });
 
-  test("loads overrides, ignores the retired confirm timeout, and matches child profiles", async () => {
+  test("loads timeout overrides and matches child profiles", async () => {
     const home = await mkdtemp(join(tmpdir(), "pi-judge-config-"));
     const paths = resolvePaths(home);
     await mkdir(join(home, ".pi", "agent"), { recursive: true });
@@ -909,6 +909,7 @@ describe("permission judge config", () => {
         expectedDigest:
           "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         timeoutMs: 750,
+        confirmTimeoutMs: 5_000,
         keepAlive: "2h",
       });
       expect(child).toEqual({
@@ -918,6 +919,7 @@ describe("permission judge config", () => {
         expectedDigest:
           "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         timeoutMs: 750,
+        confirmTimeoutMs: 5_000,
         keepAlive: "2h",
       });
     } finally {
@@ -937,6 +939,7 @@ describe("permission judge config", () => {
           model: "qwen2.5",
           expectedDigest: "sha256:not-a-digest",
           timeoutMs: 10,
+          confirmTimeoutMs: 500,
           keepAlive: "0m",
         },
       }),
@@ -944,7 +947,7 @@ describe("permission judge config", () => {
 
     try {
       expect(loadConfig({}, paths).permissionJudge?.configurationError).toBe(
-        "invalid permissionJudge fields: url, model, expectedDigest, timeoutMs, keepAlive",
+        "invalid permissionJudge fields: url, model, expectedDigest, timeoutMs, confirmTimeoutMs, keepAlive",
       );
     } finally {
       await rm(home, { recursive: true, force: true });
@@ -964,6 +967,7 @@ describe("permission judge config", () => {
           model: null,
           expectedDigest: null,
           timeoutMs: null,
+          confirmTimeoutMs: null,
           keepAlive: null,
         },
       }),
@@ -971,7 +975,7 @@ describe("permission judge config", () => {
 
     try {
       expect(loadConfig({}, paths).permissionJudge?.configurationError).toBe(
-        "invalid permissionJudge fields: enabled, url, model, expectedDigest, timeoutMs, keepAlive",
+        "invalid permissionJudge fields: enabled, url, model, expectedDigest, timeoutMs, confirmTimeoutMs, keepAlive",
       );
     } finally {
       await rm(home, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- restore `permissionJudge.confirmTimeoutMs` with a 10-second default and validated 1–300 second override range
- pass both the active abort signal and countdown timeout to permission ASK dialogs
- raise `DEFAULT_GIT_TIMEOUT_MS` from 250ms to 1000ms and synchronize documentation
- add focused config, policy, and project-context regressions

## Verification

- focused permission tests: 489 pass
- `bun run lint`: 0 errors (9 pre-existing warnings)
- `bun run tsc`
- `bun run check:pi-imports`
- `bun run check:pi-rules`
- `bun run check:pi-compat`: global pi 0.80.7
- `git diff --check`

## Full-suite note

`bun test` completed with 1594 pass, 2 skip, and 4 failures. Three unrelated failures passed when rerun individually. The remaining failure is the pre-existing transparent-theme expectation mismatch (`#515659` expected vs `#303354` checked in); this PR does not modify theme files or that test.