### PR TITLE
fix(pi): register created worktrees with sandbox

### DIFF
--- a/pi/extensions/pi-harness/features/bash-sandbox/index.ts
+++ b/pi/extensions/pi-harness/features/bash-sandbox/index.ts
@@ -16,12 +16,17 @@ import {
   type HarnessConfig,
 } from "../../config";
 import type { PiLike, ToolDefLike } from "../../lib/pi-like";
+import { validateCwdInSameRepo } from "../../lib/repo-boundary";
 import {
   PERMISSION_AUDIT_UNAVAILABLE_REASON,
   type PermissionAuditIntegration,
 } from "../permission-audit";
 import type { PermissionBlockResult } from "../permission-policy/block";
-import { buildBashSandboxProfile, type BashSandboxProfile } from "./profile";
+import {
+  buildBashSandboxProfile,
+  type BashSandboxProfile,
+  withBashSandboxWritableRoots,
+} from "./profile";
 import {
   CONTROLLED_BASH_PATH,
   createControlledBashOperations,
@@ -40,6 +45,7 @@ interface SandboxManagerLike {
     customConfig?: Partial<SandboxRuntimeConfig>,
     signal?: AbortSignal,
   ): Promise<string>;
+  updateConfig(config: SandboxRuntimeConfig): void;
   reset(): Promise<void>;
 }
 
@@ -67,6 +73,8 @@ export interface BashSandboxOperationsProvider {
 }
 
 export interface BashSandboxController {
+  registerWritableWorktree(path: string): Promise<void>;
+  revokeWritableWorktree(path: string): Promise<void>;
   boundaryFor(toolName: string): BashExecutionBoundary | undefined;
   scratchDirectoryFor(toolName: string): string | undefined;
   scratchBoundaryFor(toolName: string): BashScratchBoundary | undefined;
@@ -96,6 +104,7 @@ interface SetupBashSandboxOptions {
   ) => Promise<void>;
   readonly accessPath?: (path: string, mode?: number) => Promise<void>;
   readonly pinScratchDirectory?: (path: string) => Promise<BashScratchBoundary>;
+  readonly validateWritableWorktree?: typeof validateCwdInSameRepo;
   readonly spawnFn?: SpawnFunction;
   readonly baseEnv?: NodeJS.ProcessEnv;
 }
