### PR TITLE
fix(pi): distinguish permission ASK outcomes

### DIFF
--- a/pi/LOCAL_PERMISSION_JUDGE.md
+++ b/pi/LOCAL_PERMISSION_JUDGE.md
@@ -79,7 +79,11 @@ properties. The response parser requires exactly that two-key object. Only
 alternate casing, missing or extra keys, tool calls, truncation, and malformed
 JSON require confirmation or block.
 Interactive permission confirmations default to a ten-second countdown and
-fail closed when it expires. Set `confirmTimeoutMs` from 1,000 through 300,000
+fail closed when it expires. The policy keeps `rejected`, `timed-out`,
+`aborted`, and UI-less `not-shown` outcomes distinct. A timeout tells the agent
+that the user is unavailable, not to wait for another response, and to follow
+the system prompt while continuing without that command; explicit rejection is
+reported as a user denial. Set `confirmTimeoutMs` from 1,000 through 300,000
 milliseconds to override that window; aborting the active pi operation (for
 example with Esc) also closes the dialog.
 
@@ -209,7 +213,9 @@ continue through the ordinary escalated policy below.
     configured response model, no remote metadata, a completed non-truncated
     response, and exactly one structured decision containing only `safety` and
     `relevance`. Both must be `ALLOW`; either `ASK` or any invalid response asks
-    the user or blocks without UI.
+    the user or blocks without UI. When a live `ASK` is accepted, the matching
+    Bash tool result receives one model-visible note that the local verifier
+    returned `ASK` and that the approval covers only that execution.
 15. Append one terminal V1 audit record after every pi-harness permission stage
     has passed, or at the exact stage that blocks. A successful ALLOW or accepted
     ASK is released only after the append succeeds. `release` describes the
@@ -376,8 +382,8 @@ identity checks.
 The pure helpers in `features/permission-audit/analysis.ts` validate V1 JSONL,
 report malformed/truncated tails, aggregate decisions/routes/reasons/gates/cache
 and confirmations, and emit qualification candidates. A confirmation stage
-normally makes the effective decision `ask`, including rejected, UI-less, and
-aborted challenges; however, a separate later explicit deny or internal error
+normally makes the effective decision `ask`, including rejected, timed-out,
+UI-less, and aborted challenges; however, a separate later explicit deny or internal error
 is terminal and takes precedence as `deny`. Candidates deliberately
 have no `expected` verdict: model output and user approval are observations, not
 ground truth. Review a candidate manually before adding it to the qualification
@@ -403,7 +409,7 @@ is not made.
 
 Repeated confirmation is also used as bounded usability feedback, not as a
 safety label. After every three Bash confirmations actually displayed in one
-parent session (`accepted`, `rejected`, or `aborted`), pi-harness injects one
+parent session (`accepted`, `rejected`, `timed-out`, or `aborted`), pi-harness injects one
 hidden transient reminder asking the agent to narrow or split later command
 shapes without changing their intent. Intermediate ASK verdicts and UI-less
 `not-shown` outcomes do not count. This reminder cannot alter permission

