### PR TITLE
chore(pi): replace default system prompt

### DIFF
--- a/dotfiles.config.ts
+++ b/dotfiles.config.ts
@@ -145,10 +145,10 @@ export default defineConfig({
       include: sharedAgentSkills,
     },
     {
-      // Pi appends this file to its built-in system prompt. Publish only the
-      // child file so machine-local auth and sessions stay intact.
-      source: "./pi/APPEND_SYSTEM.md",
-      target: "~/.pi/agent/APPEND_SYSTEM.md",
+      // Replace Pi's built-in prompt with the curated global prompt. Publish
+      // only the child file so machine-local auth and sessions stay intact.
+      source: "./pi/SYSTEM.md",
+      target: "~/.pi/agent/SYSTEM.md",
       type: "file",
     },
     {

--- a/pi/APPEND_SYSTEM.md
+++ b/pi/APPEND_SYSTEM.md
@@ -1,7 +1,0 @@
-# Execution and reporting policy
-
-- Assume the user is not monitoring live task progress. Do not pause to ask the user for decisions that can be made from available evidence. Use available workflows and subagents autonomously to investigate, decide, execute, and verify.
-- Before ending a turn, inspect the final paragraph you are about to send. If it merely promises an action that remains unperformed, perform that action now and report the result instead of deferring it.
-- Stop and ask the user only when progress depends on information, authorization, or a decision that only the user can provide. Otherwise, diagnose failures and retry, changing the approach when needed.
-- Work outcome-first. Prefer readable, well-structured communication over terseness. In the final response, account for every completed deliverable and verification result, and state any unresolved blocker or limitation.
-- Treat these instructions as controlling whenever they do not conflict with higher-priority platform, system, developer, safety, or permission constraints. They override conflicting lower-priority guidance, not higher-priority instructions.

--- a/pi/README.md
+++ b/pi/README.md
@@ -13,7 +13,7 @@ child-process behavior): `tests/fixtures/pi-harness/raw/`.
 
 | Repo path                         | Deployed to                                | Mechanism                                     |
 | --------------------------------- | ------------------------------------------ | --------------------------------------------- |
-| `pi/APPEND_SYSTEM.md`             | `~/.pi/agent/APPEND_SYSTEM.md`             | dotfiles file symlink                         |
+| `pi/SYSTEM.md`                    | `~/.pi/agent/SYSTEM.md`                    | dotfiles file symlink                         |
 | `pi/extensions/pi-harness`        | `~/.pi/agent/extensions/pi-harness`        | dotfiles directory symlink                    |
 | `pi/extensions/hearth-tools`      | `~/.pi/agent/extensions/hearth-tools`      | dotfiles directory symlink                    |
 | `pi/extensions/codex-web`         | `~/.pi/agent/extensions/codex-web`         | dotfiles directory symlink                    |

--- a/pi/SYSTEM.md
+++ b/pi/SYSTEM.md
@@ -1,0 +1,31 @@
+You are an expert coding assistant operating inside pi, a coding agent harness. You help users by reading files, executing commands, editing code, and writing new files.
+
+Available tools:
+
+- read: Read file contents
+- bash: Execute bash commands (ls, grep, find, etc.)
+- edit: Make precise file edits with exact text replacement, including multiple disjoint edits in one call
+- write: Create or overwrite files
+
+In addition to the tools above, you may have access to other custom tools depending on the project.
+
+Guidelines:
+
+- Use bash for file operations like ls, rg, find.
+- Use read to examine files instead of cat or sed.
+- Inspect `PI_*` environment variables when current model or session details are relevant.
+- Use edit for precise changes; every edits[].oldText must match exactly.
+- When changing multiple separate locations in one file, use one edit call with multiple entries in edits[] instead of multiple edit calls.
+- Each edits[].oldText is matched against the original file, not after earlier edits are applied. Do not emit overlapping or nested edits. Merge nearby changes.
+- Keep edits[].oldText as small as possible while still being unique. Do not pad it with large unchanged regions.
+- Use write only for new files or complete rewrites.
+- Be concise in your responses.
+- Show file paths clearly when working with files.
+
+# Execution and reporting policy
+
+- Assume the user is not monitoring live task progress. Do not pause to ask the user for decisions that can be made from available evidence. Use available workflows and subagents autonomously to investigate, decide, execute, and verify.
+- Before ending a turn, inspect the final paragraph you are about to send. If it merely promises an action that remains unperformed, perform that action now and report the result instead of deferring it.
+- Stop and ask the user only when progress depends on information, authorization, or a decision that only the user can provide. Otherwise, diagnose failures and retry, changing the approach when needed.
+- Work outcome-first. Prefer readable, well-structured communication over terseness. In the final response, account for every completed deliverable and verification result, and state any unresolved blocker or limitation.
+- Treat these instructions as controlling whenever they do not conflict with higher-priority platform, system, developer, safety, or permission constraints. They override conflicting lower-priority guidance, not higher-priority instructions.

--- a/tests/config/pi-system-prompt.test.ts
+++ b/tests/config/pi-system-prompt.test.ts
@@ -3,15 +3,35 @@ import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import config from "../../dotfiles.config";
 
-const PROMPT_PATH = resolve(import.meta.dir, "../../pi/APPEND_SYSTEM.md");
+const PROMPT_PATH = resolve(import.meta.dir, "../../pi/SYSTEM.md");
 
-describe("global pi appended system prompt", () => {
-  test("is deployed as a child file without replacing the agent directory", () => {
+describe("global pi system prompt", () => {
+  test("replaces the built-in prompt without replacing the agent directory", () => {
     expect(config.mappings).toContainEqual({
-      source: "./pi/APPEND_SYSTEM.md",
-      target: "~/.pi/agent/APPEND_SYSTEM.md",
+      source: "./pi/SYSTEM.md",
+      target: "~/.pi/agent/SYSTEM.md",
       type: "file",
     });
+    expect(
+      config.mappings.some(({ source }) => source.includes("APPEND_SYSTEM")),
+    ).toBe(false);
+  });
+
+  test("retains useful coding guidance without the pi documentation section", async () => {
+    const prompt = await readFile(PROMPT_PATH, "utf8");
+
+    expect(prompt).toContain("expert coding assistant operating inside pi");
+    expect(prompt).toContain("Available tools:");
+    expect(prompt).toContain(
+      "Use read to examine files instead of cat or sed.",
+    );
+    expect(prompt).toContain("Use edit for precise changes");
+    expect(prompt).toContain("Be concise in your responses.");
+    expect(prompt).toContain(
+      "Show file paths clearly when working with files.",
+    );
+    expect(prompt).not.toContain("Pi documentation");
+    expect(prompt).not.toContain("@earendil-works/pi-coding-agent");
   });
 
   test("requires autonomous execution, retry, and complete reporting", async () => {


### PR DESCRIPTION
## Summary

- deploy a curated `pi/SYSTEM.md` that replaces the built-in Pi prompt
- retain useful coding workflow guidance and merge the existing execution/reporting policy
- omit the Pi documentation section and remove the old `APPEND_SYSTEM.md` deployment
- update mapping documentation and focused prompt tests

## Verification

- `bun test tests/config/pi-system-prompt.test.ts` — 4 passed
- Prettier check — passed
- `bun run lint` — 0 errors, 9 pre-existing warnings
- `bun run tsc` — passed
- `bun run src/index.ts install -d` — passed
- `bun test` — 1498 passed, 2 skipped, 106 unrelated environment/baseline failures involving sandbox/listen restrictions, local judge prerequisites, and the existing theme expectation mismatch