### PR TITLE
fix(pi): keep native ASK TUI with asuku

### DIFF
--- a/pi/README.md
+++ b/pi/README.md
@@ -389,24 +389,24 @@ typebox baseline + acceptance/rejection through pi's real `validateToolArguments
 
 ## Claude hook lifecycle mapping
 
-| Claude Code                          | pi-harness                                                                    |
-| ------------------------------------ | ----------------------------------------------------------------------------- |
-| PreToolUse (Bash matcher)            | `tool_call` via hook-bridge                                                   |
-| PreToolUse (Workflow matcher)        | `tool_call` — plan serialized into `script` so codex_stage_guard can grep it  |
-| PostToolUse (Write\|Edit\|MultiEdit) | `tool_result` via hook-bridge (trust-gated)                                   |
-| UserPromptSubmit                     | `before_agent_start` message injection                                        |
-| SessionStart / Stop                  | `session_start` / `agent_settled`                                             |
-| Task tool (subagents)                | `subagent` tool (single / parallel / chain)                                   |
-| Workflow tool (ultracode)            | `workflow` tool (declarative JSON plan)                                       |
-| TaskCompleted                        | `task_completed` tool (bit-task, codex-side hook)                             |
-| WorktreeCreate / WorktreeRemove      | `worktree_create` / `worktree_remove` tools                                   |
-| AskUserQuestion                      | exact-name `AskUserQuestion` compatibility tool                               |
-| PermissionRequest (asuku)            | asuku-notify wraps `ui.confirm`; unavailable/invalid bridge falls back to TUI |
-| Notification (asuku)                 | detached `agent_settled`; Codex 5h/7d headers and HTTP 429 join the message   |
-| permissions.deny / auto fallback     | permission-policy rules + local Ollama judge (fail-closed)                    |
-| permission decision corpus           | always-on private versioned JSONL audit (parent + child lineage)              |
-| statusLine                           | statusline feature (Claude-equivalent custom footer)                          |
-| logproxy                             | provider-log feature (opt-in, reduced scope)                                  |
+| Claude Code                          | pi-harness                                                                   |
+| ------------------------------------ | ---------------------------------------------------------------------------- |
+| PreToolUse (Bash matcher)            | `tool_call` via hook-bridge                                                  |
+| PreToolUse (Workflow matcher)        | `tool_call` — plan serialized into `script` so codex_stage_guard can grep it |
+| PostToolUse (Write\|Edit\|MultiEdit) | `tool_result` via hook-bridge (trust-gated)                                  |
+| UserPromptSubmit                     | `before_agent_start` message injection                                       |
+| SessionStart / Stop                  | `session_start` / `agent_settled`                                            |
+| Task tool (subagents)                | `subagent` tool (single / parallel / chain)                                  |
+| Workflow tool (ultracode)            | `workflow` tool (declarative JSON plan)                                      |
+| TaskCompleted                        | `task_completed` tool (bit-task, codex-side hook)                            |
+| WorktreeCreate / WorktreeRemove      | `worktree_create` / `worktree_remove` tools                                  |
+| AskUserQuestion                      | exact-name `AskUserQuestion` compatibility tool                              |
+| PermissionRequest (asuku)            | TUI shows native + asuku; RPC avoids uncancellable duplicate requests        |
+| Notification (asuku)                 | detached `agent_settled`; Codex 5h/7d headers and HTTP 429 join the message  |
+| permissions.deny / auto fallback     | permission-policy rules + local Ollama judge (fail-closed)                   |
+| permission decision corpus           | always-on private versioned JSONL audit (parent + child lineage)             |
+| statusLine                           | statusline feature (Claude-equivalent custom footer)                         |
+| logproxy                             | provider-log feature (opt-in, reduced scope)                                 |
 
 Known gaps vs Claude Code: this is a local effect-sandbox plus local-classifier
 implementation rather than Claude's server-side auto mode; there are no LSP
@@ -574,8 +574,10 @@ extra-usage balance). Records store sha256 + metadata only; log dir
 ## Smoke checklist
 
 Automated coverage lives in `tests/pi-harness/` + `tests/hooks/pi-harness/`