--- a/pi/extensions/pi-harness/features/permission-audit/analysis.ts
+++ b/pi/extensions/pi-harness/features/permission-audit/analysis.ts
@@ -85,7 +85,7 @@ const validStage = (value: unknown): value is PermissionAuditStage => {
       typeof value.phase === "string" &&
       typeof value.challengeSource === "string" &&
       typeof value.reasonCode === "string" &&
-      ["accepted", "rejected", "not-shown", "aborted"].includes(
+      ["accepted", "rejected", "timed-out", "not-shown", "aborted"].includes(
         String(value.status),
       )
     );

--- a/pi/extensions/pi-harness/features/permission-audit/model.ts
+++ b/pi/extensions/pi-harness/features/permission-audit/model.ts
@@ -131,6 +131,7 @@ export interface HookPermissionStage {
 export type PermissionConfirmationStatus =
   | "accepted"
   | "rejected"
+  | "timed-out"
   | "not-shown"
   | "aborted";
 

--- a/pi/extensions/pi-harness/features/permission-policy/index.ts
+++ b/pi/extensions/pi-harness/features/permission-policy/index.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { InputEvent, PiLike } from "../../lib/pi-like";
+import type { CtxLike, InputEvent, PiLike } from "../../lib/pi-like";
 import {
   DEFAULT_PERMISSION_JUDGE_CONFIG,
   type HarnessConfig,
@@ -24,7 +24,11 @@ import {
   type PermissionRunEvidence,
   type PermissionTaskTracker,
 } from "./context";
-import { createPermissionJudge, type JudgeOutcome } from "./judge";
+import {
+  createPermissionJudge,
+  type JudgeOutcome,
+  type PermissionJudge,
+} from "./judge";
 import {
   evaluateCommandWithAudit,
   gitReadCwdTarget,
@@ -65,6 +69,123 @@ const MALFORMED_REASON =
   "permission-policy: bash ツール入力が不正なため実行をブロックしました（command が文字列ではありません）";
 const JUDGE_DISABLED_RESIDUAL_REASON =
   "ローカル判定器が無効なため、sandbox内でも動的・不透明なコマンドには確認が必要です";
+const LOCAL_JUDGE_ASK_FEEDBACK =
+  "[pi-harness permission feedback] The local verifier returned ASK for this command. The user approved this one execution; do not treat that approval as an automatic ALLOW label for later commands.";
+
+type PermissionConfirmationOutcome =
+  | "accepted"
+  | "rejected"
+  | "timed-out"
+  | "not-shown"
+  | "aborted";
+
+interface ActiveAbortSignal {
+  readonly aborted: boolean;
+  addEventListener(
+    type: "abort",
+    listener: () => void,
+    options?: { once?: boolean },
+  ): void;
+  removeEventListener(type: "abort", listener: () => void): void;
+}
+
+interface AbortControllerLike {
+  readonly signal: ActiveAbortSignal;
+  abort(): void;
+}
+
+const isActiveAbortSignal = (value: unknown): value is ActiveAbortSignal =>
+  typeof value === "object" &&
+  value !== null &&
+  "aborted" in value &&
+  typeof value.aborted === "boolean" &&
+  "addEventListener" in value &&
+  typeof value.addEventListener === "function" &&
+  "removeEventListener" in value &&
+  typeof value.removeEventListener === "function";
+
+const signalIsAborted = (signal: ActiveAbortSignal | undefined): boolean =>
+  signal?.aborted === true;
+
+const createAbortController = (): AbortControllerLike => {
+  const value: unknown = new AbortController();
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("abort" in value) ||
+    typeof value.abort !== "function" ||
+    !("signal" in value) ||
+    !isActiveAbortSignal(value.signal)
+  ) {
+    throw new Error("AbortController is unavailable");
+  }
+  const { abort, signal } = value;
+  return {
+    signal,
+    abort: () => Reflect.apply(abort, value, []),
+  };
+};
+
+const requestPermissionConfirmation = async (
+  ctx: CtxLike,
+  title: string,
+  message: string,
+  timeoutMs: number,
+): Promise<PermissionConfirmationOutcome> => {
+  if (!ctx.hasUI) return "not-shown";
+  const parentSignal = isActiveAbortSignal(ctx.signal) ? ctx.signal : undefined;
+  if (signalIsAborted(parentSignal)) return "aborted";
+
+  // Pi intentionally collapses UI rejection, cancellation, and timeout into
+  // false. Own the deadline signal here so policy can distinguish an expired
+  // prompt while preserving Pi's native countdown/timeout metadata.
+  const confirmationController = createAbortController();
+  let timedOut = false;
+  const abortFromParent = (): void => confirmationController.abort();
+  parentSignal?.addEventListener("abort", abortFromParent, { once: true });
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    confirmationController.abort();
+  }, timeoutMs);
+
+  try {
+    const confirmed = await ctx.ui.confirm(title, message, {
+      signal: confirmationController.signal,
+      timeout: timeoutMs,
+    });
+    if (signalIsAborted(parentSignal)) return "aborted";
+    if (timedOut) return "timed-out";
+    return confirmed ? "accepted" : "rejected";
+  } catch (error) {
+    if (signalIsAborted(parentSignal)) return "aborted";
+    if (timedOut) return "timed-out";
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+    parentSignal?.removeEventListener("abort", abortFromParent);
+  }
+};
+
+const confirmationBlockReason = (
+  outcome: Exclude<PermissionConfirmationOutcome, "accepted">,
+  reason: string,
+): string => {
+  let feedback: string;
+  if (outcome === "timed-out") {
+    feedback =
+      "Permission confirmation timed out. The user is unavailable to respond. Do not wait for or request another confirmation; follow the system prompt instructions and continue handling the task without executing this command.";
+  } else if (outcome === "rejected") {
+    feedback =
+      "Permission confirmation was denied by the user. Do not execute this command.";
+  } else if (outcome === "aborted") {
+    feedback =
+      "The active pi operation was cancelled before permission was granted. Do not execute this command.";
+  } else {
+    feedback =
+      "Permission confirmation could not be shown because interactive UI is unavailable. Do not execute this command.";
+  }
+  return `${feedback}\n\nConfirmation reason: ${reason}`;
+};
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
@@ -162,6 +283,7 @@ interface SetupPermissionPolicyOptions {
   ) => Promise<PermissionProjectContext>;
   taskTracker?: PermissionTaskTracker;
   permissionAudit?: PermissionAuditIntegration;
+  judge?: PermissionJudge;
   executionBoundary?: (toolName: string) => BashExecutionBoundary | undefined;
   codexStageModes?: ReadonlySet<CodexStageMode>;
   codexStageExecutablePath?: string;
@@ -175,9 +297,10 @@ const setupPermissionPolicy = (
   const rules = options.rules ?? loadRules(readPermissionRules());
   const judgeConfig = config.permissionJudge;
   const judge =
-    judgeConfig?.enabled === true
+    options.judge ??
+    (judgeConfig?.enabled === true
       ? createPermissionJudge(judgeConfig)
-      : undefined;
+      : undefined);
   const taskTracker = options.taskTracker ?? createPermissionTaskTracker();
   const consumedCodexStageModes = consumeCodexStageCapability(config.isChild);
   const codexStageModes = options.codexStageModes ?? consumedCodexStageModes;
@@ -191,6 +314,7 @@ const setupPermissionPolicy = (
         signal,
       ));
   let judgeWarningShown = false;
+  const acceptedLocalJudgeAskCalls = new Map<string, string>();
   let activeSkillBashAllows: readonly AllowRule[] = [];
   let resolveActiveSkillBashAllows: ActiveSkillBashAllowResolver = () => [];
   let lifecycleEventsAvailable = false;
@@ -398,7 +522,23 @@ const setupPermissionPolicy = (
   pi.on("session_shutdown", () => {
     taskTracker.clear();
     clearSkillLifecycle();
+    acceptedLocalJudgeAskCalls.clear();
     judge?.clear();
+  });
+
+  pi.on("tool_result", (event) => {
+    if (
+      (event.toolName !== "bash" && event.toolName !== "bash_escalated") ||
+      event.toolCallId === undefined
+    ) {
+      return undefined;
+    }
+    const feedback = acceptedLocalJudgeAskCalls.get(event.toolCallId);
+    if (feedback === undefined) return undefined;
+    acceptedLocalJudgeAskCalls.delete(event.toolCallId);
+    return {
+      content: [{ type: "text", text: feedback }, ...(event.content ?? [])],
+    };
   });
 
   pi.on("tool_call", async (event, ctx) => {
@@ -542,21 +682,15 @@ const setupPermissionPolicy = (
         reason: string,
         reasonCode: string,
         challengeSource: string,
+        feedbackOnAccept?: string,
       ): Promise<{ block: true; reason: string } | undefined> => {
-        const confirmed =
-          ctx.hasUI && !isAborted()
-            ? await ctx.ui.confirm(title, `${reason}\n\n${command}`, {
-                signal,
-                timeout:
-                  judgeConfig?.confirmTimeoutMs ??
-                  DEFAULT_PERMISSION_JUDGE_CONFIG.confirmTimeoutMs,
-              })
-            : false;
-        let status: "not-shown" | "aborted" | "accepted" | "rejected";
-        if (!ctx.hasUI) status = "not-shown";
-        else if (isAborted()) status = "aborted";
-        else if (confirmed) status = "accepted";
-        else status = "rejected";
+        const status = await requestPermissionConfirmation(
+          ctx,
+          title,
+          `${reason}\n\n${command}`,
+          judgeConfig?.confirmTimeoutMs ??
+            DEFAULT_PERMISSION_JUDGE_CONFIG.confirmTimeoutMs,
+        );
         permissionAudit?.addStage(event.toolCallId, {
           type: "confirmation",
           phase: "permission-policy",
@@ -565,9 +699,22 @@ const setupPermissionPolicy = (
           reasonCode,
           reason,
         });
-        return confirmed && !isAborted()
-          ? undefined
-          : finalizeBlocked(event.toolCallId, reasonCode, reason);
+        if (status === "accepted") {
+          if (feedbackOnAccept !== undefined) {
+            if (acceptedLocalJudgeAskCalls.size >= 4096) {
+              const oldest = acceptedLocalJudgeAskCalls.keys().next().value;
+              if (oldest !== undefined)
+                acceptedLocalJudgeAskCalls.delete(oldest);
+            }
+            acceptedLocalJudgeAskCalls.set(event.toolCallId, feedbackOnAccept);
+          }
+          return undefined;
+        }
+        return finalizeBlocked(
+          event.toolCallId,
+          reasonCode,
+          confirmationBlockReason(status, reason),
+        );
       };
 
       if (result.verdict === "ask") {
@@ -934,6 +1081,7 @@ const setupPermissionPolicy = (
         outcome.reason,
         `judge-${outcome.kind}`,
         "local-judge",
+        outcome.kind === "ask" ? LOCAL_JUDGE_ASK_FEEDBACK : undefined,
       );
     } catch (error) {
       // Any evaluation or audit-integration failure blocks rather than failing open.

--- a/tests/pi-harness/fake-pi.ts
+++ b/tests/pi-harness/fake-pi.ts
@@ -72,6 +72,25 @@ interface ConfirmDialog {
   dialogOptions?: DialogOptionsLike;
 }
 
+interface ActiveAbortSignalLike {
+  readonly aborted: boolean;
+  addEventListener(
+    type: "abort",
+    listener: () => void,
+    options?: { once?: boolean },
+  ): void;
+}
+
+const isActiveAbortSignalLike = (
+  value: unknown,
+): value is ActiveAbortSignalLike =>
+  typeof value === "object" &&
+  value !== null &&
+  "aborted" in value &&
+  typeof value.aborted === "boolean" &&
+  "addEventListener" in value &&
+  typeof value.addEventListener === "function";
+
 interface HandlerStore {
   session_start: PiEventHandler<"session_start">[];
   input: PiEventHandler<"input">[];
@@ -140,6 +159,8 @@ export interface FakePi extends PiLike {
   readonly footerRenderRequests: number;
   /** Queue a response for the next ctx.ui.confirm call (defaults to false). */
   queueConfirm(answer: boolean): void;
+  /** Keep the next confirmation pending until its AbortSignal expires. */
+  queueConfirmUntilAborted(): void;
   /** Select the zero-based option on the next ctx.ui.select call. */
   queueSelectIndex(index: number | undefined): void;
   /** Queue text (or cancellation) for the next ctx.ui.input call. */
@@ -187,7 +208,10 @@ export const createFakePi = (
   const appendedEntries: { customType: string; data: unknown }[] = [];
   const notifications: Notification[] = [];
   const widgets = new Map<string, string[] | undefined>();
-  const confirmQueue: boolean[] = [];
+  const confirmQueue: (
+    | { readonly kind: "answer"; readonly answer: boolean }
+    | { readonly kind: "until-aborted" }
+  )[] = [];
   const selectQueue: { index: number | undefined }[] = [];
   const inputQueue: { answer: string | undefined }[] = [];
   const selectDialogs: SelectDialog[] = [];
@@ -236,7 +260,18 @@ export const createFakePi = (
       },
       confirm: async (title, message, dialogOptions) => {
         confirmDialogs.push({ title, message, dialogOptions });
-        return confirmQueue.shift() ?? false;
+        const reply = confirmQueue.shift();
+        if (reply === undefined) return false;
+        if (reply.kind === "answer") return reply.answer;
+        const signal = isActiveAbortSignalLike(dialogOptions?.signal)
+          ? dialogOptions.signal
+          : undefined;
+        if (signal?.aborted === true || signal === undefined) return false;
+        return new Promise<boolean>((resolve) => {
+          signal.addEventListener("abort", () => resolve(false), {
+            once: true,
+          });
+        });
       },
       input: async (title, placeholder, dialogOptions) => {
         inputDialogs.push({ title, placeholder, dialogOptions });
@@ -425,7 +460,10 @@ export const createFakePi = (
       return footerRenderRequests;
     },
     queueConfirm(answer) {
-      confirmQueue.push(answer);
+      confirmQueue.push({ kind: "answer", answer });
+    },
+    queueConfirmUntilAborted() {
+      confirmQueue.push({ kind: "until-aborted" });
     },
     queueSelectIndex(index) {
       selectQueue.push({ index });

--- a/tests/pi-harness/permission-audit-analysis-cli.test.ts
+++ b/tests/pi-harness/permission-audit-analysis-cli.test.ts
@@ -71,7 +71,9 @@ const deterministicAllow: PermissionAuditStage = {
   reasonCode: "configured-allow",
 };
 
-const askStages = (status: "accepted" | "rejected"): PermissionAuditStage[] => [
+const askStages = (
+  status: "accepted" | "rejected" | "timed-out",
+): PermissionAuditStage[] => [
   {
     type: "deterministic",
     phase: "initial",
@@ -175,6 +177,33 @@ describe("permission audit analysis CLI", () => {
     expect(result.exitCode).toBe(0);
     expect(JSON.parse(result.stdout)).toMatchObject({ records: 3 });
   });
+  test("summary reports timed-out confirmations distinctly", async () => {
+    const root = await tempRoot();
+    const logDir = join(root, "logs");
+    await fs.mkdir(logDir, { recursive: true, mode: 0o700 });
+    const record = buildPermissionDecisionRecord(
+      recordInput(
+        "723e4567-e89b-42d3-a456-426614174000",
+        1,
+        "git status --short",
+        askStages("timed-out"),
+        "block",
+      ),
+    );
+    await fs.writeFile(
+      join(logDir, `permission-2026-07-24-${WRITER_ID}.jsonl`),
+      `${JSON.stringify(record)}\n`,
+      { mode: 0o600 },
+    );
+
+    const result = await run("summary", "--log-dir", logDir);
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      records: 1,
+      summary: { byConfirmation: { "timed-out": 1 } },
+    });
+  });
+
   test("summary and top-ask remain body-free while reporting diagnostics", async () => {
     const root = await tempRoot();
     const { logDir, commandHash } = await writeFixture(root);

--- a/tests/pi-harness/permission-audit.test.ts
+++ b/tests/pi-harness/permission-audit.test.ts
@@ -20,7 +20,10 @@ import {
   type PermissionAuditFileHandle,
   type PermissionAuditWriter,
 } from "../../pi/extensions/pi-harness/features/permission-audit/writer";
-import type { HarnessConfig } from "../../pi/extensions/pi-harness/config";
+import {
+  DEFAULT_PERMISSION_JUDGE_CONFIG,
+  type HarnessConfig,
+} from "../../pi/extensions/pi-harness/config";
 import {
   PERMISSION_AUDIT_INVOCATION_ENV,
   PERMISSION_AUDIT_LINEAGE_ENV,
@@ -125,6 +128,25 @@ describe("permission audit record model", () => {
       buildPermissionDecisionRecord(baseInput([intermediateAsk, accepted]))
         .effectiveDecision,
     ).toBe("ask");
+
+    const timedOut: PermissionAuditStage = {
+      ...accepted,
+      status: "timed-out",
+    };
+    const timedOutRecord = buildPermissionDecisionRecord(
+      baseInput([intermediateAsk, timedOut], {
+        boundaryDisposition: "block",
+        terminalReasonCode: "judge-ask",
+      }),
+    );
+    const parsedTimedOut = parsePermissionAuditJsonl(
+      `${JSON.stringify(timedOutRecord)}\n`,
+    );
+    expect(parsedTimedOut.diagnostics).toEqual([]);
+    expect(parsedTimedOut.records[0]?.effectiveDecision).toBe("ask");
+    expect(
+      summarizePermissionAudit(parsedTimedOut.records).byConfirmation,
+    ).toEqual({ "timed-out": 1 });
 
     const denied: PermissionAuditStage = {
       type: "deterministic",
@@ -822,6 +844,59 @@ describe("permission audit policy lifecycle", () => {
     expect(parsed.records[0]?.stages).toContainEqual(
       expect.objectContaining({ type: "confirmation", status: "rejected" }),
     );
+  });
+
+  test("records timed-out ASK separately from explicit rejection", async () => {
+    const home = await tempRoot("pi-permission-audit-timeout");
+    const baseConfig = harnessConfig(home);
+    const config: HarnessConfig = {
+      ...baseConfig,
+      permissionJudge: {
+        ...DEFAULT_PERMISSION_JUDGE_CONFIG,
+        enabled: false,
+        confirmTimeoutMs: 10,
+      },
+    };
+    const pi = createFakePi({ cwd: home });
+    const taskTracker = createPermissionTaskTracker();
+    const audit = setupPermissionAudit(pi, config, { taskTracker });
+    const blocker = (reason: string) => ({ block: true as const, reason });
+    setupPermissionPolicy(pi, config, {
+      taskTracker,
+      permissionAudit: audit,
+      blockToolCall: blocker,
+    });
+    audit.registerTail(pi, blocker);
+    await activateTask(pi);
+    pi.queueConfirmUntilAborted();
+
+    expect(
+      await pi.emitToolCall({
+        type: "tool_call",
+        toolName: "bash",
+        toolCallId: "ask-timeout",
+        input: { command: "git push origin main" },
+      }),
+    ).toEqual({
+      block: true,
+      reason: expect.stringContaining("Permission confirmation timed out"),
+    });
+    await pi.emitSessionShutdown();
+
+    const [file] = await fs.readdir(config.paths.logDir);
+    const parsed = parsePermissionAuditJsonl(
+      await fs.readFile(join(config.paths.logDir, file ?? ""), "utf8"),
+    );
+    expect(parsed.records).toHaveLength(1);
+    expect(parsed.records[0]?.stages).toContainEqual(
+      expect.objectContaining({
+        type: "confirmation",
+        status: "timed-out",
+      }),
+    );
+    expect(summarizePermissionAudit(parsed.records).byConfirmation).toEqual({
+      "timed-out": 1,
+    });
   });
 
   test("propagates real parent-child audit env without recording the permission token", async () => {

--- a/tests/pi-harness/permission-judge-policy.test.ts
+++ b/tests/pi-harness/permission-judge-policy.test.ts
@@ -21,6 +21,7 @@ import {
   pinCodexStageCommand,
 } from "../../pi/extensions/pi-harness/features/permission-policy/codex-stage-capability";
 import type { PermissionProjectContext } from "../../pi/extensions/pi-harness/features/permission-policy/context";
+import type { PermissionJudge } from "../../pi/extensions/pi-harness/features/permission-policy/judge";
 import { loadRules } from "../../pi/extensions/pi-harness/features/permission-policy/rules";
 import { resolvePaths } from "../../pi/extensions/pi-harness/lib/paths";
 import type { ToolCallEvent } from "../../pi/extensions/pi-harness/lib/pi-like";
@@ -70,6 +71,16 @@ const ollamaResponse = (verdict: string): Response =>
     done: true,
     done_reason: "stop",
   });
+
+const askingJudge = (): PermissionJudge => ({
+  async judge() {
+    return {
+      kind: "ask",
+      reason: "local judge requested user confirmation",
+    };
+  },
+  clear() {},
+});
 
 const makeConfig = (
   permissionJudge?: PermissionJudgeConfig,
@@ -177,6 +188,12 @@ const createTestAbortController = (): {
   };
 };
 
+const signalAborted = (value: unknown): boolean =>
+  typeof value === "object" &&
+  value !== null &&
+  "aborted" in value &&
+  value.aborted === true;
+
 describe("permission policy local judge routing", () => {
   test("auto-approves an unruled command only on structured ALLOW", async () => {
     const upstream = await start(() => ollamaResponse("ALLOW"));
@@ -220,7 +237,9 @@ describe("permission policy local judge routing", () => {
 
     expect(await pi.emitToolCall(bashCall("git status --short"))).toEqual({
       block: true,
-      reason: "local judge requested user confirmation",
+      reason: expect.stringMatching(
+        /denied by the user[\s\S]*local judge requested user confirmation/,
+      ),
     });
     expect(chatRequests(upstream)).toHaveLength(1);
   });
@@ -270,8 +289,9 @@ describe("permission policy local judge routing", () => {
       ),
     ).toEqual({
       block: true,
-      reason:
-        "git -C の対象を登録済みの同一リポジトリworktree内と確認できませんでした",
+      reason: expect.stringMatching(
+        /interactive UI is unavailable[\s\S]*git -C の対象を登録済みの同一リポジトリworktree内と確認できませんでした/,
+      ),
     });
     expect(upstream.received).toHaveLength(0);
   });
@@ -295,8 +315,9 @@ describe("permission policy local judge routing", () => {
     ]) {
       expect(await pi.emitToolCall(bashCall(command))).toEqual({
         block: true,
-        reason:
-          "Git の作業場所・設定・不明なグローバルオプション変更には確認が必要です",
+        reason: expect.stringMatching(
+          /interactive UI is unavailable[\s\S]*Git の作業場所・設定・不明なグローバルオプション変更には確認が必要です/,
+        ),
       });
     }
     expect(discoveries).toBe(0);
@@ -580,8 +601,9 @@ describe("permission policy local judge routing", () => {
         ),
       ).toEqual({
         block: true,
-        reason:
-          "プロジェクト境界を検証できないため変更コマンドには確認が必要です",
+        reason: expect.stringMatching(
+          /interactive UI is unavailable[\s\S]*プロジェクト境界を検証できないため変更コマンドには確認が必要です/,
+        ),
       });
     }
     expect(upstream.received).toHaveLength(0);
@@ -651,7 +673,9 @@ describe("permission policy local judge routing", () => {
 
     expect(await pi.emitToolCall(bashCall(`bun "$'$(printf PWN)'"`))).toEqual({
       block: true,
-      reason: "local judge requested user confirmation",
+      reason: expect.stringMatching(
+        /interactive UI is unavailable[\s\S]*local judge requested user confirmation/,
+      ),
     });
     expect(chatRequests(upstream)).toHaveLength(1);
   });
@@ -1096,7 +1120,9 @@ describe("permission policy local judge routing", () => {
       ),
     ).toEqual({
       block: true,
-      reason: "local judge requested user confirmation",
+      reason: expect.stringMatching(
+        /interactive UI is unavailable[\s\S]*local judge requested user confirmation/,
+      ),
     });
     expect(chatRequests(upstream)).toHaveLength(1);
     expect(pi.confirmDialogs).toHaveLength(0);
@@ -1181,7 +1207,9 @@ describe("permission policy local judge routing", () => {
       ),
     ).toEqual({
       block: true,
-      reason: "登録済みの同一リポジトリworktreeへの移動と確認できませんでした",
+      reason: expect.stringMatching(
+        /interactive UI is unavailable[\s\S]*登録済みの同一リポジトリworktreeへの移動と確認できませんでした/,
+      ),
     });
     expect(upstream.received).toHaveLength(0);
   });
@@ -1234,7 +1262,9 @@ describe("permission policy local judge routing", () => {
       ),
     ).toEqual({
       block: true,
-      reason: "登録済みの同一リポジトリworktreeへの移動と確認できませんでした",
+      reason: expect.stringMatching(
+        /interactive UI is unavailable[\s\S]*登録済みの同一リポジトリworktreeへの移動と確認できませんでした/,
+      ),
     });
     expect(discoveredTarget).toBe(target);
     expect(upstream.received).toHaveLength(0);
@@ -1249,6 +1279,29 @@ describe("permission policy local judge routing", () => {
     expect(
       await accepted.emitToolCall(bashCall("git rev-parse HEAD", "accepted")),
     ).toBeUndefined();
+    const acceptedPatch = await accepted.emitToolResult({
+      type: "tool_result",
+      toolName: "bash",
+      toolCallId: "accepted",
+      content: [{ type: "text", text: "command output" }],
+      isError: false,
+    });
+    expect(acceptedPatch?.content).toEqual([
+      {
+        type: "text",
+        text: expect.stringMatching(/local verifier returned ASK/i),
+      },
+      { type: "text", text: "command output" },
+    ]);
+    expect(
+      await accepted.emitToolResult({
+        type: "tool_result",
+        toolName: "bash",
+        toolCallId: "accepted",
+        content: [{ type: "text", text: "duplicate" }],
+        isError: false,
+      }),
+    ).toBeUndefined();
 
     content = "not a verdict";
     const rejected = createFakePi();
@@ -1258,11 +1311,46 @@ describe("permission policy local judge routing", () => {
       await rejected.emitToolCall(bashCall("git rev-parse HEAD", "rejected")),
     ).toEqual({
       block: true,
-      reason: "local judge did not return a valid structured decision",
+      reason: expect.stringMatching(
+        /denied by the user[\s\S]*local judge did not return a valid structured decision/,
+      ),
     });
   });
 
-  test("bounds confirmation with the active signal and configured timeout", async () => {
+  test("surfaces accepted local ASK on only the matching tool result", async () => {
+    const pi = createFakePi();
+    pi.queueConfirm(true);
+    setupPermissionPolicy(pi, makeConfig(), { judge: askingJudge() });
+
+    expect(
+      await pi.emitToolCall(bashCall("git rev-parse HEAD", "stub-ask")),
+    ).toBeUndefined();
+    expect(
+      await pi.emitToolResult({
+        type: "tool_result",
+        toolName: "bash",
+        toolCallId: "other-call",
+        content: [{ type: "text", text: "other output" }],
+        isError: false,
+      }),
+    ).toBeUndefined();
+    const patch = await pi.emitToolResult({
+      type: "tool_result",
+      toolName: "bash",
+      toolCallId: "stub-ask",
+      content: [{ type: "text", text: "command output" }],
+      isError: false,
+    });
+    expect(patch?.content).toEqual([
+      {
+        type: "text",
+        text: expect.stringMatching(/local verifier returned ASK/i),
+      },
+      { type: "text", text: "command output" },
+    ]);
+  });
+
+  test("bounds confirmation with a composed signal and configured timeout", async () => {
     const upstream = await start(() => ollamaResponse("ASK"));
     const pi = createFakePi();
     const controller = createTestAbortController();
@@ -1278,13 +1366,40 @@ describe("permission policy local judge routing", () => {
 
     expect(await pi.emitToolCall(bashCall("git rev-parse HEAD"))).toEqual({
       block: true,
-      reason: "local judge requested user confirmation",
+      reason: expect.stringContaining("denied by the user"),
     });
     expect(pi.confirmDialogs).toHaveLength(1);
-    expect(pi.confirmDialogs[0]?.dialogOptions).toEqual({
-      signal: controller.signal,
-      timeout: 1_234,
+    expect(pi.confirmDialogs[0]?.dialogOptions?.timeout).toBe(1_234);
+    expect(pi.confirmDialogs[0]?.dialogOptions?.signal).not.toBe(
+      controller.signal,
+    );
+    expect(signalAborted(pi.confirmDialogs[0]?.dialogOptions?.signal)).toBe(
+      false,
+    );
+  });
+
+  test("reports confirmation timeout and unavailable-user guidance distinctly", async () => {
+    const pi = createFakePi();
+    pi.queueConfirmUntilAborted();
+    setupPermissionPolicy(
+      pi,
+      makeConfig({
+        ...DEFAULT_PERMISSION_JUDGE_CONFIG,
+        enabled: false,
+        confirmTimeoutMs: 10,
+      }),
+      { judge: askingJudge() },
+    );
+
+    expect(await pi.emitToolCall(bashCall("git rev-parse HEAD"))).toEqual({
+      block: true,
+      reason: expect.stringMatching(
+        /timed out[\s\S]*user is unavailable[\s\S]*system prompt instructions[\s\S]*local judge requested user confirmation/i,
+      ),
     });
+    expect(signalAborted(pi.confirmDialogs[0]?.dialogOptions?.signal)).toBe(
+      true,
+    );
   });
 
   test("blocks non-interactively when the judge does not allow", async () => {
@@ -1294,7 +1409,9 @@ describe("permission policy local judge routing", () => {
 
     expect(await pi.emitToolCall(bashCall("git rev-parse HEAD"))).toEqual({
       block: true,
-      reason: "local judge requested user confirmation",
+      reason: expect.stringMatching(
+        /interactive UI is unavailable[\s\S]*local judge requested user confirmation/,
+      ),
     });
   });
 
@@ -1310,7 +1427,9 @@ describe("permission policy local judge routing", () => {
 
     expect(await pi.emitToolCall(bashCall("git rev-parse HEAD"))).toEqual({
       block: true,
-      reason: "local judge requested user confirmation",
+      reason: expect.stringMatching(
+        /interactive UI is unavailable[\s\S]*local judge requested user confirmation/,
+      ),
     });
     expect(signals).toEqual([`${formatChildPermissionSignal(token)}\n`]);
   });

--- a/tests/pi-harness/permission-skill-policy.test.ts
+++ b/tests/pi-harness/permission-skill-policy.test.ts
@@ -654,8 +654,9 @@ describe("active skill allowed-tools permission grants", () => {
         ),
       ).toEqual({
         block: true,
-        reason:
-          "プロジェクト境界を検証できないため変更コマンドには確認が必要です",
+        reason: expect.stringMatching(
+          /interactive UI is unavailable[\s\S]*プロジェクト境界を検証できないため変更コマンドには確認が必要です/,
+        ),
       });
     }
 


### PR DESCRIPTION
## Summary

- distinguish accepted, rejected, timed-out, aborted, and unavailable-UI Bash confirmations
- tell the agent when a confirmation timed out and surface one-time local-verifier ASK feedback after approval
- record and aggregate timed-out confirmations in permission audit logs
- add focused policy, audit, CLI, and headless regression coverage

## Test plan

- `bun run tsc`
- `bun run lint` (0 errors; 9 pre-existing warnings outside this change)
- `bun test tests/pi-harness/permission-judge-policy.test.ts --test-name-pattern "surfaces accepted local ASK|reports confirmation timeout"` (2 pass)
- `bun test tests/pi-harness/permission-audit.test.ts tests/pi-harness/permission-audit-analysis-cli.test.ts tests/pi-harness/permission-rules.test.ts tests/pi-harness/permission-ask-reminder.test.ts` (443 pass)
- `git diff --check`

The full-suite attempt reached 1510 pass / 2 skip; remaining failures require loopback listeners or nested real-sandbox behavior unavailable in the outer test sandbox, plus an unrelated existing theme expectation difference.