### PR TITLE
fix(pi): restore compatibility checks on 0.83

### DIFF
--- a/pi/extensions/pi-harness/features/btw/index.ts
+++ b/pi/extensions/pi-harness/features/btw/index.ts
@@ -5,7 +5,6 @@ import type {
   ThinkingLevel,
 } from "@earendil-works/pi-agent-core";
 import {
-  AuthStorage,
   buildSessionContext,
   createAgentSession,
   DefaultResourceLoader,
@@ -139,6 +138,23 @@ const defaultForkDependencies: BtwForkDependencies = {
   },
 };
 
+// Pi 0.80 accepts ModelRegistry directly. Pi 0.83 requires the ModelRuntime
+// behind that extension-facing compatibility facade, so validate its nominal
+// runtime type before sharing the parent's provider/auth state with the child.
+const getParentModelRuntime = async (modelRegistry: ModelRegistry) => {
+  const codingAgentSdk = await import("@earendil-works/pi-coding-agent");
+  if (!("ModelRuntime" in codingAgentSdk)) return undefined;
+  const { ModelRuntime } = codingAgentSdk;
+  if (typeof ModelRuntime !== "function") {
+    throw new Error("BTW cannot identify the pi ModelRuntime constructor");
+  }
+  const modelRuntime: unknown = Reflect.get(modelRegistry, "runtime");
+  if (!(modelRuntime instanceof ModelRuntime)) {
+    throw new Error("BTW cannot access the parent pi model runtime");
+  }
+  return modelRuntime;
+};
+
 const byteLength = (value: string): number => Buffer.byteLength(value, "utf8");
 
 const truncateUtf8 = (
@@ -245,12 +261,13 @@ const answerFromReadOnlyFork = async (
       : { parentSession: snapshot.parentSession },
   );
   seedSessionManager(sessionManager, snapshot.messages);
-  const session = await dependencies.createSession({
+  const modelRuntime = await getParentModelRuntime(snapshot.modelRegistry);
+  const sessionOptions = {
     cwd: snapshot.cwd,
     agentDir,
     model: snapshot.model,
     modelRegistry: snapshot.modelRegistry,
-    authStorage: AuthStorage.inMemory(),
+    ...(modelRuntime === undefined ? {} : { modelRuntime }),
     thinkingLevel: snapshot.thinkingLevel,
     tools: [...BTW_READ_ONLY_TOOLS],
     excludeTools: [...BTW_DENIED_TOOLS],
@@ -258,7 +275,8 @@ const answerFromReadOnlyFork = async (
     resourceLoader,
     sessionManager,
     settingsManager,
-  });
+  };
+  const session = await dependencies.createSession(sessionOptions);
 
   let latestAssistant: Extract<AgentMessage, { role: "assistant" }> | undefined;
   const unsubscribeSession = session.subscribe((event) => {

--- a/scripts/pi-compat/installation.ts
+++ b/scripts/pi-compat/installation.ts
@@ -1,5 +1,15 @@
-import { basename, dirname, isAbsolute, join, resolve } from "node:path";
-import { readFile, realpath } from "node:fs/promises";
+import { constants } from "node:fs";
+import { access, readFile, realpath } from "node:fs/promises";
+import {
+  basename,
+  delimiter,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+  sep,
+} from "node:path";
 import { PI_BASELINE_PACKAGES } from "./baseline";
 import {
   runCommand,
@@ -38,12 +48,47 @@ export interface DiscoverInstallationOptions {
   platform?: NodeJS.Platform;
   run?: CommandRunner;
   commandOptions?: RunCommandOptions;
+  environment?: NodeJS.ProcessEnv;
+  excludedPackageRoots?: string[];
 }
 
 const readManifest = async (root: string): Promise<PackageManifest> =>
   JSON.parse(
     await readFile(join(root, "package.json"), "utf8"),
   ) as PackageManifest;
+
+const isWithin = (root: string, target: string): boolean => {
+  const relation = relative(resolve(root), resolve(target));
+  return (
+    relation === "" ||
+    (relation !== ".." &&
+      !relation.startsWith(`..${sep}`) &&
+      !isAbsolute(relation))
+  );
+};
+
+const findPiOnPath = async (
+  pathValue: string | undefined,
+  executable: string,
+  excludedRoots: string[],
+  platform: NodeJS.Platform,
+): Promise<string | undefined> => {
+  for (const entry of pathValue?.split(delimiter) ?? []) {
+    const candidate = resolve(entry === "" ? "." : entry, executable);
+    try {
+      await access(
+        candidate,
+        platform === "win32" ? constants.F_OK : constants.X_OK,
+      );
+      const target = await realpath(candidate);
+      if (excludedRoots.some((root) => isWithin(root, target))) continue;
+      return candidate;
+    } catch {
+      // Continue to the next PATH entry.
+    }
+  }
+  return undefined;
+};
 
 const findPackageRoot = async (
   entry: string,
@@ -130,21 +175,53 @@ export const discoverPiInstallation = async (
   const bunExecutable = resolve(options.bunExecutable ?? process.execPath);
   const platform = options.platform ?? process.platform;
   const run = options.run ?? runCommand;
-  const globalBin = assertSuccess(
-    "bun global bin discovery",
-    await run([bunExecutable, "pm", "bin", "--global"], options.commandOptions),
+  const environment =
+    options.environment ?? options.commandOptions?.env ?? process.env;
+  const configuredExcludedRoots = options.excludedPackageRoots ?? [
+    resolve(import.meta.dir, "../../node_modules"),
+  ];
+  const excludedPackageRoots = await Promise.all(
+    configuredExcludedRoots.map(async (root) => {
+      try {
+        return await realpath(root);
+      } catch {
+        return resolve(root);
+      }
+    }),
   );
-  if (!isAbsolute(globalBin)) {
-    throw new Error("Bun global bin directory is not absolute");
-  }
-
   const executable = platform === "win32" ? "pi.exe" : "pi";
-  const binaryPath = join(globalBin, executable);
+  const pathBinary = await findPiOnPath(
+    environment.PATH,
+    executable,
+    excludedPackageRoots,
+    platform,
+  );
+  let binaryPath: string;
+  let globalBin: string;
+  if (pathBinary !== undefined) {
+    binaryPath = pathBinary;
+    globalBin = dirname(pathBinary);
+  } else {
+    globalBin = assertSuccess(
+      "bun global bin discovery",
+      await run(
+        [bunExecutable, "pm", "bin", "--global"],
+        options.commandOptions,
+      ),
+    );
+    if (!isAbsolute(globalBin)) {
+      throw new Error("Bun global bin directory is not absolute");
+    }
+    binaryPath = join(globalBin, executable);
+  }
   const binaryRealPath = await realpath(binaryPath);
   const packageRoot = await findPackageRoot(
     binaryRealPath,
     "@earendil-works/pi-coding-agent",
   );
+  if (excludedPackageRoots.some((root) => isWithin(root, packageRoot))) {
+    throw new Error("discovered pi resolved to an excluded package root");
+  }
   const codingManifest = await readManifest(packageRoot);
   const packageName = codingManifest.name;
   const packageVersion = codingManifest.version;

--- a/tests/pi-harness/btw.test.ts
+++ b/tests/pi-harness/btw.test.ts
@@ -237,8 +237,7 @@ describe("BTW read-only fork runner", () => {
       ...BTW_DENIED_TOOLS,
     ]);
     expect(harness.createOptions[0].model).toBe(parentModel);
-    expect(harness.createOptions[0].authStorage).toBeDefined();
-    expect(harness.createOptions[0].authStorage?.list()).toEqual([]);
+    expect(harness.createOptions[0].modelRegistry).toBe(parent.modelRegistry);
     expect(harness.createOptions[0].thinkingLevel).toBe("low");
     expect(harness.loaderOptions[0].settingsManager).toBe(
       harness.createOptions[0].settingsManager,

--- a/tests/pi-harness/check-pi-compat.test.ts
+++ b/tests/pi-harness/check-pi-compat.test.ts
@@ -1,13 +1,23 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import {
   assertNoLocalPiResolution,
   PI_HARNESS_RUNTIME_PACKAGES,
 } from "../../scripts/pi-compat/compile";
+import { PI_BASELINE_PACKAGES } from "../../scripts/pi-compat/baseline";
 import { checkPiCompatibility } from "../../scripts/pi-compat/index";
 import {
+  discoverPiInstallation,
   satisfiesManifestRange,
   type PiInstallation,
 } from "../../scripts/pi-compat/installation";
@@ -95,6 +105,102 @@ describe("pi compatibility policy", () => {
       }),
     ).rejects.toThrow("stale baseline");
     expect(discovered).toBe(false);
+  });
+});
+
+describe("global pi installation discovery", () => {
+  test("uses the non-project pi on PATH when sandbox cache isolation breaks Bun global discovery", async () => {
+    if (process.platform === "win32") return;
+    const root = await mkdtemp(join(tmpdir(), "pi-installation-"));
+    try {
+      const localModules = join(root, "repo", "node_modules");
+      const localBin = join(localModules, ".bin");
+      await mkdir(localBin, { recursive: true });
+      await writeFile(join(localBin, "pi"), "#!/bin/sh\nexit 0\n");
+      await chmod(join(localBin, "pi"), 0o755);
+
+      const globalRoot = join(root, "global");
+      const globalModules = join(globalRoot, "node_modules");
+      const packageVersion = "0.83.0";
+      let codingAgentRoot = "";
+      for (const name of PI_BASELINE_PACKAGES) {
+        const packageRoot = join(globalModules, ...name.split("/"));
+        const version = name === "typebox" ? "1.3.7" : packageVersion;
+        await mkdir(packageRoot, { recursive: true });
+        const manifest: Record<string, unknown> = { name, version };
+        if (name === "@earendil-works/pi-coding-agent") {
+          codingAgentRoot = packageRoot;
+          manifest.bin = { pi: "dist/cli.js" };
+          await mkdir(join(packageRoot, "dist"), { recursive: true });
+          await writeFile(
+            join(packageRoot, "dist/cli.js"),
+            "#!/usr/bin/env node\n",
+          );
+          await chmod(join(packageRoot, "dist/cli.js"), 0o755);
+        }
+        await writeFile(
+          join(packageRoot, "package.json"),
+          JSON.stringify(manifest),
+        );
+      }
+
+      const globalBin = join(globalRoot, "bin");
+      await mkdir(globalBin, { recursive: true });
+      await symlink(
+        join(codingAgentRoot, "dist/cli.js"),
+        join(globalBin, "pi"),
+      );
+
+      const calls: string[][] = [];
+      const discovered = await discoverPiInstallation({
+        bunExecutable: "/tools/bun",
+        environment: {
+          PATH: `${localBin}${delimiter}${globalBin}`,
+          XDG_CACHE_HOME: join(root, "sandbox-cache"),
+        },
+        excludedPackageRoots: [localModules],
+        run: async (argv) => {
+          calls.push([...argv]);
+          return {
+            argv: [...argv],
+            exitCode: 0,
+            stdout: `${packageVersion}\n`,
+            stderr: "",
+            timedOut: false,
+            truncated: false,
+          };
+        },
+      });
+
+      expect(discovered.binaryPath).toBe(join(globalBin, "pi"));
+      expect(discovered.packageVersion).toBe(packageVersion);
+      expect(calls).toEqual([[join(globalBin, "pi"), "--version"]]);
+
+      const aliasBin = join(root, "alias-bin");
+      await mkdir(aliasBin);
+      await symlink(join(codingAgentRoot, "dist/cli.js"), join(aliasBin, "pi"));
+      await expect(
+        discoverPiInstallation({
+          environment: { PATH: aliasBin },
+          excludedPackageRoots: [codingAgentRoot],
+          run: async (argv) => {
+            if (argv[1] !== "pm") {
+              throw new Error("version command must not run");
+            }
+            return {
+              argv: [...argv],
+              exitCode: 0,
+              stdout: `${aliasBin}\n`,
+              stderr: "",
+              timedOut: false,
+              truncated: false,
+            };
+          },
+        }),
+      ).rejects.toThrow("excluded package root");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- discover the active global pi from PATH when the Bash sandbox redirects Bun cache state
- exclude repository-local pi packages using canonical paths and preserve binary/package ownership validation
- bridge the pi 0.80 ModelRegistry and pi 0.83 ModelRuntime SDK contracts for BTW read-only forks without new unsafe type assertions
- add sandbox, symlink-alias, and compatibility regression coverage

## Verification

- bun run check:pi-version
- bun run check:pi-baseline
- bun run check:pi-imports
- bun run check:pi-schemas
- bun run check:pi-rules
- bun run tsc
- bun run lint — 0 errors; 9 pre-existing hexadecimal-style warnings
- focused tests — 34 passed
- full suite outside the effect sandbox — 1600 passed, 2 skipped, 3 unrelated pre-existing/environmental failures in backup-manager and pi-theme tests