-(`bun test`). The asuku feature tests pin Allow/Deny round-trips, native TUI
-fallback, Codex rate-limit header formatting, and per-turn stale-state reset.
+(`bun test`). The asuku feature tests pin concurrent native TUI + asuku
+Allow/Deny round-trips, first-decision cancellation, native-dialog
+serialization, RPC fallback behavior, Codex rate-limit header formatting, and
+per-turn stale-state reset.
 Codex quota stays in the notification body because asuku's current
 `statusline.rate_limits` field is Claude-specific. `pi/settings.json` pins SSE;
 removing that override restores the WebSocket transport but also removes the

--- a/pi/extensions/pi-harness/features/asuku-notify/index.ts
+++ b/pi/extensions/pi-harness/features/asuku-notify/index.ts
@@ -1,8 +1,8 @@
 /**
  * asuku-notify feature — bridges pi's confirmations and completion state to
- * the asuku desktop app. Permission requests wait for asuku's Allow/Deny
- * response and fall back to pi's original TUI dialog whenever the bridge is
- * unavailable. Completion notifications remain detached and best-effort.
+ * the asuku desktop app. Permission requests keep pi's original TUI dialog
+ * visible while asuku handles the same request; the first explicit decision
+ * wins. Completion notifications remain detached and best-effort.
  */
 import { spawn } from "node:child_process";
 import { constants } from "node:fs";
@@ -76,6 +76,55 @@ interface ConfirmBridgeRegistration {
   bridgedConfirm: ConfirmFunction;
   ctx: CtxLike;
 }
