### PR TITLE
fix(pi): delegate managed Codex stages directly

### DIFF
--- a/claude/.claude/agents/codex-poc.md
+++ b/claude/.claude/agents/codex-poc.md
@@ -51,8 +51,11 @@ spec out of Bash by staging it in the sandbox-managed private scratch root:
 
 2. Use the `write` tool to replace the empty printed file with the complete
    implementation spec. Keep it directly under the printed temporary root;
-   never move it into a nested directory. Then paste the printed prompt path
-   and the canonical active worktree from Phase 1 into this literal pipeline:
+   never move it into a nested directory. Then submit this literal pipeline
+   directly through the `bash_escalated` tool, pasting the printed prompt path
+   and the canonical active worktree from Phase 1. Do not try ordinary `bash`
+   first: Codex initializes its own app-server and sandbox outside Pi's effect
+   sandbox.
 
    ```bash
    printf '%s' 'Read /PRINTED_PRIVATE_PROMPT_FILE completely and follow it exactly.' |
@@ -72,18 +75,20 @@ spec out of Bash by staging it in the sandbox-managed private scratch root:
 
 - Set a generous Bash timeout for the wrapper call (up to 600000 ms); raise
   `--timeout` for large specs.
-- The wrapper pins the validated worktree with `cd -P`, verifies the expected
-  directory identity, then runs `codex -a never exec --sandbox workspace-write`
-  from that cwd: codex edits files directly in the worktree; `.git`,
-  `.codex` and `.agents` stay read-only by codex policy.
-- codex needs network and a local app-server. Under pi, if ordinary Bash blocks
-  the wrapper at the effect boundary, retry that exact wrapper call with the
-  explicit `bash_escalated` tool. Pi grants only this agent's declared `poc`
-  mode after it verifies the literal wrapper, a scratch-local staged prompt,
-  and that `--worktree` equals the child process's active linked worktree. Any
-  changed form still gets a fresh local classification. If escalation remains
-  blocked, report the PoC as blocked. Never disable the sandbox implicitly or
-  invoke `codex` directly.
+- The wrapper canonicalizes the target with `cd -P`, verifies that it is an
+  isolated linked worktree, then runs
+  `codex -a never exec --sandbox workspace-write` from that cwd: codex edits
+  files directly in the worktree; `.git`, `.codex` and `.agents` stay read-only
+  by codex policy.
+- codex needs network and a local app-server. Under pi, always invoke the
+  wrapper with `bash_escalated`; never try ordinary Bash first. For a managed
+  child, Pi checks only that the literal wrapper uses this agent's declared
+  `poc` mode and that the shell envelope is the documented prompt pipeline. It
+  does not re-sandbox the wrapper, pin or copy its prompt/worktree, or send the
+  launch to the local judge. Pi snapshots only the trusted wrapper executable so
+  this child cannot replace its launcher before the call. The wrapper's
+  linked-worktree validation and Codex's workspace-write sandbox are
+  authoritative. Never disable that Codex sandbox or invoke `codex` directly.
 
 ### Phase 3: Report
 

--- a/claude/.claude/agents/codex-reviewer.md
+++ b/claude/.claude/agents/codex-reviewer.md
@@ -162,8 +162,11 @@ content with the standard review prompt shown below.
    <extracted artifact content here>
    ```
 
-2. When the child process already has the desired working directory, rely on
-   the wrapper's `DIR=$PWD` default. This is the preferred command:
+2. Submit the wrapper pipeline directly through the `bash_escalated` tool. Do
+   not try ordinary `bash` first: Codex initializes its own app-server and
+   sandbox, which are intentionally run outside Pi's effect sandbox. When the
+   child process already has the desired working directory, rely on the
+   wrapper's `DIR=$PWD` default:
 
    ```bash
    printf '%s' 'Read /PRINTED_PRIVATE_PROMPT_FILE completely and follow it exactly.' |
@@ -226,13 +229,15 @@ gap), 124 = timed out.
 
 - The actual review is performed by Codex CLI; this agent only orchestrates
 - Review runs are read-only (`--sandbox read-only` / the review subcommand)
-- codex needs network and a local app-server. Under pi, if ordinary Bash blocks
-  the wrapper at the effect boundary, retry that exact wrapper call with the
-  explicit `bash_escalated` tool. Pi grants only this agent's declared
-  `prompt,review` modes after it verifies the literal wrapper, the scratch-local
-  staged prompt, and the active-worktree directory. Any changed form still gets
-  a fresh local classification. If escalation remains blocked, report it.
-  Never disable the sandbox implicitly or invoke `codex` directly.
+- codex needs network and a local app-server. Under pi, always invoke the
+  wrapper with `bash_escalated`; never try ordinary Bash first. For a managed
+  child, Pi checks only that the literal wrapper mode is one this agent declared
+  and that the shell envelope is the documented direct call or prompt pipeline.
+  It does not re-sandbox the wrapper, pin or copy its prompt/cwd, or send the
+  launch to the local judge. Pi snapshots only the trusted wrapper executable so
+  this child cannot replace its launcher before the call. `codex-stage.sh` and
+  Codex's own read-only sandbox are the execution boundary. Never disable that
+  Codex sandbox or invoke `codex` directly.
 - Never pass `-m` — `~/.codex/config.toml` owns model selection
 - Privacy: the artifact and any repo files codex reads are sent to OpenAI
 - If the wrapper is missing, report that failure; never bypass it by invoking

--- a/claude/.claude/agents/codex-runner.md
+++ b/claude/.claude/agents/codex-runner.md
@@ -76,9 +76,11 @@ root:
 
 2. Use the `write` tool to replace the empty printed file with the full task,
    constraints, exact write scope, and verification. Keep it directly under
-   the printed temporary root; never move it into a nested directory. Paste
-   the printed prompt path and assigned active-worktree directory into this
-   literal pipeline:
+   the printed temporary root; never move it into a nested directory. Submit
+   this literal pipeline directly through the `bash_escalated` tool, pasting
+   the printed prompt path and assigned directory. Do not try ordinary `bash`
+   first: Codex initializes its own app-server and sandbox outside Pi's effect
+   sandbox.
 
    ```bash
    printf '%s' 'Read /PRINTED_PRIVATE_PROMPT_FILE completely and follow it exactly.' |
@@ -98,23 +100,24 @@ root:
 
 - Set a generous Bash timeout for the wrapper call (up to 600000 ms); raise
   `--timeout` for large tasks.
-- The wrapper pins `<dir>` with `cd -P`, verifies the expected directory
-  identity, then runs `codex -a never exec --sandbox workspace-write` from that
-  cwd. Codex edits files within `<dir>`. The wrapper does NOT widen the writable
-  boundary with `--add-dir`, but which paths stay protected (`.git`, etc.) is
-  whatever codex's own workspace-write sandbox policy enforces — not a wrapper
-  guarantee. That confinement to the inherited cwd is codex-sandbox-enforced,
-  so it depends on `~/.codex/config.toml` not widening
-  `sandbox_workspace_write.writable_roots`; a codex config/version
-  change, not a wrapper change, is the failure mode to watch.
-- codex needs network and a local app-server. Under pi, if ordinary Bash blocks
-  the wrapper at the effect boundary, retry that exact wrapper call with the
-  explicit `bash_escalated` tool. Pi grants only this agent's declared `run`
-  mode after it verifies the literal wrapper, a scratch-local staged prompt,
-  and that `--dir` remains inside the child process's active worktree. Any
-  changed form still gets a fresh local classification. If escalation remains
-  blocked, report the run as blocked. Never disable the sandbox implicitly or
-  invoke `codex` directly.
+- The wrapper canonicalizes `<dir>` with `cd -P`, verifies that it is inside a
+  git work tree, then runs `codex -a never exec --sandbox workspace-write` from
+  that cwd. Codex edits files within `<dir>`. The wrapper does NOT widen the
+  writable boundary with `--add-dir`, but which paths stay protected (`.git`,
+  etc.) is whatever codex's own workspace-write sandbox policy enforces — not a
+  wrapper guarantee. That confinement to the inherited cwd is
+  codex-sandbox-enforced, so it depends on `~/.codex/config.toml` not widening
+  `sandbox_workspace_write.writable_roots`; a codex config/version change, not
+  a wrapper change, is the failure mode to watch.
+- codex needs network and a local app-server. Under pi, always invoke the
+  wrapper with `bash_escalated`; never try ordinary Bash first. For a managed
+  child, Pi checks only that the literal wrapper uses this agent's declared
+  `run` mode and that the shell envelope is the documented prompt pipeline. It
+  does not re-sandbox the wrapper, pin or copy its prompt/directory, or send the
+  launch to the local judge. Pi snapshots only the trusted wrapper executable so
+  this child cannot replace its launcher before the call. The workflow
+  write-scope contract, wrapper Git check, and Codex workspace-write sandbox are
+  authoritative. Never disable that Codex sandbox or invoke `codex` directly.
 
 ### Phase 3: Report
 

--- a/claude/.claude/hooks/lib/codex-stage.sh
+++ b/claude/.claude/hooks/lib/codex-stage.sh
@@ -13,16 +13,16 @@
 #
 # Modes:
 #   codex-stage.sh review [--uncommitted | --base <branch> | --commit <sha>]
-#                         [--dir <path>] [--timeout <sec>] [--title <t>] [--out <file>]
+#                         [--dir <path>] [--timeout <sec>] [--title <t>]
 #       First-class diff review (codex exec review). `codex exec review` accepts
 #       no -C/--sandbox flags, so the target directory is entered with cd.
 #       Default selector: --uncommitted. Read-only by nature.
 #
-#   codex-stage.sh prompt [--dir <path>] [--timeout <sec>] [--out <file>] [--schema <file>]
+#   codex-stage.sh prompt [--dir <path>] [--timeout <sec>] [--schema <file>]
 #       Read-only analysis/review with a custom prompt read from stdin.
 #       The wrapper pins <dir> with cd before running codex from that cwd.
 #
-#   codex-stage.sh poc --worktree <abs-path> [--timeout <sec>] [--network] [--out <file>]
+#   codex-stage.sh poc --worktree <abs-path> [--timeout <sec>] [--network]
 #       Implementation PoC read from stdin, confined to an isolated linked git
 #       worktree (codex -a never exec --sandbox workspace-write from <worktree>).
 #       Prints `git status --porcelain` + `git diff --stat` of the worktree after
@@ -38,9 +38,9 @@
 #       runs never touch the same path). Same rails as poc (codex -a never exec
 #       --sandbox workspace-write from the pinned <dir>; no danger flags, no
 #       --add-dir, no -m). Prints a repo-wide `git status --porcelain` + `git diff --stat`
-#       after the run. Changes stay uncommitted for review. run does not accept
-#       --out (its output is returned on stdout) and uses exit 13, not poc's 14,
-#       for a non-git-work-tree target. Note: confinement of codex's edits to
+#       after the run. Changes stay uncommitted for review. Output is returned
+#       on stdout. run uses exit 13, not poc's 14, for a non-git-work-tree target.
+#       Note: confinement of codex's edits to
 #       <dir> is codex's own workspace-write sandbox (writable root = the -C dir),
 #       not something this wrapper enforces beyond withholding --add-dir.
 #
@@ -73,34 +73,21 @@ die() {
   exit "${2:-13}"
 }
 
-directory_identity() {
-  local path=$1 identity
-  if identity=$(stat -c '%d:%i' -- "$path" 2>/dev/null); then
-    printf '%s' "$identity"
+validate_bounded_integer() {
+  local name=$1 value=$2 minimum=$3 maximum=$4
+  case $value in
+    ""|*[!0-9]*|0[0-9]*) die "$name must be a canonical decimal integer" 13 ;;
+  esac
+  if [ "$value" -ge "$minimum" ] && [ "$value" -le "$maximum" ]; then
     return 0
   fi
-  if identity=$(stat -f '%d:%i' "$path" 2>/dev/null); then
-    printf '%s' "$identity"
-    return 0
-  fi
-  return 1
+  die "$name must be between $minimum and $maximum" 13
 }
 
 pin_directory() {
-  local path=$1 actual_path
+  local path=$1
   cd -P -- "$path" || die "cannot enter directory: $path" 13
-  actual_path=$(pwd -P) || die "cannot resolve directory after entry: $path" 13
-  if [ -n "$EXPECTED_DIR_PATH" ]; then
-    [ "$actual_path" = "$EXPECTED_DIR_PATH" ] \
-      || die "directory path changed before execution: $path" 13
-  fi
-  if [ -n "$EXPECTED_DIR_IDENTITY" ]; then
-    local actual_identity
-    actual_identity=$(directory_identity .) \
-      || die "cannot verify directory identity: $path" 13
-    [ "$actual_identity" = "$EXPECTED_DIR_IDENTITY" ] \
-      || die "directory identity changed before execution: $path" 13
-  fi
+  pwd -P >/dev/null || die "cannot resolve directory after entry: $path" 13
 }
 
 # Portable timeout: background the command, kill it from a watchdog.
@@ -227,13 +214,10 @@ TIMEOUT=600
 RETRY=1
 RETRY_WAIT=30
 DIR=$PWD
-OUT=""
 SCHEMA=""
 TITLE=""
 WORKTREE=""
 NETWORK=0
