### PR TITLE
fix(pi): bridge asuku permissions and Codex rate limits

### DIFF
--- a/pi/README.md
+++ b/pi/README.md
@@ -389,23 +389,24 @@ typebox baseline + acceptance/rejection through pi's real `validateToolArguments
 
 ## Claude hook lifecycle mapping
 
-| Claude Code                          | pi-harness                                                                   |
-| ------------------------------------ | ---------------------------------------------------------------------------- |
-| PreToolUse (Bash matcher)            | `tool_call` via hook-bridge                                                  |
-| PreToolUse (Workflow matcher)        | `tool_call` — plan serialized into `script` so codex_stage_guard can grep it |
-| PostToolUse (Write\|Edit\|MultiEdit) | `tool_result` via hook-bridge (trust-gated)                                  |
-| UserPromptSubmit                     | `before_agent_start` message injection                                       |
-| SessionStart / Stop                  | `session_start` / `agent_settled`                                            |
-| Task tool (subagents)                | `subagent` tool (single / parallel / chain)                                  |
-| Workflow tool (ultracode)            | `workflow` tool (declarative JSON plan)                                      |
-| TaskCompleted                        | `task_completed` tool (bit-task, codex-side hook)                            |
-| WorktreeCreate / WorktreeRemove      | `worktree_create` / `worktree_remove` tools                                  |
-| AskUserQuestion                      | exact-name `AskUserQuestion` compatibility tool                              |
-| Notification (asuku)                 | asuku-notify feature (`agent_settled`, detached)                             |
-| permissions.deny / auto fallback     | permission-policy rules + local Ollama judge (fail-closed)                   |
-| permission decision corpus           | always-on private versioned JSONL audit (parent + child lineage)             |
-| statusLine                           | statusline feature (Claude-equivalent custom footer)                         |
-| logproxy                             | provider-log feature (opt-in, reduced scope)                                 |
+| Claude Code                          | pi-harness                                                                    |
+| ------------------------------------ | ----------------------------------------------------------------------------- |
+| PreToolUse (Bash matcher)            | `tool_call` via hook-bridge                                                   |
+| PreToolUse (Workflow matcher)        | `tool_call` — plan serialized into `script` so codex_stage_guard can grep it  |
+| PostToolUse (Write\|Edit\|MultiEdit) | `tool_result` via hook-bridge (trust-gated)                                   |
+| UserPromptSubmit                     | `before_agent_start` message injection                                        |
+| SessionStart / Stop                  | `session_start` / `agent_settled`                                             |
+| Task tool (subagents)                | `subagent` tool (single / parallel / chain)                                   |
+| Workflow tool (ultracode)            | `workflow` tool (declarative JSON plan)                                       |
+| TaskCompleted                        | `task_completed` tool (bit-task, codex-side hook)                             |
+| WorktreeCreate / WorktreeRemove      | `worktree_create` / `worktree_remove` tools                                   |
+| AskUserQuestion                      | exact-name `AskUserQuestion` compatibility tool                               |
+| PermissionRequest (asuku)            | asuku-notify wraps `ui.confirm`; unavailable/invalid bridge falls back to TUI |
+| Notification (asuku)                 | detached `agent_settled`; Codex 5h/7d headers and HTTP 429 join the message   |
+| permissions.deny / auto fallback     | permission-policy rules + local Ollama judge (fail-closed)                    |
+| permission decision corpus           | always-on private versioned JSONL audit (parent + child lineage)              |
+| statusLine                           | statusline feature (Claude-equivalent custom footer)                          |
+| logproxy                             | provider-log feature (opt-in, reduced scope)                                  |
 
 Known gaps vs Claude Code: this is a local effect-sandbox plus local-classifier
 implementation rather than Claude's server-side auto mode; there are no LSP
@@ -563,17 +564,24 @@ rule or qualification label. The counter resets at the session boundary.
 ## provider-log scope (V10, measured 2026-07-11)
 
 `before_provider_request` fires and carries the payload (model captured on
-the openai-codex provider). `after_provider_response` **did not fire on the
-openai-codex transport** — pi docs: providers that abstract HTTP responses
-may not expose status/headers. Anthropic-transport verification pending
-(blocked on extra-usage balance). Records store sha256 + metadata only; log
-dir `~/.pi/agent/pi-harness/logs` (0700/0600, daily rotation, 14-day
-retention).
+the openai-codex provider). The default Codex WebSocket path does not expose
+`after_provider_response`; the tracked pi settings therefore select `transport:
+"sse"` so response status/rate-limit headers reach asuku (and provider-log when
+opted in). Anthropic-transport verification remains pending (blocked on
+extra-usage balance). Records store sha256 + metadata only; log dir
+`~/.pi/agent/pi-harness/logs` (0700/0600, daily rotation, 14-day retention).
 
 ## Smoke checklist
 
 Automated coverage lives in `tests/pi-harness/` + `tests/hooks/pi-harness/`