+
+interface ActiveAbortSignal {
+  readonly aborted: boolean;
+  addEventListener(
+    type: "abort",
+    listener: () => void,
+    options?: { once?: boolean },
+  ): void;
+  removeEventListener(type: "abort", listener: () => void): void;
+}
+
+interface AbortControllerLike {
+  readonly signal: ActiveAbortSignal;
+  abort(): void;
+}
+
+const isActiveAbortSignal = (value: unknown): value is ActiveAbortSignal =>
+  typeof value === "object" &&
+  value !== null &&
+  "aborted" in value &&
+  typeof value.aborted === "boolean" &&
+  "addEventListener" in value &&
+  typeof value.addEventListener === "function" &&
+  "removeEventListener" in value &&
+  typeof value.removeEventListener === "function";
+
+const createAbortController = (): AbortControllerLike | undefined => {
+  let value: unknown;
+  try {
+    value = new AbortController();
+  } catch {
+    return undefined;
+  }
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("abort" in value) ||
+    typeof value.abort !== "function" ||
+    !("signal" in value) ||
+    !isActiveAbortSignal(value.signal)
+  ) {
+    return undefined;
+  }
+  const { abort, signal } = value;
+  return {
+    signal,
+    abort: () => Reflect.apply(abort, value, []),
+  };
+};
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
@@ -402,10 +451,12 @@ export default function setupAsukuNotify(
 
     const originalConfirm = ui.confirm;
     let registration: ConfirmBridgeRegistration;
-    const bridgedConfirm: ConfirmFunction = async (
+    let nativeConfirmationQueue = Promise.resolve();
+    const runConfirm = async (
       title: string,
       message: string,
-      dialogOptions?: DialogOptionsLike,
+      dialogOptions: DialogOptionsLike | undefined,
+      startedAt: number,
     ): Promise<boolean> => {
       const activeCtx = registration.ctx;
       if (!activeCtx.hasUI) {
@@ -418,24 +469,31 @@ export default function setupAsukuNotify(
         dialogOptions.timeout > 0
           ? dialogOptions.timeout
           : undefined;
-      const startedAt = now();
       const remainingTimeout = (): number | undefined => {
         if (configuredTimeout === undefined) return undefined;
         return Math.max(0, configuredTimeout - Math.max(0, now() - startedAt));
       };
-      const fallbackToTui = (): Promise<boolean> => {
-        const remaining = remainingTimeout();
-        if (remaining === undefined) {
-          return originalConfirm.call(ui, title, message, dialogOptions);
+      const openNativeConfirm = (
+        options: DialogOptionsLike | undefined,
+      ): Promise<boolean> => {
+        try {
+          return Promise.resolve(
+            originalConfirm.call(ui, title, message, options),
+          ).catch(() => false);
+        } catch {
+          return Promise.resolve(false);
         }
-        if (remaining <= 0) return Promise.resolve(false);
-        return originalConfirm.call(ui, title, message, {
-          ...dialogOptions,
-          timeout: remaining,
-        });
       };
+      const bridgeAvailable = await executable(binary);
+      const remaining = remainingTimeout();
+      const nativeOptions =
+        remaining === undefined
+          ? dialogOptions
+          : { ...dialogOptions, timeout: remaining };
 
-      if (!(await executable(binary))) return fallbackToTui();
+      if (remaining !== undefined && remaining <= 0) return false;
+      if (!bridgeAvailable) return openNativeConfirm(nativeOptions);
+
       const cwd = activeCtx.cwd ?? process.cwd();
       const payload: AsukuPermissionPayload = {
         session_id: sessionId(activeCtx),
@@ -445,21 +503,90 @@ export default function setupAsukuNotify(
         cwd,
         permission_mode: "default",
       };
-      const bridgeTimeout = remainingTimeout() ?? DEFAULT_PERMISSION_TIMEOUT_MS;
-      if (bridgeTimeout <= 0) return false;
-      let decision: boolean | undefined;
-      try {
-        decision = await requestPermission(binary, payload, {
-          cwd,
-          ...(dialogOptions?.signal === undefined
-            ? {}
-            : { signal: dialogOptions.signal }),
-          timeoutMs: bridgeTimeout,
-        });
-      } catch {
-        return fallbackToTui();
+      const bridgeTimeout = remaining ?? DEFAULT_PERMISSION_TIMEOUT_MS;
+      const callerSignal = isActiveAbortSignal(dialogOptions?.signal)
+        ? dialogOptions.signal
+        : undefined;
+      if (callerSignal?.aborted === true) return false;
+
+      // RPC clients have no cancellation event for an extension_ui_request.
+      // Keep the native/asuku race TUI-only so an asuku-first decision cannot
+      // leave a stale confirmation visible in an RPC client.
+      if (activeCtx.mode !== "tui") {
+        try {
+          const decision = await requestPermission(binary, payload, {
+            cwd,
+            ...(callerSignal === undefined ? {} : { signal: callerSignal }),
+            timeoutMs: bridgeTimeout,
+          });
+          return decision ?? openNativeConfirm(nativeOptions);
+        } catch {
+          return openNativeConfirm(nativeOptions);
+        }
       }
-      return decision ?? fallbackToTui();
+
+      const bridgeAbort = createAbortController();
+      if (bridgeAbort === undefined) return openNativeConfirm(nativeOptions);
+
+      let callerAbortListener: (() => void) | undefined;
+      const noDecision = new Promise<boolean>(() => {});
+      const callerAbortDecision =
+        callerSignal === undefined
+          ? noDecision
+          : new Promise<boolean>((resolve) => {
+              callerAbortListener = () => {
+                bridgeAbort.abort();
+                resolve(false);
+              };
+              callerSignal.addEventListener("abort", callerAbortListener, {
+                once: true,
+              });
+            });
+      const sharedDialogOptions: DialogOptionsLike = {
+        ...nativeOptions,
+        signal: bridgeAbort.signal,
+      };
+      const asukuDecision = (async (): Promise<boolean> => {
+        try {
+          const decision = await requestPermission(binary, payload, {
+            cwd,
+            signal: bridgeAbort.signal,
+            timeoutMs: bridgeTimeout,
+          });
+          return decision ?? noDecision;
+        } catch {
+          return noDecision;
+        }
+      })();
+      const nativeDecision = openNativeConfirm(sharedDialogOptions);
+
+      try {
+        return await Promise.race([
+          nativeDecision,
+          asukuDecision,
+          callerAbortDecision,
+        ]);
+      } finally {
+        bridgeAbort.abort();
+        if (callerSignal !== undefined && callerAbortListener !== undefined) {
+          callerSignal.removeEventListener("abort", callerAbortListener);
+        }
+      }
+    };
+    const bridgedConfirm: ConfirmFunction = (title, message, dialogOptions) => {
+      const startedAt = now();
+      if (registration.ctx.mode !== "tui") {
+        return runConfirm(title, message, dialogOptions, startedAt);
+      }
+
+      const result = nativeConfirmationQueue.then(() =>
+        runConfirm(title, message, dialogOptions, startedAt),
+      );
+      nativeConfirmationQueue = result.then(
+        () => undefined,
+        () => undefined,
+      );
+      return result;
     };
     registration = {
       owner,

--- a/tests/pi-harness/asuku-notify.test.ts
+++ b/tests/pi-harness/asuku-notify.test.ts
@@ -3,7 +3,9 @@ import { promises as fs } from "node:fs";
 import { join } from "node:path";
 import settings from "../../pi/settings.json";
 import type { HarnessConfig } from "../../pi/extensions/pi-harness/config";
-import setupAsukuNotify from "../../pi/extensions/pi-harness/features/asuku-notify/index";
+import setupAsukuNotify, {
+  runPermissionRequest,
+} from "../../pi/extensions/pi-harness/features/asuku-notify/index";
 import type { DetachedSpawnFunction } from "../../pi/extensions/pi-harness/lib/detached";
 import { resolvePaths } from "../../pi/extensions/pi-harness/lib/paths";
 import { cleanupTestDirectory, setupTestDirectory } from "../test-helpers";
@@ -122,12 +124,20 @@ describe("pi-harness asuku-notify", () => {
     expect(payload.message.length).toBeGreaterThan(0);
   });
 
-  test("routes an allowed confirmation through asuku without opening the TUI dialog", async () => {
+  test("shows the native TUI while asuku can allow the request", async () => {
     const home = await makeTempDirectory("pi-asuku-permission-allow");
-    const captureFile = join(home, "permission.txt");
-    const binary = await writePermissionStub(home, captureFile, "allow");
+    const binary = join(home, "asuku-hook");
+    await fs.writeFile(binary, "#!/bin/bash\n", { mode: 0o755 });
+    const capturedPayloads: string[] = [];
     const pi = createFakePi({ cwd: home, sessionId: "pi-session-1" });
-    setupAsukuNotify(pi, makeConfig(home), { binaryPath: binary });
+    pi.queueConfirmUntilAborted();
+    setupAsukuNotify(pi, makeConfig(home), {
+      binaryPath: binary,
+      requestPermission: async (_command, payload) => {
+        capturedPayloads.push(JSON.stringify(payload));
+        return true;
+      },
+    });
 
     await pi.emitSessionStart({ type: "session_start", reason: "startup" });
     const accepted = await pi.ctx.ui.confirm(
@@ -137,11 +147,8 @@ describe("pi-harness asuku-notify", () => {
     );
 
     expect(accepted).toBe(true);
-    expect(pi.confirmDialogs).toHaveLength(0);
-    const captured = await fs.readFile(captureFile, "utf8");
-    const [argLine, ...payloadLines] = captured.split("\n");
-    expect(argLine).toBe("permission-request");
-    const payload = JSON.parse(payloadLines.join("\n"));
+    expect(pi.confirmDialogs).toHaveLength(1);
+    const payload = JSON.parse(capturedPayloads[0] ?? "{}");
     expect(payload.session_id).toBe("pi-session-1");
     expect(payload.hook_event_name).toBe("PermissionRequest");
     expect(payload.tool_name).toBe("PiConfirm");
@@ -149,13 +156,16 @@ describe("pi-harness asuku-notify", () => {
     expect(payload.tool_input.message).toContain("rm -rf build");
   });
 
-  test("routes an asuku denial without falling back to an approving TUI answer", async () => {
+  test("shows the native TUI while asuku can deny the request", async () => {
     const home = await makeTempDirectory("pi-asuku-permission-deny");
-    const captureFile = join(home, "permission.txt");
-    const binary = await writePermissionStub(home, captureFile, "deny");
+    const binary = join(home, "asuku-hook");
+    await fs.writeFile(binary, "#!/bin/bash\n", { mode: 0o755 });
     const pi = createFakePi({ cwd: home });
-    pi.queueConfirm(true);
-    setupAsukuNotify(pi, makeConfig(home), { binaryPath: binary });
+    pi.queueConfirmUntilAborted();
+    setupAsukuNotify(pi, makeConfig(home), {
+      binaryPath: binary,
+      requestPermission: async () => false,
+    });
 
     await pi.emitSessionStart({ type: "session_start", reason: "startup" });
     const accepted = await pi.ctx.ui.confirm("Permission", "run command", {
@@ -163,27 +173,91 @@ describe("pi-harness asuku-notify", () => {
     });
 
     expect(accepted).toBe(false);
+    expect(pi.confirmDialogs).toHaveLength(1);
+  });
+
+  test("does not leave a stale native request when asuku decides in RPC mode", async () => {
+    const home = await makeTempDirectory("pi-asuku-rpc");
+    const binary = join(home, "asuku-hook");
+    await fs.writeFile(binary, "#!/bin/bash\n", { mode: 0o755 });
+    const pi = createFakePi({ cwd: home, mode: "rpc" });
+    setupAsukuNotify(pi, makeConfig(home), {
+      binaryPath: binary,
+      requestPermission: async () => true,
+    });
+
+    await pi.emitSessionStart({ type: "session_start", reason: "startup" });
+    expect(await pi.ctx.ui.confirm("Permission", "run command")).toBe(true);
     expect(pi.confirmDialogs).toHaveLength(0);
   });
 
-  test("falls back to the original TUI confirmation for malformed asuku output", async () => {
+  test("serializes native TUI confirmations while preserving each result", async () => {
+    const home = await makeTempDirectory("pi-asuku-native-queue");
+    const binary = join(home, "asuku-hook");
+    await fs.writeFile(binary, "#!/bin/bash\n", { mode: 0o755 });
+    const pi = createFakePi({ cwd: home });
+    const openedTitles: string[] = [];
+    const nativeResolvers: ((accepted: boolean) => void)[] = [];
+    pi.ctx.ui.confirm = async (title) => {
+      openedTitles.push(title);
+      return new Promise<boolean>((resolve) => nativeResolvers.push(resolve));
+    };
+    setupAsukuNotify(pi, makeConfig(home), {
+      binaryPath: binary,
+      requestPermission: async () => undefined,
+    });
+
+    await pi.emitSessionStart({ type: "session_start", reason: "startup" });
+    const first = pi.ctx.ui.confirm("First", "first command");
+    const second = pi.ctx.ui.confirm("Second", "second command");
+    await waitFor(async () => openedTitles.length === 1);
+    expect(openedTitles).toEqual(["First"]);
+
+    nativeResolvers[0]?.(true);
+    expect(await first).toBe(true);
+    await waitFor(async () => openedTitles.length === 2);
+    expect(openedTitles).toEqual(["First", "Second"]);
+
+    nativeResolvers[1]?.(false);
+    expect(await second).toBe(false);
+  });
+
+  test("keeps the native confirmation open for malformed asuku output", async () => {
     const home = await makeTempDirectory("pi-asuku-permission-fallback");
     const captureFile = join(home, "permission.txt");
     const binary = await writePermissionStub(home, captureFile, "malformed");
     const pi = createFakePi({ cwd: home });
-    pi.queueConfirm(true);
-    setupAsukuNotify(pi, makeConfig(home), { binaryPath: binary });
-
-    await pi.emitSessionStart({ type: "session_start", reason: "startup" });
-    const accepted = await pi.ctx.ui.confirm("Permission", "run command", {
-      timeout: 1_000,
+    let nativeOpened = false;
+    let bridgeSettled = false;
+    let resolveNative: ((accepted: boolean) => void) | undefined;
+    pi.ctx.ui.confirm = async () => {
+      nativeOpened = true;
+      return new Promise<boolean>((resolve) => {
+        resolveNative = resolve;
+      });
+    };
+    setupAsukuNotify(pi, makeConfig(home), {
+      binaryPath: binary,
+      requestPermission: async (command, payload, options) => {
+        const decision = await runPermissionRequest(command, payload, options);
+        bridgeSettled = true;
+        return decision;
+      },
     });
 
-    expect(accepted).toBe(true);
-    expect(pi.confirmDialogs).toHaveLength(1);
+    await pi.emitSessionStart({ type: "session_start", reason: "startup" });
+    const accepted = pi.ctx.ui.confirm("Permission", "run command", {
+      timeout: 1_000,
+    });
+    await waitFor(async () => nativeOpened && bridgeSettled);
+    resolveNative?.(true);
+
+    expect(await accepted).toBe(true);
+    expect(nativeOpened).toBe(true);
+    expect(bridgeSettled).toBe(true);
   });
 
-  test("preserves the caller timeout budget when asuku falls back to the TUI", async () => {
+  test("gives asuku and the native TUI the same remaining timeout budget", async () => {
     const home = await makeTempDirectory("pi-asuku-timeout-budget");
     const binary = join(home, "asuku-hook");
     await fs.writeFile(binary, "#!/bin/bash\n", { mode: 0o755 });
@@ -208,23 +282,35 @@ describe("pi-harness asuku-notify", () => {
 
     expect(accepted).toBe(true);
     expect(observedTimeouts).toEqual([5_000]);
-    expect(pi.confirmDialogs[0]?.dialogOptions?.timeout).toBe(2_000);
+    expect(pi.confirmDialogs[0]?.dialogOptions?.timeout).toBe(5_000);
   });
 
-  test("fails closed instead of reopening the TUI after asuku exhausts the timeout", async () => {
-    const home = await makeTempDirectory("pi-asuku-timeout-exhausted");
+  test("aborts a pending asuku request when the native TUI decides first", async () => {
+    const home = await makeTempDirectory("pi-asuku-native-first");
     const binary = join(home, "asuku-hook");
     await fs.writeFile(binary, "#!/bin/bash\n", { mode: 0o755 });
-    let clock = 1_000;
+    let requestAborted = false;
     const pi = createFakePi({ cwd: home });
     pi.queueConfirm(true);
     setupAsukuNotify(pi, makeConfig(home), {
       binaryPath: binary,
-      now: () => clock,
-      requestPermission: async () => {
-        clock = 6_000;
-        return undefined;
-      },
+      requestPermission: async (_command, _payload, options) =>
+        new Promise<boolean | undefined>((resolve) => {
+          if (
+            options.signal !== undefined &&
+            "addEventListener" in options.signal &&
+            typeof options.signal.addEventListener === "function"
+          ) {
+            options.signal.addEventListener(
+              "abort",
+              () => {
+                requestAborted = true;
+                resolve(undefined);
+              },
+              { once: true },
+            );
+          }
+        }),
     });
 
     await pi.emitSessionStart({ type: "session_start", reason: "startup" });
@@ -232,8 +318,9 @@ describe("pi-harness asuku-notify", () => {
       timeout: 5_000,
     });
 
-    expect(accepted).toBe(false);
-    expect(pi.confirmDialogs).toHaveLength(0);
+    expect(accepted).toBe(true);
+    expect(pi.confirmDialogs).toHaveLength(1);
+    expect(requestAborted).toBe(true);
   });
 
   test("replaces a prior reload wrapper and restores the native confirmation on shutdown", async () => {
@@ -267,7 +354,7 @@ describe("pi-harness asuku-notify", () => {
     pi.queueConfirm(false);
     expect(await pi.ctx.ui.confirm("Native", "after shutdown")).toBe(false);
     expect(newRequests).toBe(1);
-    expect(pi.confirmDialogs).toHaveLength(1);
+    expect(pi.confirmDialogs).toHaveLength(2);
   });
 
   test("a disabled reload removes the prior asuku confirmation wrapper", async () => {


### PR DESCRIPTION
## Summary

- show pi native ASK confirmation and asuku permission request concurrently in TUI mode, using the first decision
- serialize native confirmations and cancel the losing request to avoid overlapping dialogs
- keep RPC mode free of stale uncancellable confirmation requests, falling back to native RPC confirmation only when asuku cannot decide
- add regression coverage and update the pi-harness documentation

## Verification

- `bun test tests/pi-harness/asuku-notify.test.ts` — 15 passed
- `bun run tsc` — passed
- `bun run lint` — 0 errors; 9 pre-existing warnings in `pi/extensions/hearth-tools/adapters.ts`
- full `bun test` attempted — 1,520 passed; environment-dependent local-server and nested-sandbox tests failed under the execution sandbox (`EADDRINUSE` / sandbox initialization)