@@ -144,7 +153,11 @@ export const setupBashSandbox = (
   const remove = options.removePath ?? rm;
   const checkAccess = options.accessPath ?? access;
   const pinScratch = options.pinScratchDirectory ?? pinScratchDirectory;
+  const validateWritableWorktree =
+    options.validateWritableWorktree ?? validateCwdInSameRepo;
   let state: BashSandboxState = { kind: "stopped" };
+  let sessionGeneration = 0;
+  const dynamicWritableWorktrees = new Set<string>();
   const approvedHosts = new Set<string>();
   const deniedHosts = new Set<string>();
   let backendAttached = false;
@@ -217,7 +230,9 @@ export const setupBashSandbox = (
   } as unknown as ToolDefLike);
 
   pi.on("session_start", async (_event, ctx) => {
+    sessionGeneration += 1;
     sessionCwd = ctx.cwd ?? cwd;
+    dynamicWritableWorktrees.clear();
     approvedHosts.clear();
     deniedHosts.clear();
     state = { kind: "starting" };
@@ -299,7 +314,9 @@ export const setupBashSandbox = (
 
   pi.on("session_shutdown", async (_event, ctx) => {
     const previous = state;
+    sessionGeneration += 1;
     state = { kind: "stopped" };
+    dynamicWritableWorktrees.clear();
     backendAttached = false;
     backendCommandPrefix = undefined;
     sessionCwd = cwd;
@@ -340,6 +357,64 @@ export const setupBashSandbox = (
   });
 
   return {
+    async registerWritableWorktree(path) {
+      const initial = state;
+      if (initial.kind !== "ready" || initial.profile === undefined) {
+        throw new Error("bash sandbox is not ready for worktree registration");
+      }
+      const generation = sessionGeneration;
+      const boundary = await validateWritableWorktree(
+        path,
+        initial.profile.cwd,
+      );
+      if (!boundary.ok) {
+        throw new Error(
+          `bash sandbox rejected writable worktree: ${boundary.reason}`,
+        );
+      }
+      if (sessionGeneration !== generation) {
+        throw new Error(
+          "bash sandbox session changed during worktree registration",
+        );
+      }
+
+      const current = state;
+      if (
+        current.kind !== "ready" ||
+        current.manager === undefined ||
+        current.profile === undefined
+      ) {
+        throw new Error("bash sandbox is not ready for worktree registration");
+      }
+      const canonicalPath = boundary.canonicalCwd;
+      if (current.profile.writableRoots.includes(canonicalPath)) return;
+
+      const profile = withBashSandboxWritableRoots(current.profile, [
+        ...current.profile.writableRoots,
+        canonicalPath,
+      ]);
+      current.manager.updateConfig(profile.runtimeConfig);
+      dynamicWritableWorktrees.add(canonicalPath);
+      state = { ...current, profile };
+    },
+    async revokeWritableWorktree(path) {
+      if (!dynamicWritableWorktrees.has(path)) return;
+      const current = state;
+      if (
+        current.kind !== "ready" ||
+        current.manager === undefined ||
+        current.profile === undefined
+      ) {
+        throw new Error("bash sandbox is not ready for worktree revocation");
+      }
+      const profile = withBashSandboxWritableRoots(
+        current.profile,
+        current.profile.writableRoots.filter((root) => root !== path),
+      );
+      current.manager.updateConfig(profile.runtimeConfig);
+      dynamicWritableWorktrees.delete(path);
+      state = { ...current, profile };
+    },
     boundaryFor(toolName) {
       if (toolName !== "bash" && toolName !== "bash_escalated") {
         return undefined;

--- a/pi/extensions/pi-harness/features/bash-sandbox/profile.ts
+++ b/pi/extensions/pi-harness/features/bash-sandbox/profile.ts
@@ -34,6 +34,33 @@ const expandHome = (path: string, home: string): string => {
 
 const unique = (values: readonly string[]): string[] => [...new Set(values)];
 
+const profileFingerprint = (runtimeConfig: SandboxRuntimeConfig): string =>
+  createHash("sha256")
+    .update("pi-harness-bash-sandbox-v1")
+    .update("\0")
+    .update(JSON.stringify(runtimeConfig))
+    .digest("hex");
+
+export const withBashSandboxWritableRoots = (
+  profile: BashSandboxProfile,
+  writableRoots: readonly string[],
+): BashSandboxProfile => {
+  const nextWritableRoots = unique(writableRoots);
+  const runtimeConfig: SandboxRuntimeConfig = {
+    ...profile.runtimeConfig,
+    filesystem: {
+      ...profile.runtimeConfig.filesystem,
+      allowWrite: nextWritableRoots,
+    },
+  };
+  return {
+    ...profile,
+    writableRoots: nextWritableRoots,
+    fingerprint: profileFingerprint(runtimeConfig),
+    runtimeConfig,
+  };
+};
+
 export const buildBashSandboxProfile = async (
   cwd: string,
   scratchDirectory: string,
@@ -104,11 +131,7 @@ export const buildBashSandboxProfile = async (
     enableWeakerNestedSandbox: false,
     mandatoryDenySearchDepth: 5,
   };
-  const fingerprint = createHash("sha256")
-    .update("pi-harness-bash-sandbox-v1")
-    .update("\0")
-    .update(JSON.stringify(runtimeConfig))
-    .digest("hex");
+  const fingerprint = profileFingerprint(runtimeConfig);
 
   return {
     cwd: canonicalCwd,

--- a/pi/extensions/pi-harness/features/bit-task/index.ts
+++ b/pi/extensions/pi-harness/features/bit-task/index.ts
@@ -51,6 +51,8 @@ interface BitTaskDeps {
   runCommand?: RunCommand;
   cwd?: string;
   env?: Record<string, string | undefined>;
+  onWorktreeCreated?: (path: string) => Promise<void> | void;
+  onWorktreeRemoved?: (path: string) => Promise<void> | void;
 }
 
 const COMMAND_TIMEOUT_MS = 10_000;
@@ -593,6 +595,7 @@ export default function setupBitTask(
             "worktree_create postcondition failed: validated identity was not published",
           );
         }
+        await deps.onWorktreeCreated?.(path);
         return textResult(path, worktreeIdentityDetails(identity));
       } catch (error) {
         if (createdPath === undefined) throw error;
@@ -830,6 +833,7 @@ export default function setupBitTask(
           `worktree_remove postcondition failed; worktree is still registered: ${canonicalPath}`,
         );
       }
+      await deps.onWorktreeRemoved?.(canonicalPath);
 
       try {
         await lstat(canonicalPath);

--- a/pi/extensions/pi-harness/features/workflow/index.ts
+++ b/pi/extensions/pi-harness/features/workflow/index.ts
@@ -55,6 +55,7 @@ interface SetupWorkflowOptions {
     signal?: AbortSignal,
     onCreated?: (path: string) => void,
   ) => Promise<string>;
+  onWorktreeCreated?: (path: string) => Promise<void> | void;
   validateCwd?: (
     candidateCwd: string,
     rootCwd: string,
@@ -439,6 +440,7 @@ const setupWorkflow = (
                       }
                     },
                   );
+                  await options.onWorktreeCreated?.(worktree);
                   worktrees[taskIndex] = worktree;
                   if (runId !== undefined) {
                     childRuns?.registry.setRunWorktree(runId, worktree);

--- a/pi/extensions/pi-harness/index.ts
+++ b/pi/extensions/pi-harness/index.ts
@@ -149,9 +149,18 @@ const setupHarness = (
     setupSubagent(pi, config, { childRuns, permissionAudit });
   }
   if (config.features.workflow) {
-    setupWorkflow(pi, config, { childRuns, permissionAudit });
+    setupWorkflow(pi, config, {
+      childRuns,
+      permissionAudit,
+      onWorktreeCreated: (path) => bashSandbox.registerWritableWorktree(path),
+    });
   }
-  if (config.features["bit-task"]) setupBitTask(pi, config);
+  if (config.features["bit-task"]) {
+    setupBitTask(pi, config, {
+      onWorktreeCreated: (path) => bashSandbox.registerWritableWorktree(path),
+      onWorktreeRemoved: (path) => bashSandbox.revokeWritableWorktree(path),
+    });
+  }
   if (config.features.statusline) setupStatusline(pi, config);
   if (config.features["provider-log"]) setupProviderLog(pi, config);
   if (config.features["asuku-notify"]) setupAsukuNotify(pi, config);

--- a/tests/pi-harness/bash-sandbox-smoke.test.ts
+++ b/tests/pi-harness/bash-sandbox-smoke.test.ts
@@ -63,10 +63,13 @@ describe.skipIf(smokeUnavailable !== undefined)(
     test("enforces write, read, symlink, network, and outer-shell boundaries", async () => {
       const root = await setupTestDirectory("pi-bash-sandbox-smoke");
       const workspace = join(root, "workspace");
+      const dynamicWorkspace = join(root, "dynamic-workspace");
       const outside = join(root, "outside");
       const scratch = join(root, "scratch");
       const home = join(root, "home");
       const allowedFile = join(workspace, "allowed.txt");
+      const dynamicFile = join(dynamicWorkspace, "dynamic.txt");
+      const revokedFile = join(dynamicWorkspace, "revoked.txt");
       const blockedFile = join(outside, "blocked.txt");
       const escapedFile = join(outside, "escaped.txt");
       const secretFile = join(outside, "credential.txt");
@@ -80,9 +83,14 @@ describe.skipIf(smokeUnavailable !== undefined)(
 
       try {
         await Promise.all(
-          [workspace, outside, scratch, home, protectedHooks].map((path) =>
-            mkdir(path, { recursive: true }),
-          ),
+          [
+            workspace,
+            dynamicWorkspace,
+            outside,
+            scratch,
+            home,
+            protectedHooks,
+          ].map((path) => mkdir(path, { recursive: true })),
         );
         await writeFile(secretFile, "credential-canary", "utf8");
         await writeFile(protectedConfig, "protected-config", "utf8");
@@ -150,6 +158,28 @@ describe.skipIf(smokeUnavailable !== undefined)(
         );
         expect(blockedWrite.exitCode).not.toBe(0);
         expect(await pathExists(blockedFile)).toBe(false);
+
+        const dynamicWriteBeforeGrant = await run(
+          `printf denied > ${shellQuote(dynamicFile)}`,
+        );
+        expect(dynamicWriteBeforeGrant.exitCode).not.toBe(0);
+        SandboxManager.updateConfig({
+          ...runtimeConfig,
+          filesystem: {
+            ...runtimeConfig.filesystem,
+            allowWrite: [workspace, scratch, dynamicWorkspace],
+          },
+        });
+        expect(
+          await run(`printf dynamic > ${shellQuote(dynamicFile)}`),
+        ).toMatchObject({ exitCode: 0 });
+        expect(await readFile(dynamicFile, "utf8")).toBe("dynamic");
+        SandboxManager.updateConfig(runtimeConfig);
+        const dynamicWriteAfterRevoke = await run(
+          `printf revoked > ${shellQuote(revokedFile)}`,
+        );
+        expect(dynamicWriteAfterRevoke.exitCode).not.toBe(0);
+        expect(await pathExists(revokedFile)).toBe(false);
 
         const deniedRead = await run(`cat ${shellQuote(secretFile)}`);
         expect(deniedRead.exitCode).not.toBe(0);

--- a/tests/pi-harness/bash-sandbox.test.ts
+++ b/tests/pi-harness/bash-sandbox.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { EventEmitter } from "node:events";
 import type { BashOperations } from "@earendil-works/pi-coding-agent";
-import type { SandboxAskCallback } from "@anthropic-ai/sandbox-runtime";
+import type {
+  SandboxAskCallback,
+  SandboxRuntimeConfig,
+} from "@anthropic-ai/sandbox-runtime";
 import {
   BASH_SANDBOX_PROVIDER_EVENT,
   setupBashSandbox,
@@ -64,12 +67,14 @@ const profile = (cwd = "/repo"): BashSandboxProfile => ({
 interface FakeManager extends SandboxManagerLike {
   asks: SandboxAskCallback[];
   wrapped: string[];
+  updates: SandboxRuntimeConfig[];
   resets: number;
 }
 
 const manager = (): FakeManager => ({
   asks: [],
   wrapped: [],
+  updates: [],
   resets: 0,
   async initialize(_config, ask) {
     if (ask !== undefined) this.asks.push(ask);
@@ -77,6 +82,9 @@ const manager = (): FakeManager => ({
   async wrapWithSandbox(command) {
     this.wrapped.push(command);
     return `sandbox(${command})`;
+  },
+  updateConfig(config) {
+    this.updates.push(config);
   },
   async reset() {
     this.resets += 1;
@@ -90,6 +98,12 @@ const setup = (
     commandPrefix?: string;
     spawnFn?: SpawnFunction;
     userOwnerOrder?: "before" | "after";
+    validateWritableWorktree?: (
+      path: string,
+      root: string,
+    ) => Promise<
+      { ok: true; canonicalCwd: string } | { ok: false; reason: string }
+    >;
   } = {},
 ) => {
   const pi = createFakePi({ cwd: "/repo", hasUI: options.hasUI });
@@ -146,6 +160,9 @@ const setup = (
     removePath: async (path) => {
       removed.push(path);
     },
+    ...(options.validateWritableWorktree === undefined
+      ? {}
+      : { validateWritableWorktree: options.validateWritableWorktree }),
     ...(options.spawnFn === undefined ? {} : { spawnFn: options.spawnFn }),
   });
   controller.registerExecutionBoundary({
@@ -299,6 +316,123 @@ describe("Bash effect sandbox lifecycle", () => {
     await runtime.pi.emitSessionShutdown();
     expect(runtime.fakeManager.resets).toBe(1);
     expect(runtime.removed).toEqual(["/private/scratch"]);
+  });
+
+  test("registers and revokes a validated worktree", async () => {
+    const validations: { path: string; root: string }[] = [];
+    const runtime = setup({
+      validateWritableWorktree: async (path, root) => {
+        validations.push({ path, root });
+        return { ok: true, canonicalCwd: "/repo/linked" };
+      },
+    });
+    await runtime.pi.emitSessionStart({
+      type: "session_start",
+      reason: "startup",
+    });
+
+    const initialFingerprint =
+      runtime.controller.boundaryFor("bash")?.profileFingerprint;
+    await runtime.controller.registerWritableWorktree("/alias/linked");
+    expect(validations).toEqual([{ path: "/alias/linked", root: "/repo" }]);
+    expect(runtime.fakeManager.updates).toHaveLength(1);
+    expect(runtime.fakeManager.updates[0]?.filesystem.allowWrite).toEqual([
+      "/repo",
+      "/private/scratch",
+      "/repo/linked",
+    ]);
+    expect(runtime.controller.boundaryFor("bash")?.profileFingerprint).not.toBe(
+      initialFingerprint,
+    );
+
+    await runtime.controller.registerWritableWorktree("/repo/linked");
+    expect(runtime.fakeManager.updates).toHaveLength(1);
+
+    await runtime.controller.revokeWritableWorktree("/repo/linked");
+    expect(runtime.fakeManager.updates).toHaveLength(2);
+    expect(runtime.fakeManager.updates[1]?.filesystem.allowWrite).toEqual([
+      "/repo",
+      "/private/scratch",
+    ]);
+  });
+
+  test("merges concurrent registrations in the same session", async () => {
+    interface AllowedWorktree {
+      ok: true;
+      canonicalCwd: string;
+    }
+    const finishValidation = new Map<
+      string,
+      (value: AllowedWorktree) => void
+    >();
+    const runtime = setup({
+      validateWritableWorktree: (path) =>
+        new Promise<AllowedWorktree>((resolve) => {
+          finishValidation.set(path, resolve);
+        }),
+    });
+    await runtime.pi.emitSessionStart({
+      type: "session_start",
+      reason: "startup",
+    });
+
+    const first = runtime.controller.registerWritableWorktree("/repo/one");
+    const second = runtime.controller.registerWritableWorktree("/repo/two");
+    finishValidation.get("/repo/one")?.({
+      ok: true,
+      canonicalCwd: "/repo/one",
+    });
+    await first;
+    finishValidation.get("/repo/two")?.({
+      ok: true,
+      canonicalCwd: "/repo/two",
+    });
+    await second;
+
+    expect(runtime.fakeManager.updates).toHaveLength(2);
+    expect(runtime.fakeManager.updates[1]?.filesystem.allowWrite).toEqual([
+      "/repo",
+      "/private/scratch",
+      "/repo/one",
+      "/repo/two",
+    ]);
+  });
+
+  test("fails closed on invalid worktrees and session changes", async () => {
+    const rejected = setup({
+      validateWritableWorktree: async () => ({
+        ok: false,
+        reason: "different repository",
+      }),
+    });
+    await rejected.pi.emitSessionStart({
+      type: "session_start",
+      reason: "startup",
+    });
+    await expect(
+      rejected.controller.registerWritableWorktree("/outside"),
+    ).rejects.toThrow("different repository");
+    expect(rejected.fakeManager.updates).toEqual([]);
+
+    let finishValidation:
+      | ((value: { ok: true; canonicalCwd: string }) => void)
+      | undefined;
+    const changing = setup({
+      validateWritableWorktree: () =>
+        new Promise((resolve) => {
+          finishValidation = resolve;
+        }),
+    });
+    await changing.pi.emitSessionStart({
+      type: "session_start",
+      reason: "startup",
+    });
+    const registration =
+      changing.controller.registerWritableWorktree("/repo/linked");
+    await changing.pi.emitSessionShutdown();
+    finishValidation?.({ ok: true, canonicalCwd: "/repo/linked" });
+    await expect(registration).rejects.toThrow("session changed");
+    expect(changing.fakeManager.updates).toEqual([]);
   });
 
   test("includes the trusted shell prefix inside the sandbox wrapper", async () => {

--- a/tests/pi-harness/bit-task.test.ts
+++ b/tests/pi-harness/bit-task.test.ts
@@ -254,8 +254,12 @@ describe("bit-task tool registration", () => {
       const hookEnvs: (Record<string, string | undefined> | undefined)[] = [];
       const commandEnvs: (Record<string, string | undefined> | undefined)[] =
         [];
+      const registeredWorktrees: string[] = [];
       const pi = createFakePi({ cwd: directory });
       setupBitTask(pi, makeConfig(), {
+        onWorktreeCreated: (path) => {
+          registeredWorktrees.push(path);
+        },
         env: { PI_HARNESS_CHILD: "0" },
         runHook: async (_script, _stdin, options) => {
           hookEnvs.push(options?.env);
@@ -301,6 +305,7 @@ describe("bit-task tool registration", () => {
       for (const env of commandEnvs) {
         expect(env?.PI_HARNESS_CHILD).toBe("1");
       }
+      expect(registeredWorktrees).toEqual([created]);
     } finally {
       await cleanupTestDirectory(directory);
     }
@@ -359,8 +364,12 @@ describe("bit-task tool registration", () => {
     try {
       const created = await fs.realpath(join(directory, "created"));
       let commandCalls = 0;
+      const registeredWorktrees: string[] = [];
       const pi = createFakePi({ cwd: directory });
       setupBitTask(pi, makeConfig(), {
+        onWorktreeCreated: (path) => {
+          registeredWorktrees.push(path);
+        },
         runHook: async () => ({
           exitCode: 0,
           timedOut: false,
@@ -383,6 +392,7 @@ describe("bit-task tool registration", () => {
       expect(error.message).toContain("omitted its creation identity");
       expect(error.message).toContain(created);
       expect(commandCalls).toBe(0);
+      expect(registeredWorktrees).toEqual([]);
     } finally {
       await cleanupTestDirectory(directory);
     }
@@ -433,8 +443,12 @@ describe("bit-task tool registration", () => {
       const created = await fs.realpath(join(directory, "created"));
       const publication = await mockWorktreePublication(created);
       let commandCalls = 0;
+      const registeredWorktrees: string[] = [];
       const pi = createFakePi({ cwd: directory });
       setupBitTask(pi, makeConfig(), {
+        onWorktreeCreated: (path) => {
+          registeredWorktrees.push(path);
+        },
         runHook: async () => {
           await fs.rm(created, { recursive: true, force: true });
           await fs.mkdir(created);
@@ -465,6 +479,7 @@ describe("bit-task tool registration", () => {
       expect(error.message).toContain("filesystem identity changed");
       expect(error.message).toContain(created);
       expect(commandCalls).toBe(0);
+      expect(registeredWorktrees).toEqual([]);
     } finally {
       await cleanupTestDirectory(directory);
     }
@@ -717,9 +732,13 @@ describe("bit-task tool registration", () => {
       const target = await fs.realpath(join(directory, "target"));
       const common = await fs.realpath(join(directory, "common.git"));
       let listCalls = 0;
+      const revokedWorktrees: string[] = [];
       const pi = createFakePi({ cwd: repo });
       setupBitTask(pi, makeConfig(), {
         cwd: repo,
+        onWorktreeRemoved: (path) => {
+          revokedWorktrees.push(path);
+        },
         runHook: async () => ({
           exitCode: 0,
           timedOut: false,
@@ -753,6 +772,7 @@ describe("bit-task tool registration", () => {
           pi.ctx,
         ),
       ).rejects.toThrow(/postcondition failed; directory still exists/i);
+      expect(revokedWorktrees).toEqual([target]);
     } finally {
       await cleanupTestDirectory(directory);
     }
@@ -819,9 +839,13 @@ describe("bit-task tool registration", () => {
       const linkedB = await fs.realpath(join(directory, "linkedB"));
       const common = await fs.realpath(join(directory, "common.git"));
       let removedB = false;
+      const revokedWorktrees: string[] = [];
       const pi = createFakePi({ cwd: linkedA });
       setupBitTask(pi, makeConfig(), {
         cwd: linkedA,
+        onWorktreeRemoved: (path) => {
+          revokedWorktrees.push(path);
+        },
         runHook: async () => {
           await fs.rm(linkedB, { recursive: true, force: true });
           removedB = true;
@@ -852,6 +876,7 @@ describe("bit-task tool registration", () => {
       );
       expect(readTextResult(result)).toContain("Removed worktree");
       expect(removedB).toBe(true);
+      expect(revokedWorktrees).toEqual([linkedB]);
     } finally {
       await cleanupTestDirectory(directory);
     }

--- a/tests/pi-harness/permission-ask-reminder.test.ts
+++ b/tests/pi-harness/permission-ask-reminder.test.ts
@@ -42,6 +42,8 @@ const setupReminderHarness = (
 ): void => {
   setupHarness(pi, value, {
     setupBashSandbox: () => ({
+      async registerWritableWorktree() {},
+      async revokeWritableWorktree() {},
       boundaryFor: (toolName) => ({
         mode: toolName === "bash" ? "sandboxed" : "escalated",
         network: "denied",

--- a/tests/pi-harness/workflow.test.ts
+++ b/tests/pi-harness/workflow.test.ts
@@ -669,6 +669,7 @@ describe("pi-harness workflow", () => {
     const home = await makeTempDirectory("pi-workflow-poc");
     await writeAgents(home, ["codex-poc"]);
     const created: { cwd: string; name: string }[] = [];
+    const registered: string[] = [];
     const workflowRoot = join(home, "repository");
     const rootAlias = join(home, "repository-alias");
     await fs.mkdir(workflowRoot);
@@ -681,6 +682,9 @@ describe("pi-harness workflow", () => {
       createWorktree: async (cwd, name) => {
         created.push({ cwd, name });
         return worktreePath;
+      },
+      onWorktreeCreated: (path) => {
+        registered.push(path);
       },
     });
 
@@ -707,12 +711,55 @@ describe("pi-harness workflow", () => {
     expect(created).toHaveLength(1);
     expect(created[0]?.cwd).toBe(await fs.realpath(workflowRoot));
     expect(created[0]?.name).not.toBe("");
+    expect(registered).toEqual([worktreePath]);
     expect(records).toHaveLength(1);
     expect(records[0]?.options.cwd).toBe(worktreePath);
     expect(text).toContain(worktreePath);
     expect(text).toContain("left in place");
     const [report] = getStageTaskReports(details, 0);
     expect(report?.worktree).toBe(worktreePath);
+  });
+
+  test("does not register a failed provisional worktree", async () => {
+    const home = await makeTempDirectory("pi-workflow-provisional");
+    await writeAgents(home, ["codex-poc"]);
+    const published = join(home, "worktrees", "provisional");
+    const registered: string[] = [];
+    const { records, spawnFn } = makeSpawnFn(() => ({ text: "never" }));
+    const pi = createFakePi({ cwd: home });
+    setupWorkflow(pi, makeConfig(home), {
+      spawnFn,
+      createWorktree: async (_cwd, _name, _signal, onCreated) => {
+        onCreated?.(published);
+        throw new Error("worktree validation failed");
+      },
+      onWorktreeCreated: (path) => {
+        registered.push(path);
+      },
+    });
+
+    await expect(
+      executeTool(
+        findWorkflowTool(pi.tools),
+        {
+          stages: [
+            {
+              mode: "fanout",
+              tasks: [
+                {
+                  agentType: "codex-poc",
+                  task: "build the poc",
+                  isolation: "worktree",
+                },
+              ],
+            },
+          ],
+        },
+        pi.ctx,
+      ),
+    ).rejects.toThrow("worktree validation failed");
+    expect(registered).toEqual([]);
+    expect(records).toEqual([]);
   });
 
   test("rejects an invalid plan before any execution", async () => {


### PR DESCRIPTION
## Summary

- dynamically register harness-validated same-repository worktrees in the active Bash sandbox
- update the runtime profile and fingerprint, merge concurrent registrations by session generation, and revoke stale grants after Git unregisters a worktree
- wire bit-task and workflow creation paths and add unit, callback, race, provisional-publication, and real sandbox-runtime coverage

## Verification

- focused pi-harness tests: 76 passed
- real Bash sandbox smoke: 2 passed
- `bun run tsc`
- Prettier check for all changed files
- oxlint for all changed files: 0 warnings / 0 errors
- `bun run check:pi-imports`
- `bun run check:pi-baseline`
- `bun run check:pi-schemas`
- `BUN_INSTALL=/Users/ushironoko/.bun bun run check:pi-compat` (global Pi 0.80.7)

Full `bun test`: 1596 passed, 2 skipped, 4 unrelated existing/environment failures (BackupManager TMPDIR restore path x2, tracked theme expectation mismatch, and pnpm statusline fixture lint status).