-(`bun test`). Host-dependent checks:
+(`bun test`). The asuku feature tests pin Allow/Deny round-trips, native TUI
+fallback, Codex rate-limit header formatting, and per-turn stale-state reset.
+Codex quota stays in the notification body because asuku's current
+`statusline.rate_limits` field is Claude-specific. `pi/settings.json` pins SSE;
+removing that override restores the WebSocket transport but also removes the
+successful-response quota headers available to this bridge.
+
+Host-dependent checks:
 
 - [x] `bun run check:pi-baseline` passes (local lock/install integrity)
 - [x] `bun run check:pi-compat` passes (global declarations + isolated RPC)

--- a/pi/extensions/pi-harness/features/asuku-notify/index.ts
+++ b/pi/extensions/pi-harness/features/asuku-notify/index.ts
@@ -1,42 +1,519 @@
 /**
- * asuku-notify feature — feeds the asuku desktop notifier when the agent
- * settles, following the codex stop/asuku_notification.sh contract: the
- * notifier runs detached with the payload on stdin, all output discarded,
- * and a missing or non-executable binary is silently skipped.
+ * asuku-notify feature — bridges pi's confirmations and completion state to
+ * the asuku desktop app. Permission requests wait for asuku's Allow/Deny
+ * response and fall back to pi's original TUI dialog whenever the bridge is
+ * unavailable. Completion notifications remain detached and best-effort.
  */
+import { spawn } from "node:child_process";
 import { constants } from "node:fs";
 import { access } from "node:fs/promises";
 import type { HarnessConfig } from "../../config";
 import { launchDetached, type DetachedSpawnFunction } from "../../lib/detached";
-import type { PiLike } from "../../lib/pi-like";
+import { sanitizeChildEnv } from "../../lib/child-env";
+import type {
+  CtxLike,
+  DialogOptionsLike,
+  PiLike,
+  UiLike,
+} from "../../lib/pi-like";
 
 const ASUKU_BINARY = "/Applications/asuku.app/Contents/MacOS/asuku-hook";
+const DEFAULT_PERMISSION_TIMEOUT_MS = 300_000;
+const PERMISSION_TERM_GRACE_MS = 1_000;
+const MAX_PERMISSION_OUTPUT_BYTES = 64 * 1024;
+
+interface AsukuPermissionPayload {
+  session_id: string;
+  hook_event_name: "PermissionRequest";
+  tool_name: "PiConfirm";
+  tool_input: {
+    title: string;
+    message: string;
+  };
+  cwd: string;
+  permission_mode: "default";
+}
+
+interface PermissionRequestOptions {
+  cwd: string;
+  signal?: AbortSignal;
+  timeoutMs: number;
+}
+
+export type PermissionRequestRunner = (
+  binary: string,
+  payload: AsukuPermissionPayload,
+  options: PermissionRequestOptions,
+) => Promise<boolean | undefined>;
 
 interface AsukuNotifyDeps {
   binaryPath?: string;
   spawnDetached?: DetachedSpawnFunction;
+  requestPermission?: PermissionRequestRunner;
+  now?: () => number;
 }