-EXPECTED_DIR_IDENTITY=""
-EXPECTED_DIR_PATH=""
 SELECTOR=()
 
 while [ $# -gt 0 ]; do
@@ -246,34 +230,20 @@ while [ $# -gt 0 ]; do
     --retry) RETRY=${2:?--retry needs a count}; shift ;;
     --retry-wait) RETRY_WAIT=${2:?--retry-wait needs seconds}; shift ;;
     --title) TITLE=${2:?--title needs text}; shift ;;
-    --out) OUT=${2:?--out needs a file}; shift ;;
     --schema) SCHEMA=${2:?--schema needs a file}; shift ;;
     --worktree) WORKTREE=${2:?--worktree needs an absolute path}; shift ;;
     --network) NETWORK=1 ;;
-    --expected-dir-identity) EXPECTED_DIR_IDENTITY=${2:?--expected-dir-identity needs device:inode}; shift ;;
-    --expected-dir-path) EXPECTED_DIR_PATH=${2:?--expected-dir-path needs an absolute path}; shift ;;
     -h|--help) usage ;;
     *) die "unknown argument: $1" 13 ;;
   esac
   shift
 done
 
-if [ -n "$EXPECTED_DIR_IDENTITY" ] && [ -z "$EXPECTED_DIR_PATH" ]; then
-  die "--expected-dir-identity requires --expected-dir-path" 13
-fi
-if [ -n "$EXPECTED_DIR_PATH" ] && [ -z "$EXPECTED_DIR_IDENTITY" ]; then
-  die "--expected-dir-path requires --expected-dir-identity" 13
-fi
+validate_bounded_integer "--timeout" "$TIMEOUT" 1 3600
+validate_bounded_integer "--retry" "$RETRY" 0 10
+validate_bounded_integer "--retry-wait" "$RETRY_WAIT" 0 300
 
 preflight