+
+interface CodexRateLimitWindow {
+  usedPercentage: number;
+  windowMinutes?: number;
+  resetsAt?: number;
+}
+
+export interface CodexRateLimitSnapshot {
+  primary?: CodexRateLimitWindow;
+  secondary?: CodexRateLimitWindow;
+  status?: number;
+}
+
+const CONFIRM_BRIDGE_KEY = Symbol.for("pi-harness.asuku-confirm-bridge");
+
+type ConfirmFunction = UiLike["confirm"];
+type BridgeUi = UiLike & { [key: symbol]: unknown };
+
+interface ConfirmBridgeRegistration {
+  owner: symbol;
+  originalConfirm: ConfirmFunction;
+  bridgedConfirm: ConfirmFunction;
+  ctx: CtxLike;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const bridgeRegistration = (
+  ui: UiLike,
+): ConfirmBridgeRegistration | undefined => {
+  const candidate = (ui as BridgeUi)[CONFIRM_BRIDGE_KEY];
+  if (
+    !isRecord(candidate) ||
+    typeof candidate.owner !== "symbol" ||
+    typeof candidate.originalConfirm !== "function" ||
+    typeof candidate.bridgedConfirm !== "function" ||
+    !isRecord(candidate.ctx)
+  ) {
+    return undefined;
+  }
+  return candidate as unknown as ConfirmBridgeRegistration;
+};
+
+const clearConfirmBridge = (ui: UiLike, owner?: symbol): boolean => {
+  const registration = bridgeRegistration(ui);
+  if (
+    registration === undefined ||
+    (owner !== undefined && registration.owner !== owner) ||
+    ui.confirm !== registration.bridgedConfirm
+  ) {
+    return false;
+  }
+  const bridgeUi = ui as BridgeUi;
+  try {
+    ui.confirm = registration.originalConfirm;
+    delete bridgeUi[CONFIRM_BRIDGE_KEY];
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const executable = async (path: string): Promise<boolean> => {
+  try {
+    await access(path, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const permissionDecision = (stdout: string): boolean | undefined => {
+  try {
+    const parsed: unknown = JSON.parse(stdout);
+    if (!isRecord(parsed)) return undefined;
+    const specific = parsed.hookSpecificOutput;
+    if (!isRecord(specific)) return undefined;
+    const { decision } = specific;
+    if (!isRecord(decision)) return undefined;
+    if (decision.behavior === "allow") return true;
+    if (decision.behavior === "deny") return false;
+    return undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+export const runPermissionRequest: PermissionRequestRunner = (
+  binary,
+  payload,
+  options,
+) =>
+  new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(binary, ["permission-request"], {
+        cwd: options.cwd,
+        env: sanitizeChildEnv(process.env, undefined, { cwd: options.cwd }),
+        stdio: ["pipe", "pipe", "ignore"],
+      });
+    } catch {
+      resolve(undefined);
+      return;
+    }
+
+    let stdout = "";
+    let stdoutBytes = 0;
+    let settled = false;
+    let terminating = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const signalAborted = (): boolean =>
+      options.signal !== undefined &&
+      "aborted" in options.signal &&
+      options.signal.aborted === true;
+    const removeAbortListener = (): void => {
+      if (
+        options.signal !== undefined &&
+        "removeEventListener" in options.signal &&
+        typeof options.signal.removeEventListener === "function"
+      ) {
+        options.signal.removeEventListener("abort", abort);
+      }
+    };
+    const settle = (decision: boolean | undefined): void => {
+      if (settled) return;
+      settled = true;
+      if (timer !== undefined) clearTimeout(timer);
+      removeAbortListener();
+      resolve(decision);
+    };
+    const terminate = (): void => {
+      if (terminating) return;
+      terminating = true;
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        // The hook already exited.
+      }
+      forceKillTimer = setTimeout(() => {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // The hook exited during the grace period.
+        }
+      }, PERMISSION_TERM_GRACE_MS);
+      if (typeof forceKillTimer === "object" && "unref" in forceKillTimer) {
+        forceKillTimer.unref();
+      }
+    };
+    const abort = (): void => {
+      terminate();
+      settle(undefined);
+    };
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdoutBytes += chunk.byteLength;
+      if (stdoutBytes > MAX_PERMISSION_OUTPUT_BYTES) {
+        terminate();
+        settle(undefined);
+        return;
+      }
+      stdout += chunk.toString("utf8");
+    });
+    child.on("error", () => settle(undefined));
+    child.on("close", (code) => {
+      if (forceKillTimer !== undefined) clearTimeout(forceKillTimer);
+      settle(code === 0 ? permissionDecision(stdout) : undefined);
+    });
+    child.stdin.on("error", () => {
+      // The hook may fail before reading stdin; close/error handles fallback.
+    });
+
+    if (
+      options.signal !== undefined &&
+      "addEventListener" in options.signal &&
+      typeof options.signal.addEventListener === "function"
+    ) {
+      options.signal.addEventListener("abort", abort, { once: true });
+    }
+    if (signalAborted()) {
+      abort();
+      return;
+    }
+    timer = setTimeout(abort, options.timeoutMs);
+    child.stdin.end(JSON.stringify(payload));
+  });
+
+const responseContainer = (event: unknown): Record<string, unknown> => {
+  if (!isRecord(event)) return {};
+  return isRecord(event.response) ? event.response : event;
+};
+
+const normalizedHeaders = (event: unknown): Map<string, string> => {
+  const { headers } = responseContainer(event);
+  const normalized = new Map<string, string>();
+  if (!isRecord(headers)) return normalized;
+  for (const [name, value] of Object.entries(headers)) {
+    if (typeof value === "string" || typeof value === "number") {
+      normalized.set(name.toLowerCase(), String(value));
+    }
+  }
+  return normalized;
+};
+
+const finiteHeader = (
+  headers: ReadonlyMap<string, string>,
+  name: string,
+): number | undefined => {
+  const raw = headers.get(name);
+  if (raw === undefined || raw.trim() === "") return undefined;
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : undefined;
+};
+
+const rateLimitWindow = (
+  headers: ReadonlyMap<string, string>,
+  name: "primary" | "secondary",
+): CodexRateLimitWindow | undefined => {
+  const prefix = `x-codex-${name}`;
+  const usedPercentage = finiteHeader(headers, `${prefix}-used-percent`);
+  if (usedPercentage === undefined) return undefined;
+  const windowMinutes = finiteHeader(headers, `${prefix}-window-minutes`);
+  const resetsAt = finiteHeader(headers, `${prefix}-reset-at`);
+  return {
+    usedPercentage,
+    ...(windowMinutes === undefined ? {} : { windowMinutes }),
+    ...(resetsAt === undefined ? {} : { resetsAt }),
+  };
+};
+
+export const parseCodexRateLimits = (
+  event: unknown,
+  allowStatusOnly429 = false,
+): CodexRateLimitSnapshot | undefined => {
+  const container = responseContainer(event);
+  const headers = normalizedHeaders(event);
+  const status =
+    typeof container.status === "number" ? container.status : undefined;
+  const hasCodexHeaders = [...headers.keys()].some((name) =>
+    name.startsWith("x-codex-"),
+  );
+  if (!hasCodexHeaders && !(allowStatusOnly429 && status === 429)) {
+    return undefined;
+  }
+
+  const primary = rateLimitWindow(headers, "primary");
+  const secondary = rateLimitWindow(headers, "secondary");
+  if (primary === undefined && secondary === undefined && status !== 429) {
+    return undefined;
+  }
+  return {
+    ...(primary === undefined ? {} : { primary }),
+    ...(secondary === undefined ? {} : { secondary }),
+    ...(status === undefined ? {} : { status }),
+  };
+};
+
+const compactNumber = (value: number): string =>
+  Number.isInteger(value) ? String(value) : String(Number(value.toFixed(2)));
+
+const windowLabel = (
+  window: CodexRateLimitWindow,
+  fallback: "primary" | "secondary",
+): string => {
+  const minutes = window.windowMinutes;
+  if (minutes === undefined) return fallback;
+  if (minutes % (7 * 24 * 60) === 0) {
+    return `${compactNumber(minutes / (24 * 60))}d`;
+  }
+  if (minutes % 60 === 0) return `${compactNumber(minutes / 60)}h`;
+  return `${compactNumber(minutes)}m`;
+};
+
+const resetSuffix = (resetsAt: number | undefined): string => {
+  if (resetsAt === undefined) return "";
+  const reset = new Date(resetsAt * 1_000);
+  return Number.isFinite(reset.getTime())
+    ? `, reset ${reset.toISOString()}`
+    : "";
+};
+
+export const formatCodexRateLimits = (
+  snapshot: CodexRateLimitSnapshot,
+): string => {
+  const windows: string[] = [];
+  if (snapshot.primary !== undefined) {
+    windows.push(
+      `${windowLabel(snapshot.primary, "primary")} ${compactNumber(snapshot.primary.usedPercentage)}% used${resetSuffix(snapshot.primary.resetsAt)}`,
+    );
+  }
+  if (snapshot.secondary !== undefined) {
+    windows.push(
+      `${windowLabel(snapshot.secondary, "secondary")} ${compactNumber(snapshot.secondary.usedPercentage)}% used${resetSuffix(snapshot.secondary.resetsAt)}`,
+    );
+  }
+  const prefix =
+    snapshot.status === 429
+      ? "Codex rate limited (HTTP 429)"
+      : "Codex rate limits";
+  return windows.length === 0 ? prefix : `${prefix}: ${windows.join("; ")}`;
+};
+
+const sessionId = (ctx: CtxLike): string =>
+  ctx.sessionManager?.getSessionId?.() ?? "pi-harness";
 
 export default function setupAsukuNotify(
   pi: PiLike,
-  _config: HarnessConfig,
+  config: HarnessConfig,
   deps: AsukuNotifyDeps = {},
 ): void {
+  const owner = Symbol("asuku-confirm-owner");
+  const cleanupBridge = (ctx: CtxLike): void => {
+    clearConfirmBridge(ctx.ui);
+  };
+
+  // setupHarness invokes this feature even while disabled so a /reload that
+  // flips the toggle off can remove the previous instance's UI wrapper.
+  if (!config.features["asuku-notify"]) {
+    pi.on("session_start", (_event, ctx) => cleanupBridge(ctx));
+    pi.on("before_agent_start", (_event, ctx) => cleanupBridge(ctx));
+    pi.on("tool_call", (_event, ctx) => cleanupBridge(ctx));
+    pi.on("session_shutdown", (_event, ctx) => cleanupBridge(ctx));
+    return;
+  }
+
   const binary = deps.binaryPath ?? ASUKU_BINARY;
   const spawnDetached = deps.spawnDetached ?? launchDetached;
+  const requestPermission = deps.requestPermission ?? runPermissionRequest;
+  const now = deps.now ?? Date.now;
+  let latestRateLimits: CodexRateLimitSnapshot | undefined;
 
-  pi.on("agent_settled", async (_event, ctx) => {
-    try {
-      await access(binary, constants.X_OK);
-    } catch {
+  const installConfirmBridge = (ctx: CtxLike): void => {
+    if (!ctx.hasUI) return;
+    const { ui } = ctx;
+    const existing = bridgeRegistration(ui);
+    if (existing?.owner === owner) {
+      existing.ctx = ctx;
       return;
     }
+    if (existing !== undefined && !clearConfirmBridge(ui)) {
+      // Another adapter replaced our predecessor; do not wrap an unknown
+      // chain or restore a function we no longer own.
+      return;
+    }
+
+    const originalConfirm = ui.confirm;
+    let registration: ConfirmBridgeRegistration;
+    const bridgedConfirm: ConfirmFunction = async (
+      title: string,
+      message: string,
+      dialogOptions?: DialogOptionsLike,
+    ): Promise<boolean> => {
+      const activeCtx = registration.ctx;
+      if (!activeCtx.hasUI) {
+        return originalConfirm.call(ui, title, message, dialogOptions);
+      }
+
+      const configuredTimeout =
+        dialogOptions?.timeout !== undefined &&
+        Number.isFinite(dialogOptions.timeout) &&
+        dialogOptions.timeout > 0
+          ? dialogOptions.timeout
+          : undefined;
+      const startedAt = now();
+      const remainingTimeout = (): number | undefined => {
+        if (configuredTimeout === undefined) return undefined;
+        return Math.max(0, configuredTimeout - Math.max(0, now() - startedAt));
+      };
+      const fallbackToTui = (): Promise<boolean> => {
+        const remaining = remainingTimeout();
+        if (remaining === undefined) {
+          return originalConfirm.call(ui, title, message, dialogOptions);
+        }
+        if (remaining <= 0) return Promise.resolve(false);
+        return originalConfirm.call(ui, title, message, {
+          ...dialogOptions,
+          timeout: remaining,
+        });
+      };
+
+      if (!(await executable(binary))) return fallbackToTui();
+      const cwd = activeCtx.cwd ?? process.cwd();
+      const payload: AsukuPermissionPayload = {
+        session_id: sessionId(activeCtx),
+        hook_event_name: "PermissionRequest",
+        tool_name: "PiConfirm",
+        tool_input: { title, message },
+        cwd,
+        permission_mode: "default",
+      };
+      const bridgeTimeout = remainingTimeout() ?? DEFAULT_PERMISSION_TIMEOUT_MS;
+      if (bridgeTimeout <= 0) return false;
+      let decision: boolean | undefined;
+      try {
+        decision = await requestPermission(binary, payload, {
+          cwd,
+          ...(dialogOptions?.signal === undefined
+            ? {}
+            : { signal: dialogOptions.signal }),
+          timeoutMs: bridgeTimeout,
+        });
+      } catch {
+        return fallbackToTui();
+      }
+      return decision ?? fallbackToTui();
+    };
+    registration = {
+      owner,
+      originalConfirm,
+      bridgedConfirm,
+      ctx,
+    };
+
+    const bridgeUi = ui as BridgeUi;
+    try {
+      bridgeUi[CONFIRM_BRIDGE_KEY] = registration;
+      ui.confirm = bridgedConfirm;
+    } catch {
+      if (ui.confirm === bridgedConfirm) ui.confirm = originalConfirm;
+      if (bridgeUi[CONFIRM_BRIDGE_KEY] === registration) {
+        delete bridgeUi[CONFIRM_BRIDGE_KEY];
+      }
+    }
+  };
+
+  pi.on("session_start", (_event, ctx) => {
+    latestRateLimits = undefined;
+    installConfirmBridge(ctx);
+  });
+  pi.on("before_agent_start", (_event, ctx) => {
+    latestRateLimits = undefined;
+    installConfirmBridge(ctx);
+  });
+  pi.on("tool_call", (_event, ctx) => installConfirmBridge(ctx));
+  pi.on("after_provider_response", (event, ctx) => {
+    const snapshot = parseCodexRateLimits(
+      event,
+      ctx.model?.provider === "openai-codex",
+    );
+    if (snapshot !== undefined) latestRateLimits = snapshot;
+  });
+  pi.on("session_shutdown", (_event, ctx) => {
+    clearConfirmBridge(ctx.ui, owner);
+    latestRateLimits = undefined;
+  });
+
+  pi.on("agent_settled", async (_event, ctx) => {
+    if (!(await executable(binary))) return;
     const cwd = ctx.cwd ?? process.cwd();
+    const rateLimitMessage =
+      latestRateLimits === undefined
+        ? ""
+        : `\n${formatCodexRateLimits(latestRateLimits)}`;
     const payload = JSON.stringify({
       hook_event_name: "Notification",
-      session_id: "pi-harness",
+      session_id: sessionId(ctx),
       cwd,
-      message: "pi agent finished its turn",
+      title: "pi",
+      message: `pi agent finished its turn${rateLimitMessage}`,
     });
     spawnDetached(binary, ["notification"], { cwd, stdin: payload });
   });

--- a/pi/extensions/pi-harness/index.ts
+++ b/pi/extensions/pi-harness/index.ts
@@ -78,6 +78,10 @@ const setupHarness = (
       createCodexStagePin = createCodexStageExecutablePin,
     ...blockerOptions
   } = options;
+  // Install (or, when disabled after /reload, remove) the shared confirmation
+  // adapter before any permission handler can call ctx.ui.confirm. The bridge
+  // remains best-effort and preserves the original TUI dialog on failure.
+  setupAsukuNotify(pi, config);
   let codexStageModes = consumeCodexStageModes(config.isChild);
   let codexStageExecutable:
     | ReturnType<typeof createCodexStageExecutablePin>
@@ -193,7 +197,6 @@ const setupHarness = (
   }
   if (config.features.statusline) setupStatusline(pi, config);
   if (config.features["provider-log"]) setupProviderLog(pi, config);
-  if (config.features["asuku-notify"]) setupAsukuNotify(pi, config);
   if (config.features["ask-user-question"]) setupAskUserQuestion(pi);
   if (!config.isChild) setupBtw(pi);
 };

--- a/pi/extensions/pi-harness/lib/pi-like.ts
+++ b/pi/extensions/pi-harness/lib/pi-like.ts
@@ -205,6 +205,7 @@ export type FooterFactoryLike = (
 export interface ModelLike {
   id: string;
   name?: string;
+  provider?: string;
 }
 
 export interface ContextUsageLike {

--- a/pi/settings.json
+++ b/pi/settings.json
@@ -3,6 +3,7 @@
   "defaultProvider": "openai-codex",
   "defaultModel": "gpt-5.6-sol",
   "defaultThinkingLevel": "xhigh",
+  "transport": "sse",
   "hideThinkingBlock": false,
   "skills": [
     "!/Users/ushironoko/.agents/skills/**"

--- a/tests/pi-harness/asuku-notify.test.ts
+++ b/tests/pi-harness/asuku-notify.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
+import settings from "../../pi/settings.json";
 import type { HarnessConfig } from "../../pi/extensions/pi-harness/config";
 import setupAsukuNotify from "../../pi/extensions/pi-harness/features/asuku-notify/index";
 import type { DetachedSpawnFunction } from "../../pi/extensions/pi-harness/lib/detached";
@@ -20,7 +21,7 @@ afterEach(async () => {
   await Promise.all(tempDirectories.splice(0).map(cleanupTestDirectory));
 });
 
-const makeConfig = (home: string): HarnessConfig => ({
+const makeConfig = (home: string, enabled = true): HarnessConfig => ({
   isChild: false,
   features: {
     "hook-bridge": true,
@@ -29,7 +30,7 @@ const makeConfig = (home: string): HarnessConfig => ({
     "bit-task": true,
     statusline: true,
     "provider-log": false,
-    "asuku-notify": true,
+    "asuku-notify": enabled,
     "ask-user-question": true,
   },
   trust: { trustedRoots: [] },
@@ -64,6 +65,33 @@ const writeStubBinary = async (
   return binary;
 };
 
+const writePermissionStub = async (
+  directory: string,
+  captureFile: string,
+  behavior: "allow" | "deny" | "malformed",
+): Promise<string> => {
+  const binary = join(directory, "asuku-hook");
+  const output =
+    behavior === "malformed"
+      ? "not-json"
+      : JSON.stringify({
+          hookSpecificOutput: {
+            hookEventName: "PermissionRequest",
+            decision: { behavior },
+          },
+        });
+  await fs.writeFile(
+    binary,
+    [
+      "#!/bin/bash",
+      `{ printf '%s\\n' "$1"; cat; } > "${captureFile}"`,
+      `printf '%s\\n' '${output}'`,
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+  return binary;
+};
+
 describe("pi-harness asuku-notify", () => {
   test("agent_settled feeds a detached notification with the session payload", async () => {
     const home = await makeTempDirectory("pi-asuku-home");
@@ -87,10 +115,291 @@ describe("pi-harness asuku-notify", () => {
     expect(argLine).toBe("notification");
     const payload = JSON.parse(payloadLines.join("\n"));
     expect(payload.hook_event_name).toBe("Notification");
-    expect(payload.session_id).toBe("pi-harness");
+    expect(payload.session_id).toBe("fake-session");
     expect(payload.cwd).toBe(home);
+    expect(payload.title).toBe("pi");
     expect(typeof payload.message).toBe("string");
     expect(payload.message.length).toBeGreaterThan(0);
+  });
+
+  test("routes an allowed confirmation through asuku without opening the TUI dialog", async () => {
+    const home = await makeTempDirectory("pi-asuku-permission-allow");
+    const captureFile = join(home, "permission.txt");
+    const binary = await writePermissionStub(home, captureFile, "allow");
+    const pi = createFakePi({ cwd: home, sessionId: "pi-session-1" });
+    setupAsukuNotify(pi, makeConfig(home), { binaryPath: binary });
+
+    await pi.emitSessionStart({ type: "session_start", reason: "startup" });
+    const accepted = await pi.ctx.ui.confirm(
+      "危険なコマンドを実行しますか？",
+      "confirmation reason\n\nrm -rf build",
+      { timeout: 1_000 },
+    );
+
+    expect(accepted).toBe(true);
+    expect(pi.confirmDialogs).toHaveLength(0);
+    const captured = await fs.readFile(captureFile, "utf8");
+    const [argLine, ...payloadLines] = captured.split("\n");
+    expect(argLine).toBe("permission-request");
+    const payload = JSON.parse(payloadLines.join("\n"));
+    expect(payload.session_id).toBe("pi-session-1");
+    expect(payload.hook_event_name).toBe("PermissionRequest");
+    expect(payload.tool_name).toBe("PiConfirm");
+    expect(payload.tool_input.title).toContain("コマンド");
+    expect(payload.tool_input.message).toContain("rm -rf build");
+  });
+
+  test("routes an asuku denial without falling back to an approving TUI answer", async () => {
+    const home = await makeTempDirectory("pi-asuku-permission-deny");
+    const captureFile = join(home, "permission.txt");
+    const binary = await writePermissionStub(home, captureFile, "deny");
+    const pi = createFakePi({ cwd: home });
+    pi.queueConfirm(true);
+    setupAsukuNotify(pi, makeConfig(home), { binaryPath: binary });
+
+    await pi.emitSessionStart({ type: "session_start", reason: "startup" });
+    const accepted = await pi.ctx.ui.confirm("Permission", "run command", {
+      timeout: 1_000,
+    });
+
+    expect(accepted).toBe(false);
+    expect(pi.confirmDialogs).toHaveLength(0);
+  });
+
+  test("falls back to the original TUI confirmation for malformed asuku output", async () => {
+    const home = await makeTempDirectory("pi-asuku-permission-fallback");
+    const captureFile = join(home, "permission.txt");
+    const binary = await writePermissionStub(home, captureFile, "malformed");
+    const pi = createFakePi({ cwd: home });
+    pi.queueConfirm(true);
+    setupAsukuNotify(pi, makeConfig(home), { binaryPath: binary });
+
+    await pi.emitSessionStart({ type: "session_start", reason: "startup" });
+    const accepted = await pi.ctx.ui.confirm("Permission", "run command", {
+      timeout: 1_000,
+    });
+
+    expect(accepted).toBe(true);
+    expect(pi.confirmDialogs).toHaveLength(1);
+  });
+
+  test("preserves the caller timeout budget when asuku falls back to the TUI", async () => {
+    const home = await makeTempDirectory("pi-asuku-timeout-budget");
+    const binary = join(home, "asuku-hook");
+    await fs.writeFile(binary, "#!/bin/bash\n", { mode: 0o755 });
+    let clock = 1_000;
+    const observedTimeouts: number[] = [];
+    const pi = createFakePi({ cwd: home });
+    pi.queueConfirm(true);
+    setupAsukuNotify(pi, makeConfig(home), {
+      binaryPath: binary,
+      now: () => clock,
+      requestPermission: async (_command, _payload, options) => {
+        observedTimeouts.push(options.timeoutMs);
+        clock = 4_000;
+        return undefined;
+      },
+    });
+
+    await pi.emitSessionStart({ type: "session_start", reason: "startup" });
+    const accepted = await pi.ctx.ui.confirm("Permission", "run command", {
+      timeout: 5_000,
+    });
+
+    expect(accepted).toBe(true);
+    expect(observedTimeouts).toEqual([5_000]);
+    expect(pi.confirmDialogs[0]?.dialogOptions?.timeout).toBe(2_000);
+  });
+
+  test("fails closed instead of reopening the TUI after asuku exhausts the timeout", async () => {
+    const home = await makeTempDirectory("pi-asuku-timeout-exhausted");
+    const binary = join(home, "asuku-hook");
+    await fs.writeFile(binary, "#!/bin/bash\n", { mode: 0o755 });
+    let clock = 1_000;
+    const pi = createFakePi({ cwd: home });
+    pi.queueConfirm(true);
+    setupAsukuNotify(pi, makeConfig(home), {
+      binaryPath: binary,
+      now: () => clock,
+      requestPermission: async () => {
+        clock = 6_000;
+        return undefined;
+      },
+    });
+
+    await pi.emitSessionStart({ type: "session_start", reason: "startup" });
+    const accepted = await pi.ctx.ui.confirm("Permission", "run command", {
+      timeout: 5_000,
+    });
+
+    expect(accepted).toBe(false);
+    expect(pi.confirmDialogs).toHaveLength(0);
+  });
+
+  test("replaces a prior reload wrapper and restores the native confirmation on shutdown", async () => {
+    const home = await makeTempDirectory("pi-asuku-reload");
+    const binary = join(home, "asuku-hook");
+    await fs.writeFile(binary, "#!/bin/bash\n", { mode: 0o755 });
+    let oldRequests = 0;
+    let newRequests = 0;
+    const pi = createFakePi({ cwd: home });
+    setupAsukuNotify(pi, makeConfig(home), {
+      binaryPath: binary,
+      requestPermission: async () => {
+        oldRequests += 1;
+        return false;
+      },
+    });
+    setupAsukuNotify(pi, makeConfig(home), {
+      binaryPath: binary,
+      requestPermission: async () => {
+        newRequests += 1;
+        return true;
+      },
+    });
+
+    await pi.emitSessionStart({ type: "session_start", reason: "reload" });
+    expect(await pi.ctx.ui.confirm("Permission", "run command")).toBe(true);
+    expect(oldRequests).toBe(0);
+    expect(newRequests).toBe(1);
+
+    await pi.emitSessionShutdown();
+    pi.queueConfirm(false);
+    expect(await pi.ctx.ui.confirm("Native", "after shutdown")).toBe(false);
+    expect(newRequests).toBe(1);
+    expect(pi.confirmDialogs).toHaveLength(1);
+  });
+
+  test("a disabled reload removes the prior asuku confirmation wrapper", async () => {
+    const home = await makeTempDirectory("pi-asuku-reload-disabled");
+    const binary = join(home, "asuku-hook");
+    await fs.writeFile(binary, "#!/bin/bash\n", { mode: 0o755 });
+    let requests = 0;
+    const pi = createFakePi({ cwd: home });
+    setupAsukuNotify(pi, makeConfig(home), {
+      binaryPath: binary,
+      requestPermission: async () => {
+        requests += 1;
+        return true;
+      },
+    });
+    setupAsukuNotify(pi, makeConfig(home, false), { binaryPath: binary });
+
+    await pi.emitSessionStart({ type: "session_start", reason: "reload" });
+    pi.queueConfirm(false);
+    expect(await pi.ctx.ui.confirm("Native", "feature disabled")).toBe(false);
+    expect(requests).toBe(0);
+    expect(pi.confirmDialogs).toHaveLength(1);
+  });
+
+  test("adds Codex quota headers and HTTP 429 state to the completion notification", async () => {
+    const home = await makeTempDirectory("pi-asuku-rate-limits");
+    const binary = join(home, "asuku-hook");
+    await fs.writeFile(binary, "#!/bin/bash\n", { mode: 0o755 });
+    const launches: { args: string[]; stdin?: string }[] = [];
+    const spawnDetached: DetachedSpawnFunction = (_command, args, options) => {
+      launches.push({
+        args,
+        ...(options.stdin === undefined ? {} : { stdin: options.stdin }),
+      });
+    };
+    const pi = createFakePi({ cwd: home });
+    setupAsukuNotify(pi, makeConfig(home), {
+      binaryPath: binary,
+      spawnDetached,
+    });
+
+    await pi.emitAfterProviderResponse({
+      type: "after_provider_response",
+      status: 429,
+      headers: {
+        "X-Codex-Primary-Used-Percent": "100",
+        "x-codex-primary-window-minutes": "300",
+        "x-codex-primary-reset-at": "1785465600",
+        "x-codex-secondary-used-percent": "81.25",
+        "x-codex-secondary-window-minutes": "10080",
+      },
+    });
+    await pi.emitAgentSettled();
+
+    expect(launches).toHaveLength(1);
+    expect(launches[0]?.args).toEqual(["notification"]);
+    const payload = JSON.parse(launches[0]?.stdin ?? "{}");
+    expect(payload.message).toContain("Codex rate limited (HTTP 429)");
+    expect(payload.message).toContain("5h 100% used");
+    expect(payload.message).toContain("7d 81.25% used");
+    expect(payload.message).toContain("reset 2026-");
+  });
+
+  test("keeps a headerless Codex HTTP 429 without mislabeling another provider", async () => {
+    expect(settings.transport).toBe("sse");
+    const home = await makeTempDirectory("pi-asuku-headerless-429");
+    const binary = join(home, "asuku-hook");
+    await fs.writeFile(binary, "#!/bin/bash\n", { mode: 0o755 });
+    const payloads: string[] = [];
+    const pi = createFakePi({
+      cwd: home,
+      model: { id: "gpt-test", provider: "openai-codex" },
+    });
+    setupAsukuNotify(pi, makeConfig(home), {
+      binaryPath: binary,
+      spawnDetached: (_command, _args, options) => {
+        if (options.stdin !== undefined) payloads.push(options.stdin);
+      },
+    });
+
+    await pi.emitAfterProviderResponse({
+      type: "after_provider_response",
+      status: 429,
+      headers: { "retry-after": "30" },
+    });
+    await pi.emitAgentSettled();
+    expect(JSON.parse(payloads[0] ?? "{}").message).toContain(
+      "Codex rate limited (HTTP 429)",
+    );
+
+    await pi.emitBeforeAgentStart({
+      type: "before_agent_start",
+      prompt: "other provider",
+    });
+    pi.ctx.model = { id: "claude-test", provider: "anthropic" };
+    await pi.emitAfterProviderResponse({
+      type: "after_provider_response",
+      status: 429,
+      headers: { "retry-after": "30" },
+    });
+    await pi.emitAgentSettled();
+    expect(JSON.parse(payloads[1] ?? "{}").message).not.toContain(
+      "Codex rate limited",
+    );
+  });
+
+  test("clears stale Codex quota details when a new agent turn starts", async () => {
+    const home = await makeTempDirectory("pi-asuku-rate-reset");
+    const binary = join(home, "asuku-hook");
+    await fs.writeFile(binary, "#!/bin/bash\n", { mode: 0o755 });
+    const payloads: string[] = [];
+    const pi = createFakePi({ cwd: home });
+    setupAsukuNotify(pi, makeConfig(home), {
+      binaryPath: binary,
+      spawnDetached: (_command, _args, options) => {
+        if (options.stdin !== undefined) payloads.push(options.stdin);
+      },
+    });
+
+    await pi.emitAfterProviderResponse({
+      type: "after_provider_response",
+      status: 200,
+      headers: { "x-codex-primary-used-percent": "42" },
+    });
+    await pi.emitBeforeAgentStart({
+      type: "before_agent_start",
+      prompt: "next turn",
+    });
+    await pi.emitAgentSettled();
+
+    const payload = JSON.parse(payloads[0] ?? "{}");
+    expect(payload.message).not.toContain("Codex rate limit");
   });
 
   test("a missing binary is silently skipped without launching anything", async () => {


### PR DESCRIPTION
## Summary

- route pi confirmation dialogs through `asuku-hook permission-request`, preserving Allow/Deny and falling back safely to the native TUI
- make the confirmation wrapper reload-safe, restore it on shutdown/disable, and preserve the caller timeout budget
- include Codex 5h/7d usage, reset times, and HTTP 429 state in detached asuku completion notifications
- pin pi to SSE so `after_provider_response` exposes Codex response headers; avoid writing Codex values into asuku’s Claude-only statusline quota field
- document the transport trade-off and add focused regression coverage

## Verification

- `bun run tsc`
- `bun run lint` (0 errors; 9 pre-existing warnings in `pi/extensions/hearth-tools/adapters.ts`)
- `bun run check:pi-imports`
- `bun run check:pi-baseline`
- 38 focused/config/integration tests passed
- 8 settings/scrubber tests passed
- `git diff --check`

## Notes

- the full suite reached 1511 passing tests inside the ordinary OS sandbox, but unrelated loopback-server and nested macOS-sandbox tests failed under that execution envelope; a sandbox-external rerun required separate confirmation and did not execute
- real asuku notification visuals were not smoke-tested; the hook protocol is covered with executable stubs