-
-# Absolutize --out before any cd/-C changes what "relative" means.
-if [ -n "$OUT" ]; then
-  case $OUT in
-    /*) ;;
-    *) OUT="$PWD/$OUT" ;;
-  esac
-fi
 
 case $MODE in
   review)
@@ -286,8 +256,7 @@ case $MODE in
     rc=0
     run_codex "" codex exec review "${SELECTOR[@]}" \
       --ephemeral \
-      ${TITLE:+--title "$TITLE"} \
-      ${OUT:+-o "$OUT"} || rc=$?
+      ${TITLE:+--title "$TITLE"} || rc=$?
     [ "$rc" -eq 0 ] || { report_failure "$rc"; exit "$rc"; }
     ;;
 
@@ -301,7 +270,6 @@ case $MODE in
       --sandbox read-only \
       --ephemeral \
       --skip-git-repo-check \
-      ${OUT:+-o "$OUT"} \
       ${SCHEMA:+--output-schema "$SCHEMA"} \
       - || rc=$?
     [ "$rc" -eq 0 ] || { report_failure "$rc"; exit "$rc"; }
@@ -337,7 +305,6 @@ case $MODE in
       --sandbox workspace-write \
       --ephemeral \
       ${NETWORK_OPT:+-c "$NETWORK_OPT"} \
-      ${OUT:+-o "$OUT"} \
       - || rc=$?
     [ "$rc" -eq 0 ] || { report_failure "$rc"; exit "$rc"; }
     echo ""
@@ -358,12 +325,6 @@ case $MODE in
     git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
       || die "run mode requires a git work tree (for reviewability): $DIR" 13
     TOPLEVEL=$(git rev-parse --show-toplevel)
-    # run's write surface is strictly --dir. --out/-o would let codex write its
-    # output file to a path absolutized against the caller's $PWD, outside that
-    # boundary — so run does not accept it. The caller captures codex's output
-    # from this wrapper's stdout instead.
-    [ -z "$OUT" ] \
-      || die "run mode does not support --out — codex output is returned on stdout" 13
     buffer_stdin
     NETWORK_OPT=""
     [ "$NETWORK" -eq 1 ] && NETWORK_OPT="sandbox_workspace_write.network_access=true"

--- a/pi/LOCAL_PERMISSION_JUDGE.md
+++ b/pi/LOCAL_PERMISSION_JUDGE.md
@@ -121,6 +121,23 @@ deterministic floor, explicit confirmation, or local judge.
 ## Decision order
 
 1. Mandatory deny rule: block.
+
+Managed Codex children have one explicit exception before the remaining steps.
+When trusted agent frontmatter declared the requested mode, a literal
+`codex-stage.sh` direct review call or documented `printf` prompt pipeline sent
+through `bash_escalated` is released without project discovery or Ollama. Pi
+does not inspect wrapper arguments, copy/pin staged files, verify cwd/worktree
+identity, or add its OS sandbox. It pins only the trusted wrapper bytes in a
+private read-only executable at child startup, then substitutes that launcher
+without changing Codex arguments. If snapshot creation fails, the capability is
+disabled while the normal fail-closed policy remains registered. The wrapper
+rejects `--out` and validates its timeout/retry numeric controls; the wrapper,
+Codex sandbox, and workflow
+isolation/write-scope contracts own the remaining checks. The shell-envelope
+recognizer still rejects undeclared modes, active substitutions, redirects,
+extra commands, non-literal wrapper paths, and malformed pipelines, which
+continue through the ordinary escalated policy below.
+
 2. Mandatory structural risk floor: ask the user, or block without UI. This
    includes destructive/force Git and filesystem operations, unverified Git
    location or transport overrides, privilege/secrets (including input
@@ -213,6 +230,12 @@ but not package runners; an unknown manager option before a later runner token
 stays conservative. In child profiles, preflight and policy rejections share the
 same authenticated permission-block signal so a blocked child cannot be
 reported as successful. Claude Code and Codex keep their existing hook behavior.
+
+The managed-child `codex-stage.sh` exception above is capability-based rather
+than a checked-in Bash allow: the parent derives its modes from trusted agent
+frontmatter, passes them through the sanitized child environment, and the child
+consumes them once. Parent sessions and arbitrary child task text cannot mint
+that capability.
 
 The checked-in allow entries mirror the broad Bash grants in
 `claude/.claude/settings.json`. They represent explicit user trust, not a claim

--- a/pi/README.md
+++ b/pi/README.md
@@ -61,9 +61,11 @@ The harness stays a single umbrella extension (`extensions/pi-harness/index.ts`)
 composing compatibility features in a fixed order. Bash audit starts first;
 the non-executing npm-script preflight may short-circuit next; permission-policy
 then remains the mandatory safety floor before the remaining hook-bridge
-features. Every handler evaluates the original command. Only after they pass is
-ordinary Bash replaced with an OS-sandbox wrapper and the audit record released
-to controlled execution. The preflight uses `/bin/bash` with a fixed root-owned
+features. Permission handlers evaluate the original command. Only after they
+pass is ordinary Bash replaced with an OS-sandbox wrapper and the audit record
+released to controlled execution. The managed Codex exception instead replaces
+only the already-validated wrapper token with a private read-only snapshot of
+that wrapper's bytes. The preflight uses `/bin/bash` with a fixed root-owned
 system `PATH`, never the repository-influenced inherited path. The
 `hearth-tools` extension is separate so native-addon preflight cannot partially
 initialize the permission/audit extension. It replaces pi's `read`, `write`,
@@ -152,10 +154,24 @@ confirmation and block without UI instead of becoming less restrictive.
 
 `bash_escalated` is the only explicit sandbox escape. It is intended only when
 the requested operation genuinely needs an effect blocked by ordinary Bash.
-Every call ignores configured/skill automatic allows, bypasses the ALLOW cache,
-and requires a fresh local classifier ALLOW; any other outcome confirms with an
-interactive user or blocks in no-UI children. Hard-denied relay/import commands
-remain denied before both execution paths.
+Calls normally ignore configured/skill automatic allows, bypass the ALLOW
+cache, and require a fresh local classifier ALLOW; any other outcome confirms
+with an interactive user or blocks in no-UI children. The one managed-child
+exception is a literal `codex-stage.sh` launch whose mode was declared by the
+trusted Codex agent definition. Pi admits that call before project discovery or
+the local judge and does not wrap it in Pi's OS sandbox, copy/pin its staged
+files, or constrain its wrapper arguments. It snapshots only the trusted
+wrapper executable into a private read-only file at child startup, preventing
+the child from replacing the home symlink before its authorized launch; the
+wrapper token changes, while every Codex argument remains intact. If that
+snapshot cannot be created, Pi disables the managed capability but still
+registers the normal fail-closed permission policy. `codex-stage.sh`, Codex's
+own read-only/workspace-write sandbox, and the workflow
+isolation/write-scope contracts are authoritative. The wrapper rejects
+sandbox-external `--out` files and validates timeout/retry controls before shell
+arithmetic. Pi still rejects an undeclared mode or a shell envelope containing
+substitutions, redirects, extra commands, or a non-literal wrapper. Hard-denied
+relay/import commands remain denied before both execution paths.
 
 The safety layer also appends soft command-hygiene guidance to every parent and
 child system prompt: prefer dedicated file tools, literal project-bounded
@@ -451,6 +467,11 @@ hook is advisory):
   validated linked worktree per task (bit-task creator, S1 postconditions)
   and leaves it in place — no auto merge, no auto remove.
 - Parallel `codex-runner` tasks must declare disjoint `writeScope`s.
+- Managed Codex agents invoke `codex-stage.sh` directly through
+  `bash_escalated`. Pi validates only the trusted agent's declared mode and the
+  literal shell envelope, then delegates execution safety to the wrapper and
+  Codex sandbox instead of nesting Codex inside Pi's effect sandbox or local
+  judge.
 - A failing task degrades the stage (reported as FAILED) instead of aborting
   the workflow — synthesis/judging stays with the parent agent.
 

--- a/pi/extensions/pi-harness/features/bash-sandbox/index.ts
+++ b/pi/extensions/pi-harness/features/bash-sandbox/index.ts
@@ -76,8 +76,6 @@ export interface BashSandboxController {
   registerWritableWorktree(path: string): Promise<void>;
   revokeWritableWorktree(path: string): Promise<void>;
   boundaryFor(toolName: string): BashExecutionBoundary | undefined;
-  scratchDirectoryFor(toolName: string): string | undefined;
-  scratchBoundaryFor(toolName: string): BashScratchBoundary | undefined;
   registerExecutionBoundary(options: {
     blockToolCall: (reason: string) => PermissionBlockResult;
     permissionAudit?: PermissionAuditIntegration;
@@ -221,11 +219,11 @@ export const setupBashSandbox = (
     name: "bash_escalated",
     label: "Bash (outside effect sandbox)",
     description:
-      "Execute a shell command outside the OS effect sandbox. Use only when ordinary bash was blocked by the sandbox and the requested effect is required. Every call is independently classified and may require user confirmation.",
+      "Execute a shell command outside the OS effect sandbox. Use when the requested effect is already known to require execution outside that sandbox (including managed codex-stage launches), or after ordinary bash is blocked. Calls normally require independent classification or user confirmation.",
     promptSnippet:
-      "Execute a classifier-gated command outside the OS effect sandbox",
+      "Execute a permission-gated command outside the OS effect sandbox",
     promptGuidelines: [
-      "Use bash_escalated only after ordinary bash fails because an explicitly requested effect is outside the sandbox; never use it merely to avoid a sandbox restriction.",
+      "Use bash_escalated directly for managed codex-stage launches and other effects already known to require execution outside Pi's sandbox; otherwise use it only after ordinary bash is blocked, never merely to avoid a sandbox restriction.",
     ],
   } as unknown as ToolDefLike);
 
@@ -425,24 +423,6 @@ export const setupBashSandbox = (
         network: networkMode(),
         profileFingerprint: profile?.fingerprint ?? "unavailable",
       };
-    },
-    scratchDirectoryFor(toolName) {
-      if (
-        (toolName !== "bash" && toolName !== "bash_escalated") ||
-        state.kind !== "ready"
-      ) {
-        return undefined;
-      }
-      return state.scratchBoundary?.path;
-    },
-    scratchBoundaryFor(toolName) {
-      if (
-        (toolName !== "bash" && toolName !== "bash_escalated") ||
-        state.kind !== "ready"
-      ) {
-        return undefined;
-      }
-      return state.scratchBoundary;
     },
     registerExecutionBoundary({ blockToolCall, permissionAudit }) {
       pi.on("tool_call", async (event, ctx) => {

--- a/pi/extensions/pi-harness/features/permission-policy/codex-stage-capability.ts
+++ b/pi/extensions/pi-harness/features/permission-policy/codex-stage-capability.ts
@@ -11,20 +11,9 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import {
-  chmod,
-  lstat,
-  mkdtemp,
-  open,
-  realpath,
-  writeFile,
-} from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { basename, dirname, isAbsolute, join } from "node:path";
+import { join } from "node:path";
 import { CODEX_STAGE_MODES, type CodexStageMode } from "../../lib/agent-md";
-import { isPathWithin } from "../../lib/trust";
-import type { BashScratchBoundary } from "../bash-sandbox";
-import type { PermissionProjectContext } from "./context";
 import { scanCommand, type Segment } from "./scan";
 
 export const CODEX_STAGE_CAPABILITY_ENV = "PI_HARNESS_CODEX_STAGE_CAPABILITY";
@@ -32,108 +21,29 @@ export const CODEX_STAGE_CAPABILITY_ENV = "PI_HARNESS_CODEX_STAGE_CAPABILITY";
 const CODEX_STAGE_WRAPPER = "~/.claude/hooks/lib/codex-stage.sh";
 const PROMPT_PREFIX = "Read ";
 const PROMPT_SUFFIX = " completely and follow it exactly.";
-const EXPECTED_DIRECTORY_IDENTITY_FLAG = "--expected-dir-identity";
-const EXPECTED_DIRECTORY_PATH_FLAG = "--expected-dir-path";
-const SAFE_GIT_SELECTOR = /^[A-Za-z0-9._/@{}~^:+-]+$/;
-const POSITIVE_INTEGER = /^[1-9][0-9]*$/;
-const NON_NEGATIVE_INTEGER = /^(?:0|[1-9][0-9]*)$/;
-const SAFE_STAGED_FILE_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]{0,159}$/;
 const MAX_WRAPPER_BYTES = 512 * 1024;
-const MAX_STAGED_ARTIFACT_BYTES = 8 * 1024 * 1024;
-const MAX_PRIVATE_ARTIFACT_BYTES = 32 * 1024 * 1024;
-const MAX_PRIVATE_ARTIFACTS = 16;
 
-export const consumeCodexStageCapability = (
-  isChild: boolean,
-  env: NodeJS.ProcessEnv = process.env,
-): ReadonlySet<CodexStageMode> => {
-  const raw = env[CODEX_STAGE_CAPABILITY_ENV];
-  delete env[CODEX_STAGE_CAPABILITY_ENV];
-  if (!isChild || raw === undefined || raw.length > 64) return new Set();
-
-  const modes = raw.split(",");
-  const knownModes = new Set<string>(CODEX_STAGE_MODES);
-  if (
-    modes.length === 0 ||
-    modes.some((mode) => !knownModes.has(mode)) ||
-    new Set(modes).size !== modes.length
-  ) {
-    return new Set();
-  }
-  return new Set(modes as CodexStageMode[]);
-};
-
-export interface CodexStageCapabilityRuntime {
+export interface CodexStageExecutablePin {
   readonly executablePath: string;
-  stageFile(
-    sourcePath: string,
-    scratchBoundary: BashScratchBoundary,
-    fileName: "prompt.md" | "schema.json",
-  ): Promise<string | undefined>;
-  releaseFiles(paths: readonly string[]): void;
   dispose(): void;
-}
-
-interface CreateCodexStageCapabilityRuntimeOptions {
-  readonly temporaryDirectory?: string;
-}
-
-interface PrivateArtifact {
-  readonly directory: string;
-  readonly bytes: number;
 }
 
 const removePrivateDirectory = (directory: string): void => {
   try {
     chmodSync(directory, 0o700);
   } catch {
-    // A missing or already-cleaned directory needs no further preparation.
+    // A missing or already-cleaned directory needs no preparation.
   }
   try {
     rmSync(directory, { recursive: true, force: true });
   } catch {
-    // Session cleanup is best-effort; capability files are non-writable and
-    // live only in a private temporary directory.
+    // Session cleanup is best-effort; the pinned file is non-writable and
+    // contains only the versioned wrapper, not prompts or model output.
   }
 };
 
 const hasExpectedOwner = (uid: number): boolean =>
   typeof process.getuid !== "function" || uid === process.getuid();
-
-const scratchIdentityMatches = async (
-  boundary: BashScratchBoundary,
-): Promise<boolean> => {
-  if (!isAbsolute(boundary.path)) return false;
-  try {
-    const stat = await lstat(boundary.path);
-    return (
-      stat.isDirectory() &&
-      !stat.isSymbolicLink() &&
-      `${stat.dev}:${stat.ino}` === boundary.identity
-    );
-  } catch {
-    return false;
-  }
-};
-
-const readBoundedFile = async (
-  handle: Awaited<ReturnType<typeof open>>,
-  expectedBytes: number,
-): Promise<Buffer | undefined> => {
-  const buffer = Buffer.alloc(expectedBytes + 1);
-  let offset = 0;
-  while (offset < buffer.byteLength) {
-    const { bytesRead } = await handle.read(
-      buffer,
-      offset,
-      buffer.byteLength - offset,
-      null,
-    );
-    if (bytesRead === 0) break;
-    offset += bytesRead;
-  }
-  return offset === expectedBytes ? buffer.subarray(0, offset) : undefined;
-};
 
 const readTrustedExecutable = (source: string): Buffer => {
   const descriptor = openSync(
@@ -185,151 +95,84 @@ const readTrustedExecutable = (source: string): Buffer => {
   }
 };
 
-export const createCodexStageCapabilityRuntime = (
+/**
+ * Snapshot only the trusted launcher into a private, read-only executable.
+ *
+ * This is not an execution sandbox and does not inspect or alter Codex
+ * arguments, cwd, worktree, prompts, or output. It closes the launcher TOCTOU
+ * between child startup and the child's one authorized escalated call.
+ */
+export const createCodexStageExecutablePin = (
   sourceExecutable: string,
-  options: CreateCodexStageCapabilityRuntimeOptions = {},
-): CodexStageCapabilityRuntime => {
-  const temporaryDirectory = options.temporaryDirectory ?? tmpdir();
+  temporaryDirectory: string = tmpdir(),
+): CodexStageExecutablePin => {
   const source = realpathSync(sourceExecutable);
-  const executableContents = readTrustedExecutable(source);
-  const executableDirectory = mkdtempSync(
+  const contents = readTrustedExecutable(source);
+  const directory = mkdtempSync(
     join(temporaryDirectory, "pi-codex-stage-bin-"),
   );
-  const executablePath = join(executableDirectory, "codex-stage.sh");
+  const executablePath = join(directory, "codex-stage.sh");
   try {
-    writeFileSync(executablePath, executableContents, {
-      flag: "wx",
-      mode: 0o500,
-    });
-    chmodSync(executableDirectory, 0o500);
+    writeFileSync(executablePath, contents, { flag: "wx", mode: 0o500 });
+    chmodSync(directory, 0o500);
   } catch (error) {
-    removePrivateDirectory(executableDirectory);
+    removePrivateDirectory(directory);
     throw error;
   }
-
-  const artifacts = new Map<string, PrivateArtifact>();
-  let artifactBytes = 0;
-  let inFlightArtifacts = 0;
-  let inFlightBytes = 0;
   let disposed = false;
-  const releaseFiles = (paths: readonly string[]): void => {
-    for (const path of paths) {
-      const artifact = artifacts.get(path);
-      if (artifact === undefined) continue;
-      artifacts.delete(path);
-      artifactBytes -= artifact.bytes;
-      removePrivateDirectory(artifact.directory);
-    }
-  };
   return {
     executablePath,
-    async stageFile(sourcePath, scratchBoundary, fileName) {
-      if (
-        disposed ||
-        !isAbsolute(sourcePath) ||
-        dirname(sourcePath) !== scratchBoundary.path ||
-        !SAFE_STAGED_FILE_NAME.test(basename(sourcePath)) ||
-        !(await scratchIdentityMatches(scratchBoundary))
-      ) {
-        return undefined;
-      }
-      let handle: Awaited<ReturnType<typeof open>> | undefined;
-      let artifactDirectory: string | undefined;
-      let reserved = false;
-      let reservedBytes = 0;
-      let registered = false;
-      try {
-        handle = await open(
-          sourcePath,
-          constants.O_RDONLY |
-            (constants.O_NOFOLLOW ?? 0) |
-            (constants.O_NONBLOCK ?? 0),
-        );
-        const openedStat = await handle.stat();
-        if (
-          disposed ||
-          !openedStat.isFile() ||
-          openedStat.nlink !== 1 ||
-          openedStat.size > MAX_STAGED_ARTIFACT_BYTES ||
-          !hasExpectedOwner(openedStat.uid) ||
-          artifacts.size + inFlightArtifacts >= MAX_PRIVATE_ARTIFACTS ||
-          artifactBytes + inFlightBytes + openedStat.size >
-            MAX_PRIVATE_ARTIFACT_BYTES
-        ) {
-          return undefined;
-        }
-        inFlightArtifacts += 1;
-        inFlightBytes += openedStat.size;
-        reserved = true;
-        reservedBytes = openedStat.size;
-
-        const currentStat = await lstat(sourcePath);
-        if (
-          disposed ||
-          currentStat.isSymbolicLink() ||
-          !currentStat.isFile() ||
-          currentStat.dev !== openedStat.dev ||
-          currentStat.ino !== openedStat.ino
-        ) {
-          return undefined;
-        }
-
-        const contents = await readBoundedFile(handle, openedStat.size);
-        if (disposed || contents === undefined) return undefined;
-        const finalOpenedStat = await handle.stat();
-        const finalCurrentStat = await lstat(sourcePath);
-        if (
-          disposed ||
-          finalOpenedStat.dev !== openedStat.dev ||
-          finalOpenedStat.ino !== openedStat.ino ||
-          finalOpenedStat.size !== openedStat.size ||
-          finalOpenedStat.nlink !== 1 ||
-          !hasExpectedOwner(finalOpenedStat.uid) ||
-          finalCurrentStat.isSymbolicLink() ||
-          !finalCurrentStat.isFile() ||
-          finalCurrentStat.dev !== openedStat.dev ||
-          finalCurrentStat.ino !== openedStat.ino ||
-          !(await scratchIdentityMatches(scratchBoundary))
-        ) {
-          return undefined;
-        }
-        artifactDirectory = await mkdtemp(
-          join(temporaryDirectory, "pi-codex-stage-artifact-"),
-        );
-        if (disposed) return undefined;
-        const artifactPath = join(artifactDirectory, fileName);
-        await writeFile(artifactPath, contents, { flag: "wx", mode: 0o400 });
-        if (disposed) return undefined;
-        await chmod(artifactDirectory, 0o500);
-        if (disposed) return undefined;
-        artifacts.set(artifactPath, {
-          directory: artifactDirectory,
-          bytes: contents.byteLength,
-        });
-        artifactBytes += contents.byteLength;
-        registered = true;
-        return artifactPath;
-      } catch {
-        return undefined;
-      } finally {
-        if (reserved) {
-          inFlightArtifacts -= 1;
-          inFlightBytes -= reservedBytes;
-        }
-        await handle?.close().catch(() => {});
-        if (artifactDirectory !== undefined && !registered) {
-          removePrivateDirectory(artifactDirectory);
-        }
-      }
-    },
-    releaseFiles,
     dispose() {
       if (disposed) return;
       disposed = true;
-      releaseFiles([...artifacts.keys()]);
-      removePrivateDirectory(executableDirectory);
+      removePrivateDirectory(directory);
     },
   };
+};
+
+const shellQuote = (value: string): string =>
+  `'${value.replaceAll("'", `'\\''`)}'`;
+
+export const pinCodexStageCommand = (
+  command: string,
+  executablePath: string,
+  wrapperIndex: number,
+): string | undefined => {
+  if (
+    wrapperIndex < 0 ||
+    command.slice(wrapperIndex, wrapperIndex + CODEX_STAGE_WRAPPER.length) !==
+      CODEX_STAGE_WRAPPER
+  ) {
+    return undefined;
+  }
+  return `${command.slice(0, wrapperIndex)}${shellQuote(executablePath)}${command.slice(wrapperIndex + CODEX_STAGE_WRAPPER.length)}`;
+};
+
+/**
+ * Consume the managed-child capability once at extension startup.
+ *
+ * The parent derives this value from trusted agent frontmatter. Repository task
+ * text and shell commands cannot add modes, and a parent process never accepts
+ * the environment value as a capability for itself.
+ */
+export const consumeCodexStageCapability = (
+  isChild: boolean,
+  env: NodeJS.ProcessEnv = process.env,
+): ReadonlySet<CodexStageMode> => {
+  const raw = env[CODEX_STAGE_CAPABILITY_ENV];
+  delete env[CODEX_STAGE_CAPABILITY_ENV];
+  if (!isChild || raw === undefined || raw.length > 64) return new Set();
+
+  const modes = raw.split(",");
+  const knownModes = new Set<string>(CODEX_STAGE_MODES);
+  if (
+    modes.length === 0 ||
+    modes.some((mode) => !knownModes.has(mode)) ||
+    new Set(modes).size !== modes.length
+  ) {
+    return new Set();
+  }
+  return new Set(modes as CodexStageMode[]);
 };
 
 const isLiteralSimpleSegment = (segment: Segment): boolean =>
@@ -341,78 +184,8 @@ const isLiteralSimpleSegment = (segment: Segment): boolean =>
   segment.opaque.size === 0 &&
   segment.literalGlobs.size === 0;
 
-interface CanonicalDirectory {
-  readonly path: string;
-  readonly identity: string;
-}
-
-const canonicalDirectory = async (
-  path: string,
-): Promise<CanonicalDirectory | undefined> => {
-  if (!isAbsolute(path)) return undefined;
-  try {
-    const initialStat = await lstat(path);
-    if (!initialStat.isDirectory() || initialStat.isSymbolicLink()) {
-      return undefined;
-    }
-    const canonicalPath = await realpath(path);
-    const canonicalStat = await lstat(canonicalPath);
-    const finalStat = await lstat(path);
-    if (
-      !canonicalStat.isDirectory() ||
-      canonicalStat.isSymbolicLink() ||
-      !finalStat.isDirectory() ||
-      finalStat.isSymbolicLink() ||
-      initialStat.dev !== canonicalStat.dev ||
-      initialStat.ino !== canonicalStat.ino ||
-      finalStat.dev !== canonicalStat.dev ||
-      finalStat.ino !== canonicalStat.ino
-    ) {
-      return undefined;
-    }
-    return {
-      path: canonicalPath,
-      identity: `${canonicalStat.dev}:${canonicalStat.ino}`,
-    };
-  } catch {
-    return undefined;
-  }
-};
-
-const stagedPromptSourcePath = (segment: Segment): string | undefined => {
-  const [head, format, instruction] = segment.words;
-  if (
-    segment.words.length !== 3 ||
-    head !== "printf" ||
-    format !== "%s" ||
-    instruction === undefined ||
-    !instruction.startsWith(PROMPT_PREFIX) ||
-    !instruction.endsWith(PROMPT_SUFFIX)
-  ) {
-    return undefined;
-  }
-  const path = instruction.slice(PROMPT_PREFIX.length, -PROMPT_SUFFIX.length);
-  return path === "" || !isAbsolute(path) ? undefined : path;
-};
-
-interface ParsedWrapperCall {
-  readonly mode: CodexStageMode;
-  readonly args: readonly string[];
-  readonly directory?: string;
-  readonly directoryValueIndex?: number;
-  readonly worktree?: string;
-  readonly worktreeValueIndex?: number;
-  readonly schema?: string;
-  readonly schemaValueIndex?: number;
-}
-
-const consumeValue = (
-  words: readonly string[],
-  index: number,
-): string | undefined => words[index + 1];
-
-const parseWrapperCall = (segment: Segment): ParsedWrapperCall | undefined => {
-  const [wrapper, rawMode, ...args] = segment.words;
+const wrapperMode = (segment: Segment): CodexStageMode | undefined => {
+  const [wrapper, rawMode] = segment.words;
   if (
     wrapper !== CODEX_STAGE_WRAPPER ||
     rawMode === undefined ||
@@ -420,160 +193,133 @@ const parseWrapperCall = (segment: Segment): ParsedWrapperCall | undefined => {
   ) {
     return undefined;
   }
-  const mode = rawMode as CodexStageMode;
-  let directory: string | undefined;
-  let directoryValueIndex: number | undefined;
-  let worktree: string | undefined;
-  let worktreeValueIndex: number | undefined;
-  let schema: string | undefined;
-  let schemaValueIndex: number | undefined;
-  let selectorCount = 0;
-  const seen = new Set<string>();
-
-  for (let index = 0; index < args.length; index += 1) {
-    const flag = args[index];
-    if (flag === undefined || seen.has(flag)) return undefined;
-    seen.add(flag);
-    switch (flag) {
-      case "--timeout": {
-        const value = consumeValue(args, index);
-        if (
-          value === undefined ||
-          !POSITIVE_INTEGER.test(value) ||
-          Number(value) > 3_600
-        ) {
-          return undefined;
-        }
-        index += 1;
-        break;
-      }
-      case "--retry": {
-        const value = consumeValue(args, index);
-        if (
-          value === undefined ||
-          !NON_NEGATIVE_INTEGER.test(value) ||
-          Number(value) > 10
-        ) {
-          return undefined;
-        }
-        index += 1;
-        break;
-      }
-      case "--retry-wait": {
-        const value = consumeValue(args, index);
-        if (
-          value === undefined ||
-          !NON_NEGATIVE_INTEGER.test(value) ||
-          Number(value) > 300
-        ) {
-          return undefined;
-        }
-        index += 1;
-        break;
-      }
-      case "--dir": {
-        if (mode !== "prompt" && mode !== "review" && mode !== "run") {
-          return undefined;
-        }
-        directory = consumeValue(args, index);
-        if (directory === undefined) return undefined;
-        directoryValueIndex = index + 1;
-        index += 1;
-        break;
-      }
-      case "--worktree": {
-        if (mode !== "poc") return undefined;
-        worktree = consumeValue(args, index);
-        if (worktree === undefined) return undefined;
-        worktreeValueIndex = index + 1;
-        index += 1;
-        break;
-      }
-      case "--schema": {
-        if (mode !== "prompt") return undefined;
-        schema = consumeValue(args, index);
-        if (schema === undefined) return undefined;
-        schemaValueIndex = index + 1;
-        index += 1;
-        break;
-      }
-      case "--uncommitted": {
-        if (mode !== "review") return undefined;
-        selectorCount += 1;
-        break;
-      }
-      case "--base":
-      case "--commit": {
-        if (mode !== "review") return undefined;
-        const value = consumeValue(args, index);
-        if (
-          value === undefined ||
-          value.startsWith("-") ||
-          !SAFE_GIT_SELECTOR.test(value)
-        ) {
-          return undefined;
-        }
-        selectorCount += 1;
-        index += 1;
-        break;
-      }
-      case "--network": {
-        if (mode !== "poc" && mode !== "run") return undefined;
-        break;
-      }
-      default: {
-        return undefined;
-      }
-    }
-  }
-
-  if (selectorCount > 1) return undefined;
-  if (mode === "poc" && worktree === undefined) return undefined;
-  if (mode === "run" && directory === undefined) return undefined;
-  return {
-    mode,
-    args,
-    ...(directory === undefined ? {} : { directory, directoryValueIndex }),
-    ...(worktree === undefined ? {} : { worktree, worktreeValueIndex }),
-    ...(schema === undefined ? {} : { schema, schemaValueIndex }),
-  };
+  return rawMode as CodexStageMode;
 };
 
-const shellQuote = (value: string): string =>
-  `'${value.replaceAll("'", `'"'"'`)}'`;
+const isStagedPromptProducer = (segment: Segment): boolean => {
+  const [head, format, instruction] = segment.words;
+  return (
+    segment.words.length === 3 &&
+    head === "printf" &&
+    format === "%s" &&
+    instruction !== undefined &&
+    instruction.startsWith(PROMPT_PREFIX) &&
+    instruction.endsWith(PROMPT_SUFFIX) &&
+    instruction.length > PROMPT_PREFIX.length + PROMPT_SUFFIX.length
+  );
+};
 
-export interface CodexStageCapabilityContext {
-  readonly modes: ReadonlySet<CodexStageMode>;
-  readonly cwd: string;
-  readonly scratchBoundary?: BashScratchBoundary;
-  readonly project: PermissionProjectContext;
-  readonly runtime?: CodexStageCapabilityRuntime;
-}
+const isShellWhitespace = (value: string | undefined): boolean =>
+  value !== undefined && /\s/u.test(value);
 
-export interface AuthorizedCodexStageEscalation {
-  readonly command: string;
-  readonly artifacts: readonly string[];
-}
+const wrapperTokenAt = (command: string, index: number): boolean =>
+  command.startsWith(CODEX_STAGE_WRAPPER, index) &&
+  (index + CODEX_STAGE_WRAPPER.length === command.length ||
+    isShellWhitespace(command[index + CODEX_STAGE_WRAPPER.length]));
 
-export const authorizeCodexStageEscalation = async (
-  command: string,
-  context: CodexStageCapabilityContext,
-): Promise<AuthorizedCodexStageEscalation | undefined> => {
-  if (
-    context.modes.size === 0 ||
-    context.scratchBoundary === undefined ||
-    context.project.kind !== "git" ||
-    context.runtime === undefined
-  ) {
-    return undefined;
+const firstCommandTokenIndex = (command: string): number => {
+  let index = 0;
+  while (isShellWhitespace(command[index])) index += 1;
+  return index;
+};
+
+const startsShellComment = (command: string, index: number): boolean => {
+  if (command[index] !== "#") return false;
+  const previous = command[index - 1];
+  return (
+    previous === undefined ||
+    isShellWhitespace(previous) ||
+    previous === ";" ||
+    previous === "|" ||
+    previous === "&" ||
+    previous === "(" ||
+    previous === ")"
+  );
+};
+
+const topLevelPipeIndex = (command: string): number | undefined => {
+  let quote: "single" | "double" | undefined;
+  let escaped = false;
+  for (let index = 0; index < command.length; index += 1) {
+    const character = command[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (quote !== "single" && character === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote === "single") {
+      if (character === "'") quote = undefined;
+      continue;
+    }
+    if (quote === "double") {
+      if (character === '"') quote = undefined;
+      continue;
+    }
+    if (character === "'") {
+      quote = "single";
+      continue;
+    }
+    if (character === '"') {
+      quote = "double";
+      continue;
+    }
+    if (startsShellComment(command, index)) {
+      const newline = command.indexOf("\n", index + 1);
+      if (newline === -1) return undefined;
+      index = newline;
+      continue;
+    }
+    if (
+      character === "|" &&
+      command[index - 1] !== "|" &&
+      command[index + 1] !== "|"
+    ) {
+      return index;
+    }
   }
+  return undefined;
+};
 
-  const { runtime, scratchBoundary } = context;
-  const stagedArtifacts: string[] = [];
-  const releaseStagedArtifacts = (): undefined => {
-    runtime.releaseFiles(stagedArtifacts);
-    return undefined;
-  };
+const literalWrapperIndex = (
+  command: string,
+  mode: CodexStageMode,
+): number | undefined => {
+  if (mode === "review") {
+    const index = firstCommandTokenIndex(command);
+    return wrapperTokenAt(command, index) ? index : undefined;
+  }
+  const pipe = topLevelPipeIndex(command);
+  if (pipe === undefined) return undefined;
+  let index = pipe + 1;
+  while (isShellWhitespace(command[index])) index += 1;
+  return wrapperTokenAt(command, index) ? index : undefined;
+};
+
+export interface CodexStageAuthorization {
+  readonly mode: CodexStageMode;
+  readonly wrapperIndex: number;
+}
+
+/**
+ * Recognize a managed Codex child's wrapper launch.
+ *
+ * Pi deliberately does not re-sandbox, inspect wrapper arguments, pin cwd or
+ * worktree identities, copy staged artifacts, or ask the local judge for these
+ * launches. codex-stage.sh and Codex's own sandbox own those boundaries. The
+ * harness checks only the shell envelope needed to ensure that the escalated
+ * call is the literal wrapper (not arbitrary shell) and that its mode was
+ * declared by the trusted agent definition. Production setup separately pins
+ * the already-trusted wrapper bytes so the child cannot replace its launcher.
+ */
+export const authorizeCodexStageEscalation = (
+  command: string,
+  modes: ReadonlySet<CodexStageMode>,
+): CodexStageAuthorization | undefined => {
+  if (modes.size === 0) return undefined;
+
   const scan = scanCommand(command);
   if (
     !scan.ok ||
@@ -585,115 +331,29 @@ export const authorizeCodexStageEscalation = async (
     return undefined;
   }
 
-  const wrapperSegment = scan.segments.at(-1);
-  if (wrapperSegment === undefined) return undefined;
-  const parsed = parseWrapperCall(wrapperSegment);
-  if (parsed === undefined || !context.modes.has(parsed.mode)) return undefined;
-
-  const activeWorktree = await canonicalDirectory(
-    context.project.activeWorktree,
-  );
-  if (activeWorktree === undefined) return undefined;
-
-  let targetDirectory: CanonicalDirectory;
-  let canonicalWorktree: CanonicalDirectory | undefined;
-  if (parsed.mode === "poc") {
-    canonicalWorktree =
-      parsed.worktree === undefined
-        ? undefined
-        : await canonicalDirectory(parsed.worktree);
-    if (
-      canonicalWorktree === undefined ||
-      canonicalWorktree.path !== activeWorktree.path
-    ) {
-      return undefined;
-    }
-    targetDirectory = canonicalWorktree;
-  } else {
-    const effectiveDirectory = parsed.directory ?? context.cwd;
-    const canonicalTarget = await canonicalDirectory(effectiveDirectory);
-    if (
-      canonicalTarget === undefined ||
-      !isPathWithin(canonicalTarget.path, activeWorktree.path)
-    ) {
-      return undefined;
-    }
-    targetDirectory = canonicalTarget;
-  }
-
-  if (parsed.mode === "review") {
-    if (
-      scan.segments.length !== 1 ||
-      wrapperSegment.followedByAnd ||
-      wrapperSegment.followedByPipe
-    ) {
-      return undefined;
-    }
-  } else {
-    if (
-      scan.segments.length !== 2 ||
-      wrapperSegment.followedByAnd ||
-      wrapperSegment.followedByPipe
-    ) {
-      return undefined;
-    }
-    const promptSegment = scan.segments[0] as Segment;
-    if (!promptSegment.followedByPipe) return undefined;
-  }
-
-  const sanitizedArgs = [...parsed.args];
-  if (parsed.directoryValueIndex !== undefined) {
-    sanitizedArgs[parsed.directoryValueIndex] = targetDirectory.path;
-  }
+  const wrapper = scan.segments.at(-1);
+  if (wrapper === undefined) return undefined;
+  const mode = wrapperMode(wrapper);
   if (
-    parsed.worktreeValueIndex !== undefined &&
-    canonicalWorktree !== undefined
+    mode === undefined ||
+    !modes.has(mode) ||
+    wrapper.followedByAnd ||
+    wrapper.followedByPipe
   ) {
-    sanitizedArgs[parsed.worktreeValueIndex] = canonicalWorktree.path;
+    return undefined;
   }
-  if (parsed.schema !== undefined) {
-    const privateSchema = await runtime.stageFile(
-      parsed.schema,
-      scratchBoundary,
-      "schema.json",
-    );
-    if (privateSchema === undefined) return undefined;
-    stagedArtifacts.push(privateSchema);
-    if (parsed.schemaValueIndex === undefined) {
-      return releaseStagedArtifacts();
-    }
-    sanitizedArgs[parsed.schemaValueIndex] = privateSchema;
-  }
-  sanitizedArgs.push(
-    EXPECTED_DIRECTORY_IDENTITY_FLAG,
-    targetDirectory.identity,
-    EXPECTED_DIRECTORY_PATH_FLAG,
-    targetDirectory.path,
-  );
-  const wrapperCommand = [
-    context.runtime.executablePath,
-    parsed.mode,
-    ...sanitizedArgs,
-  ]
-    .map(shellQuote)
-    .join(" ");
 
-  if (parsed.mode === "review") {
-    return { command: wrapperCommand, artifacts: stagedArtifacts };
+  const wrapperIndex = literalWrapperIndex(command, mode);
+  if (wrapperIndex === undefined) return undefined;
+  if (mode === "review") {
+    return scan.segments.length === 1 ? { mode, wrapperIndex } : undefined;
   }
-  const promptSegment = scan.segments[0] as Segment;
-  const promptSource = stagedPromptSourcePath(promptSegment);
-  if (promptSource === undefined) return releaseStagedArtifacts();
-  const privatePrompt = await runtime.stageFile(
-    promptSource,
-    scratchBoundary,
-    "prompt.md",
-  );
-  if (privatePrompt === undefined) return releaseStagedArtifacts();
-  stagedArtifacts.push(privatePrompt);
-  const instruction = `${PROMPT_PREFIX}${privatePrompt}${PROMPT_SUFFIX}`;
-  return {
-    command: `printf '%s' ${shellQuote(instruction)} | ${wrapperCommand}`,
-    artifacts: stagedArtifacts,
-  };
+  if (scan.segments.length !== 2) return undefined;
+
+  const [producer] = scan.segments;
+  return producer !== undefined &&
+    producer.followedByPipe &&
+    isStagedPromptProducer(producer)
+    ? { mode, wrapperIndex }
+    : undefined;
 };

--- a/pi/extensions/pi-harness/features/permission-policy/index.ts
+++ b/pi/extensions/pi-harness/features/permission-policy/index.ts
@@ -1,22 +1,18 @@
 import { readFileSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { InputEvent, PiLike } from "../../lib/pi-like";
 import {
   DEFAULT_PERMISSION_JUDGE_CONFIG,
   type HarnessConfig,
 } from "../../config";
-import type {
-  BashExecutionBoundary,
-  BashScratchBoundary,
-} from "../bash-sandbox";
+import type { BashExecutionBoundary } from "../bash-sandbox";
 import { createPermissionBlocker, type PermissionBlockResult } from "./block";
 import { appendCommandHygiene } from "./command-hygiene";
 import {
   authorizeCodexStageEscalation,
   consumeCodexStageCapability,
-  createCodexStageCapabilityRuntime,
-  type CodexStageCapabilityRuntime,
+  pinCodexStageCommand,
 } from "./codex-stage-capability";
 import type { CodexStageMode } from "../../lib/agent-md";
 import {
@@ -167,9 +163,8 @@ interface SetupPermissionPolicyOptions {
   taskTracker?: PermissionTaskTracker;
   permissionAudit?: PermissionAuditIntegration;
   executionBoundary?: (toolName: string) => BashExecutionBoundary | undefined;
-  scratchBoundaryFor?: (toolName: string) => BashScratchBoundary | undefined;
   codexStageModes?: ReadonlySet<CodexStageMode>;
-  codexStageRuntime?: CodexStageCapabilityRuntime;
+  codexStageExecutablePath?: string;
 }
 
 const setupPermissionPolicy = (
@@ -186,20 +181,7 @@ const setupPermissionPolicy = (
   const taskTracker = options.taskTracker ?? createPermissionTaskTracker();
   const consumedCodexStageModes = consumeCodexStageCapability(config.isChild);
   const codexStageModes = options.codexStageModes ?? consumedCodexStageModes;
-  const { codexStageRuntime: configuredCodexStageRuntime, permissionAudit } =
-    options;
-  let codexStageRuntime = configuredCodexStageRuntime;
-  const codexStageArtifacts = new Map<string, readonly string[]>();
-  if (codexStageRuntime === undefined && codexStageModes.size > 0) {
-    try {
-      codexStageRuntime = createCodexStageCapabilityRuntime(
-        join(config.paths.claudeHooksDir, "lib", "codex-stage.sh"),
-      );
-    } catch {
-      // A missing or unsafe trusted wrapper disables only the capability. The
-      // command still follows the ordinary live-judge escalation path.
-    }
-  }
+  const { permissionAudit } = options;
   const discoverProject =
     options.discoverProject ??
     ((cwd: string, signal?: AbortSignal, leadingCdTarget?: string) =>
@@ -413,21 +395,10 @@ const setupPermissionPolicy = (
     clearSkillLifecycle();
   });
 
-  pi.on("tool_result", (event) => {
-    const { toolCallId } = event;
-    if (toolCallId === undefined) return;
-    const artifacts = codexStageArtifacts.get(toolCallId);
-    if (artifacts === undefined) return;
-    codexStageArtifacts.delete(toolCallId);
-    codexStageRuntime?.releaseFiles(artifacts);
-  });
-
   pi.on("session_shutdown", () => {
     taskTracker.clear();
     clearSkillLifecycle();
     judge?.clear();
-    codexStageArtifacts.clear();
-    codexStageRuntime?.dispose();
   });
 
   pi.on("tool_call", async (event, ctx) => {
@@ -536,6 +507,35 @@ const setupPermissionPolicy = (
           result.audit.reasonCode,
           result.reason,
         );
+      }
+      const codexStageAuthorization = isEscalated
+        ? authorizeCodexStageEscalation(command, codexStageModes)
+        : undefined;
+      if (codexStageAuthorization !== undefined) {
+        const pinnedCommand =
+          options.codexStageExecutablePath === undefined
+            ? command
+            : pinCodexStageCommand(
+                command,
+                options.codexStageExecutablePath,
+                codexStageAuthorization.wrapperIndex,
+              );
+        if (pinnedCommand === undefined) {
+          return finalizeBlocked(
+            event.toolCallId,
+            "codex-stage-pin-failed",
+            "codex-stage executable pin could not be applied",
+          );
+        }
+        permissionAudit?.addStage(event.toolCallId, {
+          type: "deterministic",
+          phase: "codex-stage-capability",
+          verdict: "allow",
+          basis: "agent-capability",
+          reasonCode: "codex-stage-capability",
+        });
+        event.input.command = pinnedCommand;
+        return undefined;
       }
       const confirm = async (
         title: string,
@@ -838,34 +838,6 @@ const setupPermissionPolicy = (
           );
         }
         if (result.verdict === "allow" && !isEscalated) return undefined;
-      }
-      if (
-        isEscalated &&
-        result.verdict !== "ask" &&
-        ctx.cwd !== undefined &&
-        project !== undefined
-      ) {
-        const authorization = await authorizeCodexStageEscalation(command, {
-          modes: codexStageModes,
-          cwd: ctx.cwd,
-          scratchBoundary: options.scratchBoundaryFor?.(event.toolName),
-          project,
-          runtime: codexStageRuntime,
-        });
-        if (authorization !== undefined) {
-          event.input.command = authorization.command;
-          if (authorization.artifacts.length > 0) {
-            codexStageArtifacts.set(event.toolCallId, authorization.artifacts);
-          }
-          permissionAudit?.addStage(event.toolCallId, {
-            type: "deterministic",
-            phase: "codex-stage-capability",
-            verdict: "allow",
-            basis: "agent-capability",
-            reasonCode: "codex-stage-capability",
-          });
-          return undefined;
-        }
       }
       if (judge === undefined) {
         if (isEscalated) {

--- a/pi/extensions/pi-harness/index.ts
+++ b/pi/extensions/pi-harness/index.ts
@@ -11,11 +11,15 @@
  * active — see config.ts.
  */
 import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
-import { delimiter } from "node:path";
+import { delimiter, join } from "node:path";
 import type { PiLike } from "./lib/pi-like";
 import { loadConfig, type HarnessConfig } from "./config";
 import setupBashSandboxFeature from "./features/bash-sandbox/index";
 import setupPermissionPolicy from "./features/permission-policy/index";
+import {
+  consumeCodexStageCapability,
+  createCodexStageExecutablePin,
+} from "./features/permission-policy/codex-stage-capability";
 import { createPermissionTaskTracker } from "./features/permission-policy/context";
 import { setupPermissionAudit } from "./features/permission-audit/index";
 import {
@@ -57,6 +61,8 @@ const PERMISSION_PREFLIGHT_PATH = [
 // to lib/pi-like.ts. Shapes verified against tests/fixtures/pi-harness/raw/.
 interface SetupHarnessOptions extends PermissionBlockerOptions {
   readonly setupBashSandbox?: typeof setupBashSandboxFeature;
+  readonly consumeCodexStageCapability?: typeof consumeCodexStageCapability;
+  readonly createCodexStageExecutablePin?: typeof createCodexStageExecutablePin;
 }
 
 const setupHarness = (
@@ -66,8 +72,31 @@ const setupHarness = (
 ): void => {
   const {
     setupBashSandbox: createBashSandbox = setupBashSandboxFeature,
+    consumeCodexStageCapability:
+      consumeCodexStageModes = consumeCodexStageCapability,
+    createCodexStageExecutablePin:
+      createCodexStagePin = createCodexStageExecutablePin,
     ...blockerOptions
   } = options;
+  let codexStageModes = consumeCodexStageModes(config.isChild);
+  let codexStageExecutable:
+    | ReturnType<typeof createCodexStageExecutablePin>
+    | undefined;
+  if (codexStageModes.size > 0) {
+    try {
+      codexStageExecutable = createCodexStagePin(
+        join(config.paths.claudeHooksDir, "lib", "codex-stage.sh"),
+      );
+    } catch {
+      // The managed bypass is optional; the mandatory permission policy is
+      // not. Disable the capability and continue registering the normal
+      // fail-closed boundary when launcher pinning is unavailable.
+      codexStageModes = new Set();
+    }
+  }
+  if (codexStageExecutable !== undefined) {
+    pi.on("session_shutdown", () => codexStageExecutable.dispose());
+  }
   // One blocker owns the child authenticator for every permission handler.
   // This preserves the parent observer's failure classification even when a
   // bridge hook rejects before (or after) the mandatory policy handler.
@@ -129,7 +158,8 @@ const setupHarness = (
     taskTracker: permissionTaskTracker,
     permissionAudit,
     executionBoundary: (toolName) => bashSandbox.boundaryFor(toolName),
-    scratchBoundaryFor: (toolName) => bashSandbox.scratchBoundaryFor(toolName),
+    codexStageModes,
+    codexStageExecutablePath: codexStageExecutable?.executablePath,
   });
 
   if (bridgeRegistry?.remaining.length) {

--- a/tests/hooks/claude-harness/codex-stage.test.ts
+++ b/tests/hooks/claude-harness/codex-stage.test.ts
@@ -33,16 +33,25 @@ const setupFixture = async () => {
   return { root, target, bin, temporaryDirectory };
 };
 
-const directoryPin = async (
-  path: string,
-): Promise<{ path: string; identity: string }> => {
-  const canonicalPath = await fs.realpath(path);
-  const stat = await fs.stat(canonicalPath);
-  return {
-    path: canonicalPath,
-    identity: `${stat.dev}:${stat.ino}`,
-  };
-};
+type Fixture = Awaited<ReturnType<typeof setupFixture>>;
+
+const runPrompt = (
+  fixture: Fixture,
+  args: string[],
+  env: Record<string, string> = {},
+) =>
+  Bun.spawnSync(["bash", WRAPPER, "prompt", ...args], {
+    cwd: fixture.root,
+    env: {
+      HOME: fixture.root,
+      PATH: `${fixture.bin}:${process.env.PATH ?? ""}`,
+      TMPDIR: fixture.temporaryDirectory,
+      ...env,
+    },
+    stdin: Buffer.from("Return a smoke result."),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
 
 const isProcessAlive = (pid: number): boolean => {
   try {
@@ -68,128 +77,57 @@ afterEach(async () => {
   await Promise.all(tempDirectories.splice(0).map(cleanupTestDirectory));
 });
 
-describe("codex-stage pinned directory execution", () => {
-  test("validates the directory identity and runs Codex from the pinned cwd without -C", async () => {
+describe("codex-stage execution boundary", () => {
+  test("runs Codex from the requested canonical cwd without -C", async () => {
     const fixture = await setupFixture();
-    const pin = await directoryPin(fixture.target);
-    const result = Bun.spawnSync(
-      [
-        "bash",
-        WRAPPER,
-        "prompt",
-        "--dir",
-        fixture.target,
-        "--timeout",
-        "10",
-        "--expected-dir-identity",
-        pin.identity,
-        "--expected-dir-path",
-        pin.path,
-      ],
-      {
-        cwd: fixture.root,
-        env: {
-          HOME: fixture.root,
-          PATH: `${fixture.bin}:${process.env.PATH ?? ""}`,
-          TMPDIR: fixture.temporaryDirectory,
-        },
-        stdin: Buffer.from("Return a smoke result."),
-        stdout: "pipe",
-        stderr: "pipe",
-      },
-    );
+    const result = runPrompt(fixture, [
+      "--dir",
+      fixture.target,
+      "--timeout",
+      "10",
+    ]);
 
     expect(result.exitCode).toBe(0);
     const stdout = result.stdout.toString();
-    expect(stdout).toContain(`PWD=${pin.path}`);
+    expect(stdout).toContain(`PWD=${await fs.realpath(fixture.target)}`);
     expect(stdout).toContain("<exec> <--sandbox> <read-only>");
     expect(stdout).not.toContain("<-C>");
     expect(result.stderr.toString()).toBe("");
   });
 
-  test("rejects a directory replaced after policy identity capture", async () => {
+  test("rejects sandbox-external output and unsafe numeric controls", async () => {
     const fixture = await setupFixture();
-    const pin = await directoryPin(fixture.target);
-    await fs.rename(fixture.target, join(fixture.root, "original-target"));
-    await fs.mkdir(fixture.target);
+    const output = join(fixture.root, "review-output.md");
+    const injected = join(fixture.root, "injected");
+    const cases: { args: string[]; error: string }[] = [
+      { args: ["--out", output], error: "unknown argument: --out" },
+      { args: ["--timeout", "0"], error: "must be between 1 and 3600" },
+      { args: ["--timeout", "01"], error: "canonical decimal integer" },
+      { args: ["--timeout", "10x"], error: "canonical decimal integer" },
+      { args: ["--timeout", "10 "], error: "canonical decimal integer" },
+      { args: ["--timeout", "3601"], error: "must be between 1 and 3600" },
+      { args: ["--retry", "-1"], error: "canonical decimal integer" },
+      { args: ["--retry", "1x"], error: "canonical decimal integer" },
+      { args: ["--retry", "11"], error: "must be between 0 and 10" },
+      { args: ["--retry-wait", "30x"], error: "canonical decimal integer" },
+      { args: ["--retry-wait", "301"], error: "must be between 0 and 300" },
+      { args: ["--retry-wait", "LANG"], error: "canonical decimal integer" },
+    ];
 
-    const result = Bun.spawnSync(
-      [
-        "bash",
-        WRAPPER,
-        "prompt",
-        "--dir",
-        fixture.target,
-        "--timeout",
-        "10",
-        "--expected-dir-identity",
-        pin.identity,
-        "--expected-dir-path",
-        pin.path,
-      ],
-      {
-        cwd: fixture.root,
-        env: {
-          HOME: fixture.root,
-          PATH: `${fixture.bin}:${process.env.PATH ?? ""}`,
-          TMPDIR: fixture.temporaryDirectory,
-        },
-        stdin: Buffer.from("Must not reach Codex."),
-        stdout: "pipe",
-        stderr: "pipe",
-      },
-    );
-
-    expect(result.exitCode).toBe(13);
-    expect(result.stdout.toString()).toBe("");
-    expect(result.stderr.toString()).toContain("directory identity changed");
-  });
-
-  test("rejects the same directory inode relocated behind a symlink", async () => {
-    const fixture = await setupFixture();
-    const pin = await directoryPin(fixture.target);
-    const relocatedTarget = join(
-      fixture.temporaryDirectory,
-      "relocated-target",
-    );
-    await fs.rename(fixture.target, relocatedTarget);
-    await fs.symlink(relocatedTarget, fixture.target);
-
-    const result = Bun.spawnSync(
-      [
-        "bash",
-        WRAPPER,
-        "prompt",
-        "--dir",
-        fixture.target,
-        "--timeout",
-        "10",
-        "--expected-dir-identity",
-        pin.identity,
-        "--expected-dir-path",
-        pin.path,
-      ],
-      {
-        cwd: fixture.root,
-        env: {
-          HOME: fixture.root,
-          PATH: `${fixture.bin}:${process.env.PATH ?? ""}`,
-          TMPDIR: fixture.temporaryDirectory,
-        },
-        stdin: Buffer.from("Must not follow the relocated inode."),
-        stdout: "pipe",
-        stderr: "pipe",
-      },
-    );
-
-    expect(result.exitCode).toBe(13);
-    expect(result.stdout.toString()).toBe("");
-    expect(result.stderr.toString()).toContain("directory path changed");
+    for (const value of cases) {
+      const result = runPrompt(fixture, value.args, {
+        LANG: `x[$(touch ${injected})]`,
+      });
+      expect(result.exitCode).toBe(13);
+      expect(result.stdout.toString()).toBe("");
+      expect(result.stderr.toString()).toContain(value.error);
+    }
+    expect(await Bun.file(output).exists()).toBe(false);
+    expect(await Bun.file(injected).exists()).toBe(false);
   });
 
   test("kills a TERM-ignoring Codex grandchild process group on timeout", async () => {
     const fixture = await setupFixture();
-    const pin = await directoryPin(fixture.target);
     const grandchildPidFile = join(fixture.root, "grandchild.pid");
     await fs.writeFile(
       join(fixture.bin, "codex"),
@@ -205,19 +143,7 @@ describe("codex-stage pinned directory execution", () => {
     );
 
     const result = Bun.spawnSync(
-      [
-        "bash",
-        WRAPPER,
-        "prompt",
-        "--dir",
-        fixture.target,
-        "--timeout",
-        "1",
-        "--expected-dir-identity",
-        pin.identity,
-        "--expected-dir-path",
-        pin.path,
-      ],
+      ["bash", WRAPPER, "prompt", "--dir", fixture.target, "--timeout", "1"],
       {
         cwd: fixture.root,
         env: {
@@ -243,7 +169,6 @@ describe("codex-stage pinned directory execution", () => {
 
   test("retains the watchdog when the Codex leader exits before its grandchild", async () => {
     const fixture = await setupFixture();
-    const pin = await directoryPin(fixture.target);
     const grandchildPidFile = join(fixture.root, "early-exit-grandchild.pid");
     await fs.writeFile(
       join(fixture.bin, "codex"),
@@ -262,19 +187,7 @@ describe("codex-stage pinned directory execution", () => {
     });
 
     const result = Bun.spawnSync(
-      [
-        "bash",
-        WRAPPER,
-        "prompt",
-        "--dir",
-        fixture.target,
-        "--timeout",
-        "1",
-        "--expected-dir-identity",
-        pin.identity,
-        "--expected-dir-path",
-        pin.path,
-      ],
+      ["bash", WRAPPER, "prompt", "--dir", fixture.target, "--timeout", "1"],
       {
         cwd: fixture.root,
         env: {

--- a/tests/pi-harness/agent-loader.test.ts
+++ b/tests/pi-harness/agent-loader.test.ts
@@ -10,7 +10,6 @@ import setupPermissionPolicy from "../../pi/extensions/pi-harness/features/permi
 import {
   CODEX_STAGE_CAPABILITY_ENV,
   consumeCodexStageCapability,
-  createCodexStageCapabilityRuntime,
 } from "../../pi/extensions/pi-harness/features/permission-policy/codex-stage-capability";
 import { ChildRunRegistry } from "../../pi/extensions/pi-harness/features/child-runs/registry";
 import type { PermissionAuditIntegration } from "../../pi/extensions/pi-harness/features/permission-audit/index";
@@ -301,6 +300,23 @@ describe("pi-harness subagent", () => {
         systemPrompt: "Review carefully.",
       },
     ]);
+  });
+
+  test("requires managed Codex agents to launch the wrapper directly outside Pi sandbox", () => {
+    for (const name of ["codex-reviewer", "codex-poc", "codex-runner"]) {
+      const definition = readFileSync(
+        join(import.meta.dir, "../../claude/.claude/agents", `${name}.md`),
+        "utf8",
+      );
+      expect(definition).toContain(
+        "always invoke the\n  wrapper with `bash_escalated`; never try ordinary Bash first",
+      );
+      expect(definition).not.toContain("if ordinary Bash blocks");
+      expect(definition).toContain("does not re-sandbox the wrapper");
+      expect(definition).toContain(
+        "snapshots only the trusted wrapper executable",
+      );
+    }
   });
 
   test("returns an empty agent list for a missing directory", async () => {
@@ -656,13 +672,7 @@ describe("pi-harness subagent", () => {
     await fs.mkdir(agentsDirectory, { recursive: true });
     await fs.mkdir(wrapperDirectory, { recursive: true });
     await fs.mkdir(sandboxScratch, { mode: 0o700 });
-    const canonicalScratch = await fs.realpath(sandboxScratch);
-    const scratchStat = await fs.stat(canonicalScratch);
-    const scratchBoundary = {
-      path: canonicalScratch,
-      identity: `${scratchStat.dev}:${scratchStat.ino}`,
-    };
-    const promptArtifact = join(canonicalScratch, "codex-reviewer-a1B2C3.md");
+    const promptArtifact = join(sandboxScratch, "codex-reviewer-a1B2C3.md");
     await fs.copyFile(
       join(import.meta.dir, "../../claude/.claude/agents/codex-reviewer.md"),
       join(agentsDirectory, "codex-reviewer.md"),
@@ -679,10 +689,6 @@ describe("pi-harness subagent", () => {
       ].join("\n"),
       { mode: 0o755 },
     );
-    const codexStageRuntime = createCodexStageCapabilityRuntime(wrapperPath, {
-      temporaryDirectory: home,
-    });
-
     let policyDecision: Awaited<
       ReturnType<ReturnType<typeof createFakePi>["emitToolCall"]>
     > = undefined;
@@ -734,7 +740,6 @@ describe("pi-harness subagent", () => {
                 codexStageModes: consumeCodexStageCapability(true, {
                   ...launchOptions.env,
                 }),
-                codexStageRuntime,
                 discoverProject: async () => ({
                   kind: "git",
                   cwd: home,
@@ -749,7 +754,6 @@ describe("pi-harness subagent", () => {
                   network: "denied",
                   profileFingerprint: "c".repeat(64),
                 }),
-                scratchBoundaryFor: () => scratchBoundary,
                 permissionSignalToken:
                   launchOptions.env[CHILD_PERMISSION_SIGNAL_ENV],
                 writePermissionSignal: (text) => controller.emitStderr(text),
@@ -819,10 +823,9 @@ describe("pi-harness subagent", () => {
     expect(result.permissionBlocked).toBeUndefined();
     expect(result.failed).toBe(false);
     expect(result.output).toContain("mock codex reached");
-    expect(await fs.readFile(receivedPrompt, "utf8")).toMatch(
-      /^Read \/.*\/pi-codex-stage-artifact-.*\/prompt\.md completely and follow it exactly\.$/,
+    expect(await fs.readFile(receivedPrompt, "utf8")).toBe(
+      `Read ${promptArtifact} completely and follow it exactly.`,
     );
-    codexStageRuntime.dispose();
   });
 
   test("treats a child permission block as failure even when pi exits zero", async () => {

--- a/tests/pi-harness/bash-sandbox.test.ts
+++ b/tests/pi-harness/bash-sandbox.test.ts
@@ -302,15 +302,14 @@ describe("Bash effect sandbox lifecycle", () => {
       network: "denied",
       profileFingerprint: "a".repeat(64),
     });
-    expect(runtime.controller.scratchDirectoryFor("bash_escalated")).toBe(
-      "/private/scratch",
-    );
-    expect(runtime.controller.scratchBoundaryFor("bash_escalated")).toEqual({
-      path: "/private/scratch",
-      identity: "10:20",
-    });
     expect(runtime.pi.tools.map((tool) => tool.name)).toContain(
       "bash_escalated",
+    );
+    const escalated = runtime.pi.tools.find(
+      (tool) => tool.name === "bash_escalated",
+    );
+    expect(escalated?.promptGuidelines?.join("\n")).toContain(
+      "Use bash_escalated directly for managed codex-stage launches",
     );
 
     await runtime.pi.emitSessionShutdown();

--- a/tests/pi-harness/harness-composition.test.ts
+++ b/tests/pi-harness/harness-composition.test.ts
@@ -143,6 +143,40 @@ describe("pi-harness coordination browser composition", () => {
     expect(registered.shortcuts.has("ctrl+alt+i")).toBe(false);
   });
 
+  test("keeps the mandatory permission policy when Codex launcher pinning fails", async () => {
+    const value = {
+      ...config("pi-composition-codex-pin-failure", {
+        subagent: false,
+        workflow: false,
+        "bit-task": false,
+      }),
+      isChild: true,
+    };
+    const pi = createFakePi({ cwd: value.paths.home, hasUI: false });
+    let pinAttempts = 0;
+
+    expect(() =>
+      setupHarness(pi, value, {
+        consumeCodexStageCapability: () => new Set(["review"] as const),
+        createCodexStageExecutablePin: () => {
+          pinAttempts += 1;
+          throw new Error("simulated pin failure");
+        },
+      }),
+    ).not.toThrow();
+    expect(pinAttempts).toBe(1);
+    expect(
+      await pi.emitToolCall({
+        type: "tool_call",
+        toolName: "bash_escalated",
+        toolCallId: "codex-pin-failure",
+        input: {
+          command: "~/.claude/hooks/lib/codex-stage.sh review --uncommitted",
+        },
+      }),
+    ).toEqual({ block: true, reason: expect.any(String) });
+  });
+
   test("PI_HARNESS_CHILD=1 disables both resident sources", () => {
     const childConfig = loadConfig(
       { PI_HARNESS_CHILD: "1" },

--- a/tests/pi-harness/permission-ask-reminder.test.ts
+++ b/tests/pi-harness/permission-ask-reminder.test.ts
@@ -49,11 +49,6 @@ const setupReminderHarness = (
         network: "denied",
         profileFingerprint: "e".repeat(64),
       }),
-      scratchDirectoryFor: () => "/private/scratch",
-      scratchBoundaryFor: () => ({
-        path: "/private/scratch",
-        identity: "10:20",
-      }),
       registerExecutionBoundary() {},
     }),
   });

--- a/tests/pi-harness/permission-judge-policy.test.ts
+++ b/tests/pi-harness/permission-judge-policy.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import {
   DEFAULT_PERMISSION_JUDGE_CONFIG,
@@ -16,23 +17,17 @@ import {
 import {
   CODEX_STAGE_CAPABILITY_ENV,
   consumeCodexStageCapability,
-  createCodexStageCapabilityRuntime,
-  type CodexStageCapabilityRuntime,
+  createCodexStageExecutablePin,
+  pinCodexStageCommand,
 } from "../../pi/extensions/pi-harness/features/permission-policy/codex-stage-capability";
 import type { PermissionProjectContext } from "../../pi/extensions/pi-harness/features/permission-policy/context";
 import { loadRules } from "../../pi/extensions/pi-harness/features/permission-policy/rules";
 import { resolvePaths } from "../../pi/extensions/pi-harness/lib/paths";
 import type { ToolCallEvent } from "../../pi/extensions/pi-harness/lib/pi-like";
-import {
-  cleanupTestDirectory,
-  setupTestDirectory,
-  startMockUpstream,
-  type MockUpstream,
-} from "../test-helpers";
+import { startMockUpstream, type MockUpstream } from "../test-helpers";
 import { createFakePi } from "./fake-pi";
 
 const upstreams: MockUpstream[] = [];
-const tempDirectories: string[] = [];
 
 const start = async (
   chatHandler: Parameters<typeof startMockUpstream>[0],
@@ -63,7 +58,6 @@ const chatRequests = (upstream: MockUpstream) =>
 
 afterEach(async () => {
   await Promise.all(upstreams.splice(0).map((upstream) => upstream.close()));
-  await Promise.all(tempDirectories.splice(0).map(cleanupTestDirectory));
 });
 
 const ollamaResponse = (verdict: string): Response =>
@@ -161,26 +155,6 @@ const verifiedGitCwdProject = (cwd: string): PermissionProjectContext => ({
     sameRepository: true,
   },
 });
-
-const makeCodexStageRuntime =
-  async (): Promise<CodexStageCapabilityRuntime> => {
-    const directory = await setupTestDirectory("codex-stage-runtime");
-    tempDirectories.push(directory);
-    const source = join(directory, "codex-stage-source.sh");
-    await fs.writeFile(source, "#!/bin/bash\ncat\n", { mode: 0o700 });
-    return createCodexStageCapabilityRuntime(source, {
-      temporaryDirectory: directory,
-    });
-  };
-
-const makeScratchBoundary = async (path: string) => {
-  const canonicalPath = await fs.realpath(path);
-  const stat = await fs.stat(canonicalPath);
-  return {
-    path: canonicalPath,
-    identity: `${stat.dev}:${stat.ino}`,
-  };
-};
 
 const createTestAbortController = (): {
   signal: AbortSignal;
@@ -900,243 +874,126 @@ describe("permission policy local judge routing", () => {
     expect(malformedEnv[CODEX_STAGE_CAPABILITY_ENV]).toBeUndefined();
   });
 
-  test("pins the trusted wrapper and staged artifacts into non-writable private copies", async () => {
-    const scratch = await setupTestDirectory("codex-stage-runtime-scratch");
-    tempDirectories.push(scratch);
-    const scratchBoundary = await makeScratchBoundary(scratch);
-    const prompt = join(scratchBoundary.path, "prompt.md");
-    await fs.writeFile(prompt, "private staged prompt");
-    const runtime = await makeCodexStageRuntime();
+  test("pins trusted wrapper bytes without pinning Codex activity", async () => {
+    const directory = await fs.mkdtemp(join(tmpdir(), "codex-stage-pin-test-"));
+    const source = join(directory, "source.sh");
+    let pin: ReturnType<typeof createCodexStageExecutablePin> | undefined;
+    try {
+      await fs.writeFile(source, "#!/bin/sh\necho trusted\n", { mode: 0o700 });
+      pin = createCodexStageExecutablePin(source, directory);
+      await fs.writeFile(source, "#!/bin/sh\necho replaced\n", { mode: 0o700 });
 
-    const staged = await runtime.stageFile(
-      prompt,
-      scratchBoundary,
-      "prompt.md",
-    );
-    expect(staged).toBeDefined();
-    if (staged === undefined) throw new Error("expected staged prompt copy");
-    expect(staged.startsWith(scratch)).toBe(false);
-    expect(await fs.readFile(staged, "utf8")).toBe("private staged prompt");
-    const stagedStat = await fs.stat(staged);
-    const { executablePath } = runtime;
-    const executableStat = await fs.stat(executablePath);
-    expect(stagedStat.mode & 0o222).toBe(0);
-    expect(executableStat.mode & 0o222).toBe(0);
+      expect(await fs.readFile(pin.executablePath, "utf8")).toContain(
+        "echo trusted",
+      );
+      const pinnedStat = await fs.stat(pin.executablePath);
+      expect(pinnedStat.mode & 0o777).toBe(0o500);
+      const command =
+        "printf '%s' 'Read /tmp/prompt.md completely and follow it exactly.' | ~/.claude/hooks/lib/codex-stage.sh prompt --dir '/outside/repository' --network";
+      const wrapperIndex = command.indexOf(
+        "~/.claude/hooks/lib/codex-stage.sh",
+      );
+      expect(
+        pinCodexStageCommand(command, pin.executablePath, wrapperIndex),
+      ).toBe(
+        command.replace(
+          "~/.claude/hooks/lib/codex-stage.sh",
+          `'${pin.executablePath}'`,
+        ),
+      );
+      expect(
+        pinCodexStageCommand("bun test", pin.executablePath, 0),
+      ).toBeUndefined();
+      expect(
+        pinCodexStageCommand(
+          "~/.claude/hooks/lib/codex-stage.sh review",
+          "/tmp/a'b/codex-stage.sh",
+          0,
+        ),
+      ).toBe(String.raw`'/tmp/a'\''b/codex-stage.sh' review`);
 
-    const outsideDirectory = await setupTestDirectory(
-      "codex-stage-runtime-outside",
-    );
-    tempDirectories.push(outsideDirectory);
-    const outside = join(outsideDirectory, "outside-prompt.md");
-    await fs.writeFile(outside, "outside");
-    const symlink = join(scratchBoundary.path, "symlink.md");
-    await fs.symlink(outside, symlink);
-    expect(
-      await runtime.stageFile(symlink, scratchBoundary, "prompt.md"),
-    ).toBeUndefined();
-    const nestedDirectory = join(scratchBoundary.path, "nested");
-    await fs.mkdir(nestedDirectory);
-    const nestedPrompt = join(nestedDirectory, "prompt.md");
-    await fs.writeFile(nestedPrompt, "nested prompt");
-    expect(
-      await runtime.stageFile(nestedPrompt, scratchBoundary, "prompt.md"),
-    ).toBeUndefined();
-    const fifo = join(scratchBoundary.path, "prompt.fifo");
-    const mkfifo = Bun.spawnSync(["mkfifo", fifo]);
-    expect(mkfifo.exitCode).toBe(0);
-    const fifoStage = await Promise.race([
-      runtime.stageFile(fifo, scratchBoundary, "prompt.md"),
-      Bun.sleep(1_000).then(() => "timed out" as const),
-    ]);
-    expect(fifoStage).toBeUndefined();
-
-    const originalScratch = `${scratchBoundary.path}-original`;
-    await fs.rename(scratchBoundary.path, originalScratch);
-    await fs.symlink(outsideDirectory, scratchBoundary.path);
-    expect(
-      await runtime.stageFile(
-        join(scratchBoundary.path, "outside-prompt.md"),
-        scratchBoundary,
-        "prompt.md",
-      ),
-    ).toBeUndefined();
-    await fs.rm(scratchBoundary.path);
-    await fs.rename(originalScratch, scratchBoundary.path);
-
-    runtime.dispose();
-    await expect(fs.access(staged)).rejects.toThrow();
-    await expect(fs.access(executablePath)).rejects.toThrow();
-  });
-
-  test("reserves aggregate staging capacity before concurrent reads and cleans disposal races", async () => {
-    const scratch = await setupTestDirectory("codex-stage-runtime-cap");
-    tempDirectories.push(scratch);
-    const scratchBoundary = await makeScratchBoundary(scratch);
-    const runtime = await makeCodexStageRuntime();
-    const sources: string[] = [];
-    for (let index = 0; index < 5; index += 1) {
-      const source = join(scratchBoundary.path, `prompt-${index}.md`);
-      await fs.writeFile(source, Buffer.alloc(8 * 1024 * 1024, index));
-      sources.push(source);
+      const pinnedPath = pin.executablePath;
+      pin.dispose();
+      pin = undefined;
+      expect(await Bun.file(pinnedPath).exists()).toBe(false);
+    } finally {
+      pin?.dispose();
+      await fs.rm(directory, { recursive: true, force: true });
     }
-
-    const staged = await Promise.all(
-      sources.map((source) =>
-        runtime.stageFile(source, scratchBoundary, "prompt.md"),
-      ),
-    );
-    expect(staged.filter((path) => path !== undefined)).toHaveLength(4);
-    expect(staged.filter((path) => path === undefined)).toHaveLength(1);
-    runtime.dispose();
-
-    const disposingRuntime = await makeCodexStageRuntime();
-    const pending = disposingRuntime.stageFile(
-      sources[0] ?? "",
-      scratchBoundary,
-      "prompt.md",
-    );
-    const runtimeRoot = resolve(disposingRuntime.executablePath, "../..");
-    disposingRuntime.dispose();
-    expect(await pending).toBeUndefined();
-    const runtimeEntries = await fs.readdir(runtimeRoot);
-    expect(
-      runtimeEntries.filter((entry) =>
-        entry.startsWith("pi-codex-stage-artifact-"),
-      ),
-    ).toEqual([]);
   });
 
-  test("allows only an agent-declared path-validated codex-stage escalation without the judge", async () => {
-    const upstream = await start(() => ollamaResponse("ASK"));
-    const cwd = await setupTestDirectory("codex-stage-capability");
-    tempDirectories.push(cwd);
-    const scratch = join(cwd, "sandbox-scratch");
-    await fs.mkdir(scratch, { recursive: true });
-    const scratchBoundary = await makeScratchBoundary(scratch);
-    const prompt = join(scratchBoundary.path, "codex-reviewer-a1B2C3.md");
-    await fs.writeFile(prompt, "Review the assigned artifact.");
-    const runtime = await makeCodexStageRuntime();
-
+  test("delegates declared codex-stage modes without Pi sandbox or judge checks", async () => {
+    const cwd = "/private/project";
+    const { integration, stages } = captureAuditStages();
+    let discoveries = 0;
     const pi = createFakePi({ cwd, hasUI: false });
-    setupPermissionPolicy(pi, makeConfig(judgeConfig(upstream), true), {
-      codexStageModes: new Set(["prompt", "review"]),
-      discoverProject: async () => verifiedProject(cwd),
-      executionBoundary,
-      scratchBoundaryFor: () => scratchBoundary,
-      codexStageRuntime: runtime,
-      permissionSignalToken: "123e4567-e89b-42d3-a456-426614174000",
-      writePermissionSignal: () => {},
-    });
-
-    const command = [
-      `printf '%s' 'Read ${prompt} completely and follow it exactly.' |`,
-      "  ~/.claude/hooks/lib/codex-stage.sh prompt --timeout 600",
-    ].join("\n");
-    const promptCall = escalatedCall(command, "codex-stage-capability");
-    expect(await pi.emitToolCall(promptCall)).toBeUndefined();
-    expect(promptCall.input.command).toContain(runtime.executablePath);
-    expect(promptCall.input.command).toContain("--expected-dir-identity");
-    expect(promptCall.input.command).toContain("--expected-dir-path");
-    expect(promptCall.input.command).not.toContain(
-      "~/.claude/hooks/lib/codex-stage.sh",
-    );
-    expect(promptCall.input.command).not.toContain(prompt);
-    const privatePromptMatch = /Read ([^ ]+) completely/.exec(
-      String(promptCall.input.command),
-    );
-    const privatePrompt = privatePromptMatch?.[1];
-    if (privatePrompt === undefined) {
-      throw new Error("rewritten private prompt path was not found");
-    }
-    await fs.access(privatePrompt);
-    await pi.emitToolResult({
-      type: "tool_result",
-      toolName: "bash_escalated",
-      toolCallId: "codex-stage-capability",
-      content: [],
-      isError: false,
-    });
-    await expect(fs.access(privatePrompt)).rejects.toThrow();
-
-    const reviewCall = escalatedCall(
-      `~/.claude/hooks/lib/codex-stage.sh review --uncommitted --dir '${cwd}' --timeout 600`,
-      "codex-stage-review-capability",
-    );
-    expect(await pi.emitToolCall(reviewCall)).toBeUndefined();
-    expect(reviewCall.input.command).toContain(runtime.executablePath);
-    expect(reviewCall.input.command).toContain("--expected-dir-identity");
-    expect(reviewCall.input.command).toContain("--expected-dir-path");
-
-    for (const [mode, wrapper] of [
-      [
-        "poc",
-        `~/.claude/hooks/lib/codex-stage.sh poc --worktree '${cwd}' --network --timeout 600`,
-      ],
-      [
-        "run",
-        `~/.claude/hooks/lib/codex-stage.sh run --dir '${cwd}' --network --timeout 600`,
-      ],
-    ] as const) {
-      const workerPi = createFakePi({ cwd, hasUI: false });
-      setupPermissionPolicy(workerPi, makeConfig(judgeConfig(upstream), true), {
-        codexStageModes: new Set([mode]),
-        discoverProject: async () => verifiedProject(cwd),
+    setupPermissionPolicy(
+      pi,
+      makeConfig({ ...DEFAULT_PERMISSION_JUDGE_CONFIG, enabled: false }, true),
+      {
+        codexStageModes: new Set(["prompt", "review", "poc", "run"]),
+        codexStageExecutablePath: "/private/pinned/codex-stage.sh",
+        discoverProject: async () => {
+          discoveries += 1;
+          return verifiedProject(cwd);
+        },
         executionBoundary,
-        scratchBoundaryFor: () => scratchBoundary,
-        codexStageRuntime: runtime,
+        permissionAudit: integration,
         permissionSignalToken: "123e4567-e89b-42d3-a456-426614174000",
         writePermissionSignal: () => {},
-      });
-      const workerCommand = [
-        `printf '%s' 'Read ${prompt} completely and follow it exactly.' |`,
-        `  ${wrapper}`,
-      ].join("\n");
-      expect(
-        await workerPi.emitToolCall(
-          escalatedCall(workerCommand, `codex-stage-${mode}-capability`),
-        ),
-      ).toBeUndefined();
+      },
+    );
+
+    const wrapper = "~/.claude/hooks/lib/codex-stage.sh";
+    const commands = [
+      `# | ${wrapper} ignored\nprintf '%s' 'Read /tmp/${wrapper}/review.md completely and follow it exactly.' | ${wrapper} prompt --dir '/outside/repository' --timeout 600`,
+      `${wrapper} review --commit deadbeef --dir '/outside/repository' --title 'mention ${wrapper}' # ${wrapper}`,
+      `printf '%s' 'Read /outside/poc.md completely and follow it exactly.' | ${wrapper} poc --worktree '/outside/worktree' --network`,
+      `printf '%s' 'Read /outside/run.md completely and follow it exactly.' | ${wrapper} run --dir '/outside/repository' --network`,
+    ];
+    for (const [index, command] of commands.entries()) {
+      const call = escalatedCall(command, `codex-stage-delegated-${index}`);
+      expect(await pi.emitToolCall(call)).toBeUndefined();
+      const executableIndex = command.startsWith(wrapper)
+        ? 0
+        : command.lastIndexOf(`| ${wrapper}`) + 2;
+      expect(call.input.command).toBe(
+        `${command.slice(0, executableIndex)}'/private/pinned/codex-stage.sh'${command.slice(executableIndex + wrapper.length)}`,
+      );
     }
-    expect(upstream.received).toHaveLength(0);
-    runtime.dispose();
+
+    expect(discoveries).toBe(0);
+    expect(
+      stages.filter(
+        ({ stage }) => stage.reasonCode === "codex-stage-capability",
+      ),
+    ).toHaveLength(commands.length);
   });
 
-  test("keeps malformed, over-broad, and mode-mismatched codex-stage calls on the live judge route", async () => {
-    const upstream = await start(() => ollamaResponse("ASK"));
-    const cwd = await setupTestDirectory("codex-stage-holdouts");
-    tempDirectories.push(cwd);
-    const scratch = join(cwd, "sandbox-scratch");
-    const outsidePrompt = join(cwd, "outside-prompt.md");
-    await fs.mkdir(scratch, { recursive: true });
-    const scratchBoundary = await makeScratchBoundary(scratch);
-    const prompt = join(scratchBoundary.path, "codex-reviewer-a1B2C3.md");
-    await fs.writeFile(prompt, "Review the assigned artifact.");
-    await fs.writeFile(outsidePrompt, "Must not cross the staging boundary.");
-    const runtime = await makeCodexStageRuntime();
-
+  test("keeps arbitrary shell and undeclared codex-stage modes outside the capability", async () => {
+    const cwd = "/private/project";
     const pi = createFakePi({ cwd, hasUI: false });
-    setupPermissionPolicy(pi, makeConfig(judgeConfig(upstream), true), {
-      codexStageModes: new Set(["prompt", "review"]),
-      discoverProject: async () => verifiedProject(cwd),
-      executionBoundary,
-      scratchBoundaryFor: () => scratchBoundary,
-      codexStageRuntime: runtime,
-      permissionSignalToken: "123e4567-e89b-42d3-a456-426614174000",
-      writePermissionSignal: () => {},
-    });
+    setupPermissionPolicy(
+      pi,
+      makeConfig({ ...DEFAULT_PERMISSION_JUDGE_CONFIG, enabled: false }, true),
+      {
+        codexStageModes: new Set(["prompt", "review"]),
+        discoverProject: async () => verifiedProject(cwd),
+        executionBoundary,
+        permissionSignalToken: "123e4567-e89b-42d3-a456-426614174000",
+        writePermissionSignal: () => {},
+      },
+    );
 
+    const prompt = "/tmp/claude/codex-reviewer-observed.md";
     const commands = [
-      `printf '%s' 'Read ${outsidePrompt} completely and follow it exactly.' | ~/.claude/hooks/lib/codex-stage.sh prompt --timeout 600`,
-      `printf '%s' 'Read ${prompt} completely and follow it exactly.' | ~/.claude/hooks/lib/codex-stage.sh poc --worktree '${cwd}' --timeout 600`,
-      `~/.claude/hooks/lib/codex-stage.sh review --uncommitted --dir '${cwd}' --out '${join(scratch, "review.md")}' --timeout 600`,
-      `printf '%s' 'Read ${prompt} completely and follow it exactly.' ; ~/.claude/hooks/lib/codex-stage.sh prompt --timeout 600`,
-      `printf '%s' 'Read ${prompt} completely and follow it exactly.' && ~/.claude/hooks/lib/codex-stage.sh prompt --timeout 600`,
-      `printf '%s' 'Read ${prompt} completely and follow it exactly.' |& ~/.claude/hooks/lib/codex-stage.sh prompt --timeout 600`,
-      `printf '%s' 'Read ${prompt} completely and follow it exactly.' | /tmp/codex-stage.sh prompt --timeout 600`,
-      `'~/.claude/hooks/lib/codex-stage.sh' review --uncommitted --dir '${cwd}'`,
-      `"~/.claude/hooks/lib/codex-stage.sh" review --uncommitted --dir '${cwd}'`,
-      String.raw`\~/.claude/hooks/lib/codex-stage.sh review --uncommitted --dir '${cwd}'`,
-      `~/.claude/hooks/lib/codex-stage.sh review --uncommitted --dir '${cwd}' |`,
+      `~/.claude/hooks/lib/codex-stage.sh prompt --timeout 600`,
+      `printf '%s' 'Read ${prompt} completely and follow it exactly.' | ~/.claude/hooks/lib/codex-stage.sh poc --worktree '/outside/worktree'`,
+      `printf '%s' 'Read ${prompt} completely and follow it exactly.' ; ~/.claude/hooks/lib/codex-stage.sh prompt`,
+      `printf '%s' 'Read ${prompt} completely and follow it exactly.' | /tmp/codex-stage.sh prompt`,
+      `"~/.claude/hooks/lib/codex-stage.sh" review --uncommitted`,
+      `printf '%s' "$(cat ~/.ssh/id_ed25519)" | ~/.claude/hooks/lib/codex-stage.sh prompt`,
+      `printf '%s' 'Read ${prompt} completely and follow it exactly.' | ~/.claude/hooks/lib/codex-stage.sh prompt ; bun test`,
       "bun test",
     ];
     for (const [index, command] of commands.entries()) {
@@ -1144,60 +1001,27 @@ describe("permission policy local judge routing", () => {
         await pi.emitToolCall(
           escalatedCall(command, `codex-stage-holdout-${index}`),
         ),
-      ).toEqual({
-        block: true,
-        reason: "local judge requested user confirmation",
-      });
+      ).toEqual({ block: true, reason: expect.any(String) });
     }
-    expect(chatRequests(upstream)).toHaveLength(commands.length);
-
-    const outsideDirectory = await setupTestDirectory("codex-stage-outside");
-    tempDirectories.push(outsideDirectory);
-    const allModesPi = createFakePi({ cwd, hasUI: false });
-    setupPermissionPolicy(allModesPi, makeConfig(judgeConfig(upstream), true), {
-      codexStageModes: new Set(["prompt", "review", "poc", "run"]),
-      discoverProject: async () => verifiedProject(cwd),
-      executionBoundary,
-      scratchBoundaryFor: () => scratchBoundary,
-      codexStageRuntime: runtime,
-      permissionSignalToken: "123e4567-e89b-42d3-a456-426614174000",
-      writePermissionSignal: () => {},
-    });
-    for (const [index, wrapper] of [
-      `~/.claude/hooks/lib/codex-stage.sh poc --worktree '${scratch}' --timeout 600`,
-      `~/.claude/hooks/lib/codex-stage.sh run --dir '${outsideDirectory}' --timeout 600`,
-    ].entries()) {
-      const command = `printf '%s' 'Read ${prompt} completely and follow it exactly.' | ${wrapper}`;
-      expect(
-        await allModesPi.emitToolCall(
-          escalatedCall(command, `codex-stage-path-holdout-${index}`),
-        ),
-      ).toEqual({
-        block: true,
-        reason: "local judge requested user confirmation",
-      });
-    }
-    expect(chatRequests(upstream)).toHaveLength(commands.length + 2);
-    runtime.dispose();
   });
 
-  test("keeps configured ASK and DENY above the codex-stage capability", async () => {
-    const upstream = await start(() => ollamaResponse("ASK"));
-    const cwd = await setupTestDirectory("codex-stage-policy-floor");
-    tempDirectories.push(cwd);
-    const runtime = await makeCodexStageRuntime();
+  test("bypasses configured ASK but keeps DENY above managed codex-stage", async () => {
+    const cwd = "/private/project";
     const command = `~/.claude/hooks/lib/codex-stage.sh review --uncommitted --dir '${cwd}'`;
     const baseOptions = {
       codexStageModes: new Set(["review"] as const),
       discoverProject: async () => verifiedProject(cwd),
       executionBoundary,
-      codexStageRuntime: runtime,
       permissionSignalToken: "123e4567-e89b-42d3-a456-426614174000",
       writePermissionSignal: () => {},
     };
+    const config = makeConfig(
+      { ...DEFAULT_PERMISSION_JUDGE_CONFIG, enabled: false },
+      true,
+    );
 
     const askPi = createFakePi({ cwd, hasUI: false });
-    setupPermissionPolicy(askPi, makeConfig(judgeConfig(upstream), true), {
+    setupPermissionPolicy(askPi, config, {
       ...baseOptions,
       rules: loadRules(
         JSON.stringify({
@@ -1213,15 +1037,11 @@ describe("permission policy local judge routing", () => {
       ),
     });
     expect(
-      await askPi.emitToolCall(escalatedCall(command, "codex-stage-ask-floor")),
-    ).toEqual({
-      block: true,
-      reason: "local judge requested user confirmation",
-    });
-    expect(chatRequests(upstream)).toHaveLength(1);
+      await askPi.emitToolCall(escalatedCall(command, "codex-stage-ask")),
+    ).toBeUndefined();
 
     const denyPi = createFakePi({ cwd, hasUI: false });
-    setupPermissionPolicy(denyPi, makeConfig(judgeConfig(upstream), true), {
+    setupPermissionPolicy(denyPi, config, {
       ...baseOptions,
       rules: loadRules(
         JSON.stringify({
@@ -1237,12 +1057,8 @@ describe("permission policy local judge routing", () => {
       ),
     });
     expect(
-      await denyPi.emitToolCall(
-        escalatedCall(command, "codex-stage-deny-floor"),
-      ),
+      await denyPi.emitToolCall(escalatedCall(command, "codex-stage-deny")),
     ).toEqual({ block: true, reason: expect.any(String) });
-    expect(chatRequests(upstream)).toHaveLength(1);
-    runtime.dispose();
   });
 
   test("requires a fresh live judge ALLOW for every escalated call", async () => {


### PR DESCRIPTION
## Summary

- route managed `codex-stage.sh` launches directly through `bash_escalated`, bypassing the Pi effect sandbox and local judge after mandatory deny and literal mode/envelope checks
- replace the old cwd/worktree/artifact runtime restrictions with a private read-only snapshot of only the trusted wrapper executable, with fail-closed fallback when pinning is unavailable
- update Codex reviewer/poc/runner guidance and harden the wrapper by removing `--out` and validating bounded canonical timeout/retry values

## Preserved contracts

- `codex-poc` still requires an isolated linked worktree
- `codex-runner` still uses Codex workspace-write without requiring an isolated worktree
- parallel runner `writeScope` partitioning remains enforced by workflow planning
- all Codex calls remain ephemeral, authenticated, timeout-bounded, and never pass `-m`

## Verification

- real managed Codex reviewer/app-server launches completed successfully
- final iterative Codex security review reported no actionable findings
- related Pi harness suites: 569 passed, 0 failed
- final focused wrapper/capability/child tests: 13 passed, 0 failed
- `bun run tsc`
- `bun run lint` — no errors; 9 pre-existing Hearth hexadecimal warnings only
- `bun run lint:sh` and direct `shellcheck` for `codex-stage.sh`
- Prettier checks
- Pi rules/import/schema/baseline/compatibility checks
- Codex agent synchronization and exec-policy checks

## Test limitation

A single full `bun test` run is not available in the normal Pi sandbox because loopback binding for mock servers is denied; headless sandbox-external execution is also rejected by the local judge. The affected change areas were covered through the focused and grouped suites above.