### PR TITLE
feat(pi): expand sandbox mechanical allows

### DIFF
--- a/pi/extensions/pi-harness/features/bash-sandbox/index.ts
+++ b/pi/extensions/pi-harness/features/bash-sandbox/index.ts
@@ -57,6 +57,8 @@ export interface BashExecutionBoundary {
   readonly mode: "sandboxed" | "escalated";
   readonly network: "denied" | "allowlisted" | "unavailable";
   readonly profileFingerprint: string;
+  readonly writableWorktrees?: readonly string[];
+  readonly worktreeCreateRoots?: readonly string[];
 }
 
 export interface BashScratchBoundary {
@@ -156,6 +158,7 @@ export const setupBashSandbox = (
   let state: BashSandboxState = { kind: "stopped" };
   let sessionGeneration = 0;
   const dynamicWritableWorktrees = new Set<string>();
+  const dynamicallyAddedWritableRoots = new Set<string>();
   const approvedHosts = new Set<string>();
   const deniedHosts = new Set<string>();
   let backendAttached = false;
@@ -231,6 +234,7 @@ export const setupBashSandbox = (
     sessionGeneration += 1;
     sessionCwd = ctx.cwd ?? cwd;
     dynamicWritableWorktrees.clear();
+    dynamicallyAddedWritableRoots.clear();
     approvedHosts.clear();
     deniedHosts.clear();
     state = { kind: "starting" };
@@ -385,7 +389,12 @@ export const setupBashSandbox = (
         throw new Error("bash sandbox is not ready for worktree registration");
       }
       const canonicalPath = boundary.canonicalCwd;
-      if (current.profile.writableRoots.includes(canonicalPath)) return;
+      if (current.profile.writableRoots.includes(canonicalPath)) {
+        if (canonicalPath !== current.profile.activeWorktree) {
+          dynamicWritableWorktrees.add(canonicalPath);
+        }
+        return;
+      }
 
       const profile = withBashSandboxWritableRoots(current.profile, [
         ...current.profile.writableRoots,
@@ -393,6 +402,7 @@ export const setupBashSandbox = (
       ]);
       current.manager.updateConfig(profile.runtimeConfig);
       dynamicWritableWorktrees.add(canonicalPath);
+      dynamicallyAddedWritableRoots.add(canonicalPath);
       state = { ...current, profile };
     },
     async revokeWritableWorktree(path) {
@@ -405,12 +415,13 @@ export const setupBashSandbox = (
       ) {
         throw new Error("bash sandbox is not ready for worktree revocation");
       }
+      dynamicWritableWorktrees.delete(path);
+      if (!dynamicallyAddedWritableRoots.delete(path)) return;
       const profile = withBashSandboxWritableRoots(
         current.profile,
         current.profile.writableRoots.filter((root) => root !== path),
       );
       current.manager.updateConfig(profile.runtimeConfig);
-      dynamicWritableWorktrees.delete(path);
       state = { ...current, profile };
     },
     boundaryFor(toolName) {
@@ -422,6 +433,17 @@ export const setupBashSandbox = (
         mode: toolName === "bash" ? "sandboxed" : "escalated",
         network: networkMode(),
         profileFingerprint: profile?.fingerprint ?? "unavailable",
+        ...(toolName !== "bash" || profile === undefined
+          ? {}
+          : {
+              writableWorktrees: [
+                ...(profile.activeWorktree === undefined
+                  ? []
+                  : [profile.activeWorktree]),
+                ...dynamicWritableWorktrees,
+              ],
+              worktreeCreateRoots: profile.configuredWriteRoots,
+            }),
       };
     },
     registerExecutionBoundary({ blockToolCall, permissionAudit }) {

--- a/pi/extensions/pi-harness/features/bash-sandbox/profile.ts
+++ b/pi/extensions/pi-harness/features/bash-sandbox/profile.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { realpath } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
 import type { BashSandboxConfig } from "../../config";
 import {
@@ -13,7 +13,9 @@ export const BASH_SANDBOX_PROJECT_DISCOVERY_TIMEOUT_MS = 5_000;
 
 export interface BashSandboxProfile {
   readonly cwd: string;
+  readonly activeWorktree?: string;
   readonly writableRoots: readonly string[];
+  readonly configuredWriteRoots: readonly string[];
   readonly scratchDirectory: string;
   readonly networkMode: "denied" | "allowlisted";
   readonly fingerprint: string;
@@ -33,6 +35,27 @@ const expandHome = (path: string, home: string): string => {
 };
 
 const unique = (values: readonly string[]): string[] => [...new Set(values)];
+
+const canonicalizeWithMissingTail = async (
+  path: string,
+  canonicalize: (path: string) => Promise<string>,
+): Promise<string> => {
+  let current = resolve(path);
+  const missingTail: string[] = [];
+  while (true) {
+    try {
+      return resolve(await canonicalize(current), ...missingTail);
+    } catch (error) {
+      const { code } = error as NodeJS.ErrnoException;
+      const parent = dirname(current);
+      if ((code !== "ENOENT" && code !== "ENOTDIR") || parent === current) {
+        throw error;
+      }
+      missingTail.unshift(basename(current));
+      current = parent;
+    }
+  }
+};
 
 const profileFingerprint = (runtimeConfig: SandboxRuntimeConfig): string =>
   createHash("sha256")
@@ -98,8 +121,10 @@ export const buildBashSandboxProfile = async (
   }
 
   const home = options.home ?? homedir();
-  const configuredWriteRoots = config.filesystem.allowWrite.map((path) =>
-    expandHome(path, home),
+  const configuredWriteRoots = await Promise.all(
+    config.filesystem.allowWrite.map((path) =>
+      canonicalizeWithMissingTail(expandHome(path, home), canonicalize),
+    ),
   );
   const writableRoots = unique([
     ...projectRoots,
@@ -135,7 +160,11 @@ export const buildBashSandboxProfile = async (
 
   return {
     cwd: canonicalCwd,
+    ...(project.kind === "git"
+      ? { activeWorktree: project.activeWorktree }
+      : {}),
     writableRoots,
+    configuredWriteRoots,
     scratchDirectory,
     networkMode:
       config.network.allowedDomains.length === 0 ? "denied" : "allowlisted",

--- a/pi/extensions/pi-harness/features/bash-sandbox/runtime.ts
+++ b/pi/extensions/pi-harness/features/bash-sandbox/runtime.ts
@@ -39,6 +39,8 @@ export const buildControlledBashEnv = (
       ? "/usr/bin:/bin:/usr/sbin:/sbin"
       : sanitized.PATH;
   env.SHELL = CONTROLLED_BASH_PATH;
+  // Read-only Git commands must not refresh sibling-worktree indexes.
+  env.GIT_OPTIONAL_LOCKS = "0";
   env.TMPDIR = scratchDirectory;
   env.TMP = scratchDirectory;
   env.TEMP = scratchDirectory;

--- a/pi/extensions/pi-harness/features/permission-policy/index.ts
+++ b/pi/extensions/pi-harness/features/permission-policy/index.ts
@@ -559,6 +559,16 @@ const setupPermissionPolicy = (
     const effectSandboxed = executionBoundary?.mode === "sandboxed";
     const isEscalated = executionBoundary?.mode === "escalated";
     const evaluationRules = isEscalated ? { ...rules, allow: [] } : rules;
+    const sandboxEvaluationOptions = {
+      effectSandboxed,
+      ...(effectSandboxed && executionBoundary?.writableWorktrees !== undefined
+        ? { trustedWritableWorktrees: executionBoundary.writableWorktrees }
+        : {}),
+      ...(effectSandboxed &&
+      executionBoundary?.worktreeCreateRoots !== undefined
+        ? { trustedWorktreeCreateRoots: executionBoundary.worktreeCreateRoots }
+        : {}),
+    };
 
     try {
       const { input } = event;
@@ -594,7 +604,7 @@ const setupPermissionPolicy = (
         command,
         evaluationRules,
         isEscalated ? [] : activeSkillBashAllows,
-        { effectSandboxed },
+        sandboxEvaluationOptions,
       );
       recordDeterministic(event.toolCallId, "initial", result);
       if (result.verdict === "allow" && result.grantedBySkill === true) {
@@ -603,9 +613,11 @@ const setupPermissionPolicy = (
           gitCwd === undefined ||
           (gitCwd !== null && ctx.cwd === undefined)
         ) {
-          result = evaluateCommandWithAudit(command, evaluationRules, {
-            effectSandboxed,
-          });
+          result = evaluateCommandWithAudit(
+            command,
+            evaluationRules,
+            sandboxEvaluationOptions,
+          );
           recordDeterministic(event.toolCallId, "skill-fallback", result);
         } else if (gitCwd !== null && ctx.cwd !== undefined) {
           const candidate = resolve(ctx.cwd, gitCwd);
@@ -620,9 +632,11 @@ const setupPermissionPolicy = (
             projectDiscovery.leadingNavigation?.scope !== "listed-worktree" ||
             !projectDiscovery.leadingNavigation.sameRepository
           ) {
-            result = evaluateCommandWithAudit(command, evaluationRules, {
-              effectSandboxed,
-            });
+            result = evaluateCommandWithAudit(
+              command,
+              evaluationRules,
+              sandboxEvaluationOptions,
+            );
             recordDeterministic(event.toolCallId, "skill-fallback", result);
           }
         }
@@ -776,8 +790,16 @@ const setupPermissionPolicy = (
             });
             trustedGitReadCwdTarget = readCwdTarget;
             result = evaluateCommandWithAudit(command, evaluationRules, {
-              effectSandboxed,
+              ...sandboxEvaluationOptions,
               trustedGitCwdTarget: readCwdTarget,
+              ...(projectDiscovery.kind !== "git"
+                ? {}
+                : {
+                    trustedReadContext: {
+                      cwd: projectDiscovery.cwd,
+                      navigableRoots: projectDiscovery.navigableRoots,
+                    },
+                  }),
             });
             recordDeterministic(event.toolCallId, "verified-git-c", result);
           }
@@ -959,7 +981,7 @@ const setupPermissionPolicy = (
         trustedReadContext !== undefined
       ) {
         result = evaluateCommandWithAudit(command, evaluationRules, {
-          effectSandboxed,
+          ...sandboxEvaluationOptions,
           ...(trustedLeadingCdTarget === undefined
             ? {}
             : { trustedLeadingCdTarget }),

--- a/pi/extensions/pi-harness/features/permission-policy/rules.ts
+++ b/pi/extensions/pi-harness/features/permission-policy/rules.ts
@@ -56,6 +56,8 @@ export type PermissionVerdictBasis =
   | "configured-ask"
   | "speculative-ask"
   | "builtin-read-allow"
+  | "sandbox-git-allow"
+  | "sandbox-read-allow"
   | "sandbox-residual"
   | "default-continue"
   | "combined-allow"
@@ -98,6 +100,10 @@ interface EvaluationOptions {
   readonly trustedLeadingCdTarget?: string;
   /** Literal git -C target verified as a same-repository listed worktree path. */
   readonly trustedGitCwdTarget?: string;
+  /** Canonical worktree roots writable in the active sandbox profile. */
+  readonly trustedWritableWorktrees?: readonly string[];
+  /** Canonical configured roots that may contain a newly created worktree. */
+  readonly trustedWorktreeCreateRoots?: readonly string[];
   /** Filesystem-verified scope used only by narrow mechanical read allows. */
   readonly trustedReadContext?: TrustedReadContext;
 }
@@ -490,11 +496,28 @@ const abbreviatesLongOption = (
   return name !== "" && options.some((option) => option.startsWith(name));
 };
 
+const STANDARD_GIT_URL_SCHEMES: ReadonlySet<string> = new Set([
+  "file",
+  "ftp",
+  "ftps",
+  "git",
+  "http",
+  "https",
+  "git+ssh",
+  "ssh",
+  "ssh+git",
+]);
+
+const gitUrlScheme = (word: string): string | undefined =>
+  /^([A-Za-z][A-Za-z0-9+.-]*):\/\//.exec(word)?.[1]?.toLowerCase();
+
 const remoteHelperExec = (word: string): boolean => {
   const repository = word.startsWith("--repo=")
     ? word.slice("--repo=".length)
     : word;
-  return /^[A-Za-z0-9][A-Za-z0-9+.-]*::/.test(repository);
+  if (/^[A-Za-z0-9][A-Za-z0-9+.-]*::/.test(repository)) return true;
+  const scheme = gitUrlScheme(repository);
+  return scheme !== undefined && !STANDARD_GIT_URL_SCHEMES.has(scheme);
 };
 
 const clusteredPushRisk = (
@@ -545,6 +568,352 @@ const gitPushRisk = (rest: readonly string[]): string | undefined => {
   return undefined;
 };
 
+const FORCE_FETCH_LONG_OPTIONS = ["force"] as const;
+const HELPER_FETCH_LONG_OPTIONS = ["server-option", "upload-pack"] as const;
+const DYNAMIC_FETCH_LONG_OPTIONS = ["refmap", "stdin"] as const;
+const DESTRUCTIVE_FETCH_LONG_OPTIONS = [
+  "prune",
+  "prune-tags",
+  "update-head-ok",
+] as const;
+
+type FetchRisk = "destructive" | "force" | "helper";
+
+const clusteredFetchRisk = (word: string): FetchRisk | undefined => {
+  if (!/^-[^-]/.test(word)) return undefined;
+  for (const option of word.slice(1)) {
+    if (option === "f") return "force";
+    if (option === "o") return "helper";
+    if (option === "p" || option === "P" || option === "u") {
+      return "destructive";
+    }
+    // -j consumes the remainder as its jobs value.
+    if (option === "j") return undefined;
+  }
+  return undefined;
+};
+
+const FETCH_LONG_OPTIONS_WITH_VALUE = [
+  "deepen",
+  "depth",
+  "filter",
+  "jobs",
+  "negotiation-tip",
+  "refmap",
+  "server-option",
+  "shallow-exclude",
+  "shallow-since",
+  "submodule-prefix",
+  "upload-pack",
+] as const;
+const FETCH_SHORT_OPTIONS_WITH_VALUE: ReadonlySet<string> = new Set(["j", "o"]);
+
+const shortOptionConsumesNext = (
+  word: string,
+  optionsWithValue: ReadonlySet<string>,
+): boolean => {
+  if (!/^-[^-]/.test(word)) return false;
+  for (let index = 1; index < word.length; index += 1) {
+    if (optionsWithValue.has(word[index] ?? "")) {
+      return index === word.length - 1;
+    }
+  }
+  return false;
+};
+
+const gitFetchRisk = (rest: readonly string[]): string | undefined => {
+  let parsingOptions = true;
+  let multipleRepositories = false;
+  let positionalCount = 0;
+  for (let index = 0; index < rest.length; index += 1) {
+    const word = rest[index];
+    if (word === undefined) break;
+    if (word === "--" && parsingOptions) {
+      parsingOptions = false;
+      continue;
+    }
+    const shortRisk = parsingOptions ? clusteredFetchRisk(word) : undefined;
+    if (
+      (parsingOptions &&
+        abbreviatesLongOption(word, FORCE_FETCH_LONG_OPTIONS)) ||
+      shortRisk === "force"
+    ) {
+      return "強制 git fetch には確認が必要です";
+    }
+    if (
+      (parsingOptions &&
+        abbreviatesLongOption(word, HELPER_FETCH_LONG_OPTIONS)) ||
+      shortRisk === "helper"
+    ) {
+      return "外部helperまたはtransport overrideを使う git fetch には確認が必要です";
+    }
+    if (
+      parsingOptions &&
+      abbreviatesLongOption(word, DYNAMIC_FETCH_LONG_OPTIONS)
+    ) {
+      return "動的なrefspecを使う git fetch には確認が必要です";
+    }
+    if (
+      (parsingOptions &&
+        abbreviatesLongOption(word, DESTRUCTIVE_FETCH_LONG_OPTIONS)) ||
+      shortRisk === "destructive"
+    ) {
+      return "refを削除・直接更新する git fetch には確認が必要です";
+    }
+    if (parsingOptions && abbreviatesLongOption(word, ["multiple"])) {
+      multipleRepositories = true;
+    }
+    if (
+      parsingOptions &&
+      !word.includes("=") &&
+      (abbreviatesLongOption(word, FETCH_LONG_OPTIONS_WITH_VALUE) ||
+        shortOptionConsumesNext(word, FETCH_SHORT_OPTIONS_WITH_VALUE))
+    ) {
+      index += 1;
+      continue;
+    }
+    if (parsingOptions && word.startsWith("-")) continue;
+
+    const isRepository = multipleRepositories || positionalCount === 0;
+    positionalCount += 1;
+    if (isRepository) {
+      if (remoteHelperExec(word)) {
+        return "外部helperまたはtransport overrideを使う git fetch には確認が必要です";
+      }
+      continue;
+    }
+    if (word.startsWith("+")) {
+      return "強制 git fetch には確認が必要です";
+    }
+    if (word.includes(":")) {
+      return "refを削除・直接更新する git fetch には確認が必要です";
+    }
+  }
+  return undefined;
+};
+
+const clusteredSwitchRisk = (
+  word: string,
+  subcommand: "checkout" | "switch",
+): boolean => {
+  if (!/^-[^-]/.test(word)) return false;
+  for (const option of word.slice(1)) {
+    if (option === "f" || option === "m") return true;
+    if (subcommand === "switch") {
+      if (option === "C") return true;
+      // -c consumes the remainder as the new branch name.
+      if (option === "c") return false;
+    } else {
+      if (option === "B") return true;
+      // -b consumes the remainder as the new branch name.
+      if (option === "b") return false;
+    }
+  }
+  return false;
+};
+
+const gitSwitchRisk = (
+  subcommand: "checkout" | "switch",
+  rest: readonly string[],
+): string | undefined => {
+  const destructiveLongOptions = [
+    "conflict",
+    "discard-changes",
+    "force",
+    "force-create",
+    "ignore-other-worktrees",
+    "merge",
+    "orphan",
+  ] as const;
+  for (const word of rest) {
+    if (word === "--") return undefined;
+    if (
+      abbreviatesLongOption(word, destructiveLongOptions) ||
+      clusteredSwitchRisk(word, subcommand)
+    ) {
+      return `git ${subcommand} による変更破棄・branch強制更新には確認が必要です`;
+    }
+  }
+  return undefined;
+};
+
+const COMMIT_LONG_OPTIONS_WITH_VALUE = [
+  "author",
+  "cleanup",
+  "date",
+  "file",
+  "fixup",
+  "message",
+  "reedit-message",
+  "reuse-message",
+  "squash",
+  "template",
+  "trailer",
+] as const;
+const COMMIT_SHORT_OPTIONS_WITH_VALUE: ReadonlySet<string> = new Set([
+  "C",
+  "F",
+  "c",
+  "m",
+  "t",
+]);
+const LOG_SHOW_LONG_OPTIONS_WITH_VALUE = [
+  "after",
+  "anchored",
+  "author",
+  "before",
+  "committer",
+  "date",
+  "decorate-refs",
+  "decorate-refs-exclude",
+  "diff-algorithm",
+  "diff-filter",
+  "dst-prefix",
+  "encoding",
+  "exclude",
+  "exclude-hidden",
+  "find-object",
+  "glob",
+  "grep",
+  "grep-reflog",
+  "ignore-matching-lines",
+  "inter-hunk-context",
+  "line-prefix",
+  "max-count",
+  "max-parents",
+  "min-parents",
+  "output",
+  "output-indicator-context",
+  "output-indicator-new",
+  "output-indicator-old",
+  "rotate-to",
+  "since",
+  "since-as-filter",
+  "skip",
+  "skip-to",
+  "src-prefix",
+  "stat-count",
+  "stat-name-width",
+  "stat-width",
+  "until",
+  "word-diff-regex",
+  "ws-error-highlight",
+] as const;
+const LOG_SHOW_SHORT_OPTIONS_WITH_VALUE: ReadonlySet<string> = new Set([
+  "G",
+  "L",
+  "O",
+  "S",
+  "U",
+  "l",
+  "n",
+]);
+const MERGE_LONG_OPTIONS_WITH_VALUE = [
+  "cleanup",
+  "file",
+  "into-name",
+  "message",
+  "strategy",
+  "strategy-option",
+] as const;
+const MERGE_SHORT_OPTIONS_WITH_VALUE: ReadonlySet<string> = new Set([
+  "F",
+  "X",
+  "m",
+  "s",
+]);
+
+const gitCommitRisk = (rest: readonly string[]): string | undefined => {
+  let parsingOptions = true;
+  for (let index = 0; index < rest.length; index += 1) {
+    const word = rest[index];
+    if (word === undefined) break;
+    if (word === "--" && parsingOptions) {
+      parsingOptions = false;
+      continue;
+    }
+    if (!parsingOptions) continue;
+    if (abbreviatesLongOption(word, ["amend"])) {
+      return "git commit --amend による履歴変更には確認が必要です";
+    }
+    if (
+      abbreviatesLongOption(word, ["pathspec-file-nul", "pathspec-from-file"])
+    ) {
+      return "外部入力からpathspecを読む git commit には確認が必要です";
+    }
+    if (
+      !word.includes("=") &&
+      (abbreviatesLongOption(word, COMMIT_LONG_OPTIONS_WITH_VALUE) ||
+        shortOptionConsumesNext(word, COMMIT_SHORT_OPTIONS_WITH_VALUE))
+    ) {
+      index += 1;
+    }
+  }
+  return undefined;
+};
+
+const gitMergeRisk = (rest: readonly string[]): string | undefined => {
+  let parsingOptions = true;
+  for (let index = 0; index < rest.length; index += 1) {
+    const word = rest[index];
+    if (word === undefined) break;
+    if (word === "--" && parsingOptions) {
+      parsingOptions = false;
+      continue;
+    }
+    if (!parsingOptions) continue;
+    if (abbreviatesLongOption(word, ["abort", "quit"])) {
+      return "git merge の中断による作業ツリー・状態変更には確認が必要です";
+    }
+    if (
+      !word.includes("=") &&
+      (abbreviatesLongOption(word, MERGE_LONG_OPTIONS_WITH_VALUE) ||
+        shortOptionConsumesNext(word, MERGE_SHORT_OPTIONS_WITH_VALUE))
+    ) {
+      index += 1;
+    }
+  }
+  return undefined;
+};
+
+const gitPathspecOperands = (
+  subcommand: string,
+  rest: readonly string[],
+): readonly string[] => {
+  if (!["add", "commit", "log", "show"].includes(subcommand)) return [];
+  let longOptionsWithValue: readonly string[] = [];
+  let shortOptionsWithValue: ReadonlySet<string> = new Set();
+  if (subcommand === "commit") {
+    longOptionsWithValue = COMMIT_LONG_OPTIONS_WITH_VALUE;
+    shortOptionsWithValue = COMMIT_SHORT_OPTIONS_WITH_VALUE;
+  } else if (subcommand === "log" || subcommand === "show") {
+    longOptionsWithValue = LOG_SHOW_LONG_OPTIONS_WITH_VALUE;
+    shortOptionsWithValue = LOG_SHOW_SHORT_OPTIONS_WITH_VALUE;
+  }
+  const operands: string[] = [];
+  let parsingOptions = true;
+  for (let index = 0; index < rest.length; index += 1) {
+    const word = rest[index];
+    if (word === undefined) break;
+    if (word === "--" && parsingOptions) {
+      parsingOptions = false;
+      continue;
+    }
+    if (
+      parsingOptions &&
+      !word.includes("=") &&
+      (abbreviatesLongOption(word, longOptionsWithValue) ||
+        shortOptionConsumesNext(word, shortOptionsWithValue))
+    ) {
+      index += 1;
+      continue;
+    }
+    if (parsingOptions && word.startsWith("-")) continue;
+    operands.push(word);
+  }
+  return operands;
+};
+
 const gitSubcommandAsk = (
   subcommand: string,
   rest: readonly string[],
@@ -587,22 +956,49 @@ const gitSubcommandAsk = (
   ) {
     return "Git worktree の削除・移動・修復には確認が必要です";
   }
-  if (
-    subcommand === "fetch" &&
-    rest.some(
-      (word) =>
-        optionIs(word, "-f", "--force") ||
-        word.startsWith("+") ||
-        remoteHelperExec(word),
-    )
-  ) {
-    return "強制または外部helper経由の git fetch には確認が必要です";
+  if (subcommand === "fetch") {
+    const risk = gitFetchRisk(rest);
+    if (risk !== undefined) return risk;
+  }
+  if (subcommand === "switch" || subcommand === "checkout") {
+    const risk = gitSwitchRisk(subcommand, rest);
+    if (risk !== undefined) return risk;
   }
   if (
-    (subcommand === "switch" || subcommand === "checkout") &&
-    rest.some((word) => optionIs(word, "-f", "--force", "--discard-changes"))
+    gitPathspecOperands(subcommand, rest).some(
+      (word) => word.startsWith(":(") || /^:[!/^]/.test(word),
+    )
   ) {
-    return `git ${subcommand} による変更破棄には確認が必要です`;
+    return `git ${subcommand} のpathspec magicには確認が必要です`;
+  }
+  if (subcommand === "add") {
+    let parsingOptions = true;
+    for (const word of rest) {
+      if (word === "--") {
+        parsingOptions = false;
+        continue;
+      }
+      if (
+        parsingOptions &&
+        (abbreviatesLongOption(word, ["force"]) || /^-[^-]*f/.test(word))
+      ) {
+        return "ignored fileを強制追加する git add には確認が必要です";
+      }
+      if (
+        parsingOptions &&
+        abbreviatesLongOption(word, ["pathspec-file-nul", "pathspec-from-file"])
+      ) {
+        return "外部入力からpathspecを読む git add には確認が必要です";
+      }
+    }
+  }
+  if (subcommand === "commit") {
+    const risk = gitCommitRisk(rest);
+    if (risk !== undefined) return risk;
+  }
+  if (subcommand === "merge") {
+    const risk = gitMergeRisk(rest);
+    if (risk !== undefined) return risk;
   }
   if (subcommand === "add" && rest.some(hasPathTraversal)) {
     return "worktree 外を参照する git add には確認が必要です";
@@ -700,11 +1096,24 @@ const SENSITIVE_PATH_COMPONENTS: readonly (readonly string[])[] = [
   ["etc", "sudoers"],
 ];
 
+const stripGitPathspecMagic = (word: string): string => {
+  if (word.startsWith(":(")) {
+    const end = word.indexOf(")", 2);
+    return end === -1 ? word : word.slice(end + 1);
+  }
+  return /^:[!/^]/.test(word) ? word.slice(2) : word;
+};
+
 const containsSensitivePath = (words: readonly string[]): boolean =>
   words.some((word) => {
     // `:` is also a boundary for Git revision paths such as
     // `HEAD:.ssh/id_ed25519`; `/` covers absolute, home, and relative paths.
-    const components = word.toLowerCase().split(/[/:]/).filter(Boolean);
+    // Strip Git's leading pathspec magic so `:(top).ssh/...` cannot hide the
+    // sensitive component from deterministic inspection.
+    const components = stripGitPathspecMagic(word)
+      .toLowerCase()
+      .split(/[/:]/)
+      .filter(Boolean);
     return SENSITIVE_PATH_COMPONENTS.some((sensitive) =>
       components.some((_, start) =>
         sensitive.every(
@@ -1139,6 +1548,689 @@ const isHelperCapableGitRead = (normalized: NormalizedSegment): boolean => {
   return subcommand !== undefined && HELPER_CAPABLE_GIT_READS.has(subcommand);
 };
 
+interface KnownGitArgSpec {
+  readonly longFlags?: ReadonlySet<string>;
+  /** Optional values are accepted only in attached `--name=value` form. */
+  readonly longOptionalValues?: ReadonlySet<string>;
+  readonly longValues?: ReadonlySet<string>;
+  readonly shortFlags?: ReadonlySet<string>;
+  readonly shortValues?: ReadonlySet<string>;
+  readonly numericShort?: boolean;
+}
+
+const parseKnownGitArgs = (
+  rest: readonly string[],
+  spec: KnownGitArgSpec,
+): readonly string[] | undefined => {
+  const positionals: string[] = [];
+  let parsingOptions = true;
+  for (let index = 0; index < rest.length; index += 1) {
+    const word = rest[index];
+    if (word === undefined) return undefined;
+    if (parsingOptions && word === "--") {
+      parsingOptions = false;
+      continue;
+    }
+    if (!parsingOptions || !word.startsWith("-") || word === "-") {
+      positionals.push(word);
+      continue;
+    }
+    if (spec.numericShort === true && /^-\d+$/.test(word)) continue;
+    if (word.startsWith("--")) {
+      const equals = word.indexOf("=");
+      const name = equals === -1 ? word : word.slice(0, equals);
+      if (equals !== -1) {
+        if (
+          (!spec.longValues?.has(name) &&
+            !spec.longOptionalValues?.has(name)) ||
+          equals === word.length - 1
+        ) {
+          return undefined;
+        }
+        continue;
+      }
+      if (spec.longFlags?.has(name) || spec.longOptionalValues?.has(name)) {
+        continue;
+      }
+      const value = rest[index + 1];
+      if (
+        !spec.longValues?.has(name) ||
+        value === undefined ||
+        (value.startsWith("-") && !/^-\d+$/.test(value))
+      ) {
+        return undefined;
+      }
+      index += 1;
+      continue;
+    }
+    for (let offset = 1; offset < word.length; offset += 1) {
+      const option = word[offset] ?? "";
+      if (spec.shortFlags?.has(option)) continue;
+      if (!spec.shortValues?.has(option)) return undefined;
+      if (offset === word.length - 1) {
+        const value = rest[index + 1];
+        if (
+          value === undefined ||
+          (value.startsWith("-") && !/^-\d+$/.test(value))
+        ) {
+          return undefined;
+        }
+        index += 1;
+      }
+      break;
+    }
+  }
+  return positionals;
+};
+
+const set = (...values: readonly string[]): ReadonlySet<string> =>
+  new Set(values);
+
+const GIT_DIFF_ARG_SPEC: KnownGitArgSpec = {
+  longFlags: set(
+    "--binary",
+    "--cached",
+    "--check",
+    "--compact-summary",
+    "--exit-code",
+    "--find-copies-harder",
+    "--full-index",
+    "--histogram",
+    "--ignore-all-space",
+    "--ignore-blank-lines",
+    "--ignore-cr-at-eol",
+    "--ignore-space-at-eol",
+    "--ignore-space-change",
+    "--irreversible-delete",
+    "--minimal",
+    "--name-only",
+    "--name-status",
+    "--no-ext-diff",
+    "--no-patch",
+    "--no-renames",
+    "--no-textconv",
+    "--numstat",
+    "--patch",
+    "--patience",
+    "--pickaxe-all",
+    "--pickaxe-regex",
+    "--quiet",
+    "--raw",
+    "--relative",
+    "--shortstat",
+    "--stat",
+    "--staged",
+    "--summary",
+  ),
+  longValues: set(
+    "--abbrev",
+    "--anchored",
+    "--break-rewrites",
+    "--diff-algorithm",
+    "--diff-filter",
+    "--dirstat",
+    "--dst-prefix",
+    "--find-copies",
+    "--find-object",
+    "--find-renames",
+    "--inter-hunk-context",
+    "--line-prefix",
+    "--output-indicator-context",
+    "--output-indicator-new",
+    "--output-indicator-old",
+    "--rotate-to",
+    "--skip-to",
+    "--src-prefix",
+    "--stat-count",
+    "--stat-name-width",
+    "--stat-width",
+    "--submodule",
+    "--unified",
+    "--word-diff",
+    "--word-diff-regex",
+    "--ws-error-highlight",
+  ),
+  shortFlags: set("b", "c", "m", "p", "s", "u", "w"),
+  shortValues: set("G", "O", "S", "U", "l"),
+};
+
+const PURE_GIT_READ_SUBCOMMANDS: ReadonlySet<string> = set(
+  "describe",
+  "for-each-ref",
+  "ls-files",
+  "ls-tree",
+  "merge-base",
+  "name-rev",
+  "rev-list",
+  "rev-parse",
+  "show-ref",
+);
+
+const pureGitReadSpec = (subcommand: string): KnownGitArgSpec | undefined => {
+  switch (subcommand) {
+    case "rev-parse": {
+      return {
+        longFlags: set(
+          "--absolute-git-dir",
+          "--all",
+          "--branches",
+          "--end-of-options",
+          "--flags",
+          "--git-common-dir",
+          "--git-dir",
+          "--is-bare-repository",
+          "--is-inside-git-dir",
+          "--is-inside-work-tree",
+          "--is-shallow-repository",
+          "--local-env-vars",
+          "--no-flags",
+          "--no-revs",
+          "--quiet",
+          "--remotes",
+          "--revs-only",
+          "--show-cdup",
+          "--show-prefix",
+          "--show-superproject-working-tree",
+          "--show-toplevel",
+          "--show-object-format",
+          "--sq",
+          "--symbolic",
+          "--symbolic-full-name",
+          "--tags",
+          "--verify",
+        ),
+        longValues: set(
+          "--abbrev-ref",
+          "--branches",
+          "--default",
+          "--disambiguate",
+          "--exclude",
+          "--git-path",
+          "--glob",
+          "--path-format",
+          "--prefix",
+          "--remotes",
+          "--short",
+          "--tags",
+        ),
+        shortFlags: set("q"),
+      };
+    }
+    case "merge-base": {
+      return {
+        longFlags: set(
+          "--all",
+          "--fork-point",
+          "--independent",
+          "--is-ancestor",
+          "--octopus",
+        ),
+        shortFlags: set("a"),
+      };
+    }
+    case "ls-files": {
+      return {
+        longFlags: set(
+          "--cached",
+          "--debug",
+          "--deleted",
+          "--directory",
+          "--empty-directory",
+          "--eol",
+          "--error-unmatch",
+          "--ignored",
+          "--killed",
+          "--modified",
+          "--others",
+          "--recurse-submodules",
+          "--resolve-undo",
+          "--stage",
+          "--unmerged",
+          "--verbose",
+        ),
+        longValues: set("--abbrev", "--format", "--with-tree"),
+        shortFlags: set("c", "d", "i", "k", "m", "o", "s", "t", "u", "v"),
+      };
+    }
+    case "ls-tree": {
+      return {
+        longFlags: set(
+          "--full-name",
+          "--full-tree",
+          "--long",
+          "--name-only",
+          "--name-status",
+          "--object-only",
+        ),
+        longValues: set("--abbrev", "--format"),
+        shortFlags: set("d", "l", "r", "t", "z"),
+      };
+    }
+    case "show-ref": {
+      return {
+        longFlags: set(
+          "--dereference",
+          "--exists",
+          "--head",
+          "--heads",
+          "--quiet",
+          "--tags",
+          "--verify",
+        ),
+        longValues: set("--abbrev", "--hash"),
+        shortFlags: set("d", "q", "s"),
+      };
+    }
+    case "for-each-ref": {
+      return {
+        longFlags: set(
+          "--ignore-case",
+          "--omit-empty",
+          "--perl",
+          "--python",
+          "--shell",
+          "--tcl",
+        ),
+        longValues: set(
+          "--contains",
+          "--count",
+          "--format",
+          "--merged",
+          "--no-contains",
+          "--no-merged",
+          "--points-at",
+          "--sort",
+        ),
+      };
+    }
+    case "describe": {
+      return {
+        longFlags: set(
+          "--all",
+          "--always",
+          "--contains",
+          "--debug",
+          "--exact-match",
+          "--first-parent",
+          "--long",
+          "--tags",
+        ),
+        longValues: set(
+          "--abbrev",
+          "--broken",
+          "--candidates",
+          "--dirty",
+          "--exclude",
+          "--match",
+        ),
+      };
+    }
+    case "name-rev": {
+      return {
+        longFlags: set("--all", "--always", "--name-only", "--tags"),
+        longValues: set("--exclude", "--refs"),
+      };
+    }
+    case "rev-list": {
+      return {
+        longFlags: set(
+          "--all",
+          "--alternate-refs",
+          "--author-date-order",
+          "--boundary",
+          "--branches",
+          "--cherry-mark",
+          "--cherry-pick",
+          "--children",
+          "--count",
+          "--date-order",
+          "--do-walk",
+          "--first-parent",
+          "--full-history",
+          "--header",
+          "--ignore-missing",
+          "--left-only",
+          "--left-right",
+          "--no-object-names",
+          "--no-walk",
+          "--objects",
+          "--objects-edge",
+          "--objects-edge-aggressive",
+          "--parents",
+          "--quiet",
+          "--remotes",
+          "--reverse",
+          "--right-only",
+          "--single-worktree",
+          "--tags",
+          "--timestamp",
+          "--topo-order",
+        ),
+        longValues: set(
+          "--after",
+          "--before",
+          "--exclude",
+          "--filter",
+          "--glob",
+          "--max-count",
+          "--max-parents",
+          "--min-parents",
+          "--missing",
+          "--pretty",
+          "--since",
+          "--skip",
+          "--until",
+        ),
+        shortValues: set("n"),
+        numericShort: true,
+      };
+    }
+    default: {
+      return undefined;
+    }
+  }
+};
+
+const optionWordsBeforeTerminator = (
+  rest: readonly string[],
+): readonly string[] => {
+  const terminator = rest.indexOf("--");
+  return terminator === -1 ? rest : rest.slice(0, terminator);
+};
+
+const gitReadOnlyModeEligible = (
+  subcommand: string,
+  rest: readonly string[],
+): boolean => {
+  if (PURE_GIT_READ_SUBCOMMANDS.has(subcommand)) {
+    const spec = pureGitReadSpec(subcommand);
+    return spec !== undefined && parseKnownGitArgs(rest, spec) !== undefined;
+  }
+  if (subcommand === "diff") {
+    return parseKnownGitArgs(rest, GIT_DIFF_ARG_SPEC) !== undefined;
+  }
+  if (subcommand === "branch") {
+    const args = parseKnownGitArgs(rest, {
+      longFlags: set(
+        "--all",
+        "--ignore-case",
+        "--list",
+        "--omit-empty",
+        "--remotes",
+        "--show-current",
+        "--verbose",
+      ),
+      longOptionalValues: set(
+        "--abbrev",
+        "--color",
+        "--column",
+        "--contains",
+        "--merged",
+        "--no-contains",
+        "--no-merged",
+      ),
+      longValues: set("--format", "--points-at", "--sort"),
+      shortFlags: set("a", "r", "v"),
+    });
+    if (args === undefined) return false;
+    if (rest.length === 0) return true;
+    if (rest.length === 1 && rest[0] === "--show-current") return true;
+    return optionWordsBeforeTerminator(rest).includes("--list");
+  }
+  if (subcommand === "remote") return rest.length === 0;
+  if (subcommand === "stash") {
+    const [mode, ...args] = rest;
+    if (mode === "list") {
+      return (
+        parseKnownGitArgs(args, {
+          longFlags: set("--oneline"),
+          longValues: set("--format", "--max-count"),
+          shortValues: set("n"),
+          numericShort: true,
+        })?.length === 0
+      );
+    }
+    if (mode === "show") {
+      return parseKnownGitArgs(args, GIT_DIFF_ARG_SPEC) !== undefined;
+    }
+    return false;
+  }
+  if (subcommand === "tag") {
+    const args = parseKnownGitArgs(rest, {
+      longFlags: set("--ignore-case", "--list", "--omit-empty"),
+      longOptionalValues: set(
+        "--color",
+        "--column",
+        "--contains",
+        "--merged",
+        "--no-contains",
+        "--no-merged",
+      ),
+      longValues: set("--format", "--points-at", "--sort"),
+      shortFlags: set("l", "n"),
+    });
+    if (args === undefined) return false;
+    if (rest.length === 0) return true;
+    return optionWordsBeforeTerminator(rest).some(
+      (word) => word === "--list" || /^-[^-]*l/.test(word),
+    );
+  }
+  return false;
+};
+
+const pathInsideRoots = (
+  operand: string,
+  cwd: string,
+  roots: readonly string[],
+  allowMissing: boolean,
+): boolean => {
+  if (operand === "" || operand.startsWith("~") || hasPathTraversal(operand)) {
+    return false;
+  }
+  const candidate = isAbsolute(operand) ? operand : resolve(cwd, operand);
+  if (allowMissing) return canonicalOrAncestorInsideRoots(candidate, roots);
+  try {
+    return pathInsideVerifiedRoots(realpathSync(candidate), roots);
+  } catch {
+    return false;
+  }
+};
+
+const effectiveGitCwd = (options: EvaluationOptions): string | undefined => {
+  const context = options.trustedReadContext;
+  if (context === undefined) return undefined;
+  if (options.trustedGitCwdTarget === undefined) return context.cwd;
+  const candidate = isAbsolute(options.trustedGitCwdTarget)
+    ? options.trustedGitCwdTarget
+    : resolve(context.cwd, options.trustedGitCwdTarget);
+  try {
+    return realpathSync(candidate);
+  } catch {
+    return undefined;
+  }
+};
+
+const gitWorktreeModeEligible = (
+  rest: readonly string[],
+  options: EvaluationOptions,
+): boolean => {
+  const [mode, ...args] = rest;
+  if (mode === "list") {
+    return (
+      parseKnownGitArgs(args, {
+        longFlags: set("--porcelain", "--verbose", "--zero"),
+        longValues: set("--expire"),
+        shortFlags: set("v", "z"),
+      })?.length === 0
+    );
+  }
+  const context = options.trustedReadContext;
+  const gitCwd = effectiveGitCwd(options);
+  if (context === undefined || gitCwd === undefined) return false;
+  if (mode === "add") {
+    const positionals = parseKnownGitArgs(args, {
+      longFlags: set(
+        "--checkout",
+        "--detach",
+        "--guess-remote",
+        "--lock",
+        "--no-checkout",
+        "--no-guess-remote",
+        "--no-track",
+        "--orphan",
+        "--quiet",
+        "--track",
+      ),
+      longValues: set("--reason"),
+      shortFlags: set("d", "q"),
+      shortValues: set("b"),
+    });
+    const target = positionals?.[0];
+    return (
+      target !== undefined &&
+      (positionals?.length ?? 0) <= 2 &&
+      (options.trustedWorktreeCreateRoots?.length ?? 0) > 0 &&
+      pathInsideRoots(
+        target,
+        gitCwd,
+        options.trustedWorktreeCreateRoots ?? [],
+        true,
+      )
+    );
+  }
+  if (mode === "lock" || mode === "unlock") {
+    const positionals = parseKnownGitArgs(
+      args,
+      mode === "lock" ? { longValues: set("--reason") } : {},
+    );
+    const target = positionals?.[0];
+    return (
+      target !== undefined &&
+      positionals?.length === 1 &&
+      pathInsideRoots(
+        target,
+        gitCwd,
+        options.trustedWritableWorktrees ?? [],
+        false,
+      )
+    );
+  }
+  return false;
+};
+
+const BASE_SANDBOX_GIT_SUBCOMMANDS: ReadonlySet<string> = set(
+  "add",
+  "commit",
+  "fetch",
+  "log",
+  "merge",
+  "merge-tree",
+  "show",
+  "status",
+  "switch",
+);
+const MUTATING_SANDBOX_GIT_SUBCOMMANDS: ReadonlySet<string> = set(
+  "add",
+  "commit",
+  "fetch",
+  "merge",
+  "merge-tree",
+  "pull",
+  "switch",
+);
+const SANDBOX_GIT_CANDIDATE_SUBCOMMANDS: ReadonlySet<string> = new Set([
+  ...BASE_SANDBOX_GIT_SUBCOMMANDS,
+  ...PURE_GIT_READ_SUBCOMMANDS,
+  "branch",
+  "diff",
+  "pull",
+  "remote",
+  "stash",
+  "tag",
+  "worktree",
+]);
+
+const gitSubcommandModeEligible = (
+  subcommand: string,
+  rest: readonly string[],
+  options: EvaluationOptions,
+): boolean => {
+  if (BASE_SANDBOX_GIT_SUBCOMMANDS.has(subcommand)) return true;
+  if (gitReadOnlyModeEligible(subcommand, rest)) return true;
+  if (subcommand === "worktree") return gitWorktreeModeEligible(rest, options);
+  // Pull may be rewritten through repository url.*.insteadOf/protocol config.
+  // Keep every form residual until the resolved transport is pinned at runtime.
+  return false;
+};
+
+const gitModeMutates = (subcommand: string, rest: readonly string[]): boolean =>
+  MUTATING_SANDBOX_GIT_SUBCOMMANDS.has(subcommand) ||
+  (subcommand === "worktree" &&
+    ["add", "lock", "unlock"].includes(rest[0] ?? ""));
+
+const gitCwdIsWritable = (
+  target: string,
+  options: EvaluationOptions,
+): boolean => {
+  const context = options.trustedReadContext;
+  if (context === undefined) return false;
+  return pathInsideRoots(
+    target,
+    context.cwd,
+    options.trustedWritableWorktrees ?? [],
+    false,
+  );
+};
+
+const isSandboxAllowedGitCommand = (
+  segment: Segment,
+  normalized: NormalizedSegment,
+  options: EvaluationOptions,
+): boolean => {
+  if (
+    segment.allowCandidate === undefined ||
+    segment.hasAnsiC ||
+    segment.words[0] !== normalized.words[0] ||
+    normalized.words[0] !== "git" ||
+    normalized.opaque.size !== 0 ||
+    hasGitReadExecutionOption(normalized.words)
+  ) {
+    return false;
+  }
+  const position = gitSubcommandPosition(normalized.words);
+  if (
+    position === undefined ||
+    position.ambiguousOption ||
+    normalized.opaque.has(position.index)
+  ) {
+    return false;
+  }
+  const target = literalGitCwdTarget(normalized, position);
+  if (position.riskyGlobalOption) {
+    if (
+      !position.cOnlyGlobalOption ||
+      target === undefined ||
+      target !== options.trustedGitCwdTarget
+    ) {
+      return false;
+    }
+  }
+  const subcommand = normalized.words[position.index];
+  if (subcommand === undefined) return false;
+  const rest = normalized.words.slice(position.index + 1);
+  if (!gitSubcommandModeEligible(subcommand, rest, options)) return false;
+  if (gitModeMutates(subcommand, rest)) {
+    if (target !== undefined && options.trustedReadContext === undefined) {
+      return false;
+    }
+    if (options.trustedReadContext !== undefined) {
+      const effectiveCwd = target ?? options.trustedReadContext.cwd;
+      if (!gitCwdIsWritable(effectiveCwd, options)) return false;
+    }
+  }
+  return true;
+};
+
 const gitReadCwdTarget = (command: string): string | undefined => {
   const scanned = scanCommand(command);
   if (
@@ -1164,16 +2256,360 @@ const gitReadCwdTarget = (command: string): string | undefined => {
     normalized.opaque.size !== 0 ||
     segment.words[0] !== normalized.words[0] ||
     hasGitReadExecutionOption(normalized.words) ||
-    !isHelperCapableGitRead(normalized) ||
     structuralKnownRisk(segment, normalized)?.reason !==
       GIT_GLOBAL_OPTION_REASON
   ) {
     return undefined;
   }
   const position = gitSubcommandPosition(normalized.words);
-  return position === undefined
-    ? undefined
-    : literalGitCwdTarget(normalized, position);
+  const subcommand =
+    position === undefined ? undefined : normalized.words[position.index];
+  if (
+    position === undefined ||
+    subcommand === undefined ||
+    !SANDBOX_GIT_CANDIDATE_SUBCOMMANDS.has(subcommand)
+  ) {
+    return undefined;
+  }
+  return literalGitCwdTarget(normalized, position);
+};
+
+const commandPositionals = (
+  rest: readonly string[],
+  spec: KnownGitArgSpec,
+): readonly string[] | undefined => parseKnownGitArgs(rest, spec);
+
+const grepFileOperands = (
+  rest: readonly string[],
+): readonly string[] | undefined => {
+  const hasExplicitPattern = rest.some(
+    (word) =>
+      word === "-e" ||
+      word === "--regexp" ||
+      word.startsWith("--regexp=") ||
+      /^-[^-]*e/.test(word),
+  );
+  const positionals = commandPositionals(rest, {
+    longFlags: set(
+      "--basic-regexp",
+      "--binary-files-without-match",
+      "--byte-offset",
+      "--count",
+      "--extended-regexp",
+      "--files-with-matches",
+      "--files-without-match",
+      "--fixed-strings",
+      "--ignore-case",
+      "--invert-match",
+      "--line-number",
+      "--line-regexp",
+      "--no-filename",
+      "--no-messages",
+      "--only-matching",
+      "--quiet",
+      "--text",
+      "--with-filename",
+      "--word-regexp",
+    ),
+    longOptionalValues: set("--color"),
+    longValues: set(
+      "--after-context",
+      "--before-context",
+      "--binary-files",
+      "--context",
+      "--max-count",
+      "--regexp",
+    ),
+    shortFlags: set(
+      "E",
+      "F",
+      "G",
+      "H",
+      "I",
+      "L",
+      "P",
+      "Z",
+      "a",
+      "b",
+      "c",
+      "h",
+      "i",
+      "l",
+      "n",
+      "o",
+      "q",
+      "s",
+      "v",
+      "w",
+      "x",
+      "z",
+    ),
+    shortValues: set("A", "B", "C", "e", "m"),
+  });
+  if (positionals === undefined) return undefined;
+  if (hasExplicitPattern) return positionals;
+  return positionals.length === 0 ? undefined : positionals.slice(1);
+};
+
+const stripJqStrings = (filter: string): string => {
+  let output = "";
+  let quoted = false;
+  let escaped = false;
+  for (const character of filter) {
+    if (quoted) {
+      if (escaped) escaped = false;
+      else if (character === "\\") escaped = true;
+      else if (character === '"') quoted = false;
+      output += " ";
+      continue;
+    }
+    if (character === '"') {
+      quoted = true;
+      output += " ";
+    } else {
+      output += character;
+    }
+  }
+  return output;
+};
+
+const jqFilterAllowed = (filter: string): boolean => {
+  // jq executes expressions inside string interpolation. Reject interpolation
+  // wholesale rather than trying to parse nested jq syntax here.
+  if (filter.includes(String.raw`\(`)) return false;
+  const code = stripJqStrings(filter);
+  return !(
+    /\$ENV\b/.test(code) ||
+    /(^|[^.$A-Za-z0-9_])(env|include|import|input|inputs|module|modulemeta)\b/.test(
+      code,
+    )
+  );
+};
+
+interface JqReadArgs {
+  readonly files: readonly string[];
+  readonly noInput: boolean;
+}
+
+const jqReadArgs = (rest: readonly string[]): JqReadArgs | undefined => {
+  let parsingOptions = true;
+  let noInput = false;
+  const positionals: string[] = [];
+  for (let index = 0; index < rest.length; index += 1) {
+    const word = rest[index];
+    if (word === undefined) return undefined;
+    if (parsingOptions && word === "--") {
+      parsingOptions = false;
+      continue;
+    }
+    if (!parsingOptions || !word.startsWith("-") || word === "-") {
+      positionals.push(word);
+      continue;
+    }
+    if (/^-[acejMnrRsSV0]+$/.test(word)) {
+      if (word.includes("n")) noInput = true;
+      continue;
+    }
+    if (
+      [
+        "--compact-output",
+        "--exit-status",
+        "--join-output",
+        "--monochrome-output",
+        "--null-input",
+        "--raw-input",
+        "--raw-output",
+        "--slurp",
+        "--sort-keys",
+        "--version",
+      ].includes(word)
+    ) {
+      if (word === "--null-input") noInput = true;
+      continue;
+    }
+    if (word === "--indent") {
+      if (rest[index + 1] === undefined) return undefined;
+      index += 1;
+      continue;
+    }
+    if (word === "--arg" || word === "--argjson") {
+      if (rest[index + 1] === undefined || rest[index + 2] === undefined) {
+        return undefined;
+      }
+      index += 2;
+      continue;
+    }
+    return undefined;
+  }
+  const [filter, ...files] = positionals;
+  if (filter === undefined || !jqFilterAllowed(filter)) return undefined;
+  return { files, noInput };
+};
+
+const sandboxProjectReadAllowed = (
+  segment: Segment,
+  normalized: NormalizedSegment,
+  context: TrustedReadContext | undefined,
+): boolean => {
+  if (
+    segment.allowCandidate === undefined ||
+    segment.hasAnsiC ||
+    segment.words[0] !== normalized.words[0] ||
+    normalized.opaque.size !== 0 ||
+    segment.redirectionTargets.length !== 0
+  ) {
+    return false;
+  }
+  const [command, ...rest] = normalized.words;
+  if (context === undefined) return false;
+  if (command === "pwd") {
+    return (
+      commandPositionals(rest, { shortFlags: set("L", "P") })?.length === 0
+    );
+  }
+
+  let operands: readonly string[] | undefined;
+  let safeWithoutOperands = false;
+  if (command === "ls") {
+    operands = commandPositionals(rest, {
+      longFlags: set(
+        "--all",
+        "--almost-all",
+        "--classify",
+        "--directory",
+        "--group-directories-first",
+        "--human-readable",
+        "--inode",
+        "--literal",
+        "--long",
+        "--numeric-uid-gid",
+        "--quote-name",
+        "--reverse",
+        "--size",
+      ),
+      longOptionalValues: set("--color"),
+      longValues: set(
+        "--block-size",
+        "--format",
+        "--hide",
+        "--ignore",
+        "--indicator-style",
+        "--quoting-style",
+        "--sort",
+        "--time",
+        "--time-style",
+        "--width",
+      ),
+      shortFlags: set(
+        "1",
+        "A",
+        "F",
+        "G",
+        "H",
+        "S",
+        "U",
+        "a",
+        "d",
+        "f",
+        "g",
+        "h",
+        "i",
+        "k",
+        "l",
+        "m",
+        "n",
+        "o",
+        "p",
+        "q",
+        "r",
+        "s",
+        "t",
+        "u",
+        "v",
+        "x",
+      ),
+    });
+  } else if (command === "stat") {
+    operands = commandPositionals(rest, {
+      longFlags: set("--dereference", "--file-system", "--terse"),
+      longValues: set("--format", "--printf"),
+      shortFlags: set("L", "t"),
+    });
+  } else if (command === "readlink") {
+    operands = commandPositionals(rest, {
+      longFlags: set(
+        "--canonicalize",
+        "--canonicalize-existing",
+        "--canonicalize-missing",
+        "--no-newline",
+        "--quiet",
+        "--verbose",
+        "--zero",
+      ),
+      shortFlags: set("e", "f", "m", "n", "q", "s", "v", "z"),
+    });
+  } else if (command === "realpath") {
+    operands = commandPositionals(rest, {
+      longFlags: set(
+        "--canonicalize-existing",
+        "--canonicalize-missing",
+        "--logical",
+        "--physical",
+        "--quiet",
+        "--strip",
+        "--zero",
+      ),
+      shortFlags: set("L", "P", "e", "m", "q", "s", "z"),
+    });
+  } else if (command === "cat") {
+    operands = commandPositionals(rest, {
+      longFlags: set(
+        "--number",
+        "--number-nonblank",
+        "--show-all",
+        "--show-ends",
+        "--show-nonprinting",
+        "--show-tabs",
+        "--squeeze-blank",
+      ),
+      shortFlags: set("A", "E", "T", "b", "e", "n", "s", "t", "u", "v"),
+    });
+  } else if (command === "head" || command === "tail") {
+    operands = commandPositionals(rest, {
+      longFlags: set("--quiet", "--verbose", "--zero-terminated"),
+      longValues: set("--bytes", "--lines"),
+      shortFlags: set("q", "v", "z"),
+      shortValues: set("c", "n"),
+      numericShort: true,
+    });
+  } else if (command === "wc") {
+    operands = commandPositionals(rest, {
+      longFlags: set(
+        "--bytes",
+        "--chars",
+        "--lines",
+        "--max-line-length",
+        "--words",
+      ),
+      shortFlags: set("L", "c", "l", "m", "w"),
+    });
+  } else if (command === "grep") {
+    operands = grepFileOperands(rest);
+  } else if (command === "jq") {
+    const jqArgs = jqReadArgs(rest);
+    operands = jqArgs?.files;
+    safeWithoutOperands = jqArgs?.noInput === true;
+  } else {
+    return false;
+  }
+  if (operands === undefined) return false;
+  if (operands.length === 0 && safeWithoutOperands) return true;
+
+  // Pre-execution path validation cannot pin a pathname until Bash opens it.
+  // The runtime has denyRead but no project read allowlist, so another process
+  // could swap any validated path to an outside symlink. Keep every pathname
+  // reader residual until execution can consume a pinned object/path.
+  return false;
 };
 
 const structuralKnownAllow = (
@@ -1236,6 +2672,8 @@ const evaluateNormalized = (
   allowCandidate: string | undefined,
   trustedLeadingCdTarget: string | undefined,
   trustedGitCwdTarget: string | undefined,
+  trustedWritableWorktrees: readonly string[] | undefined,
+  trustedWorktreeCreateRoots: readonly string[] | undefined,
   trustedReadContext: TrustedReadContext | undefined,
   effectSandboxed: boolean,
 ): AuditedVerdict => {
@@ -1356,6 +2794,35 @@ const evaluateNormalized = (
     );
   }
 
+  // The OS sandbox confines filesystem/network effects, so these common Git
+  // operations can bypass the residual model route when their command shape is
+  // fully concrete. Deterministic deny/ask rules above still win for force,
+  // destructive checkout, sensitive paths, path traversal, risky global
+  // options, and any configured confirmation rule.
+  if (
+    effectSandboxed &&
+    isSandboxAllowedGitCommand(segment, normalized, {
+      effectSandboxed,
+      ...(trustedGitCwdTarget === undefined ? {} : { trustedGitCwdTarget }),
+      ...(trustedWritableWorktrees === undefined
+        ? {}
+        : { trustedWritableWorktrees }),
+      ...(trustedWorktreeCreateRoots === undefined
+        ? {}
+        : { trustedWorktreeCreateRoots }),
+      ...(trustedReadContext === undefined ? {} : { trustedReadContext }),
+    })
+  ) {
+    return audited({ verdict: "allow" }, "sandbox-git-allow");
+  }
+
+  if (
+    effectSandboxed &&
+    sandboxProjectReadAllowed(segment, normalized, trustedReadContext)
+  ) {
+    return audited({ verdict: "allow" }, "sandbox-read-allow");
+  }
+
   if (structuralKnownAllow(segment, normalized, trustedReadContext)) {
     return audited({ verdict: "allow" }, "builtin-read-allow");
   }
@@ -1434,20 +2901,32 @@ const evaluateCommandInner = (
       : audited({ verdict: "deny", reason: UNPARSEABLE_REASON }, "parse-error");
   }
   const verdicts: AuditedVerdict[] = [];
+  let readerPathsStable = true;
   for (const [index, segment] of scanned.segments.entries()) {
     const normalized = normalizeSegment(segment);
-    verdicts.push(
-      evaluateNormalized(
-        segment,
-        normalized,
-        rules,
-        segment.allowCandidate,
-        depth === 0 && index === 0 ? options.trustedLeadingCdTarget : undefined,
-        depth === 0 && index === 0 ? options.trustedGitCwdTarget : undefined,
-        depth === 0 ? options.trustedReadContext : undefined,
-        options.effectSandboxed === true,
-      ),
+    const verdict = evaluateNormalized(
+      segment,
+      normalized,
+      rules,
+      segment.allowCandidate,
+      depth === 0 && index === 0 ? options.trustedLeadingCdTarget : undefined,
+      depth === 0 && index === 0 ? options.trustedGitCwdTarget : undefined,
+      depth === 0 ? options.trustedWritableWorktrees : undefined,
+      depth === 0 ? options.trustedWorktreeCreateRoots : undefined,
+      depth === 0 && readerPathsStable ? options.trustedReadContext : undefined,
+      options.effectSandboxed === true,
     );
+    verdicts.push(verdict);
+    if (
+      depth === 0 &&
+      ![
+        "builtin-read-allow",
+        "sandbox-read-allow",
+        "trusted-leading-cd",
+      ].includes(verdict.audit.basis)
+    ) {
+      readerPathsStable = false;
+    }
     // `sh -c '<script>'` runs exactly <script>; evaluate it so a denied body
     // (e.g. `bit relay sync`) is denied instead of downgraded to an opaque ask.
     const inner = interpreterConcreteArg(normalized);
@@ -1481,8 +2960,10 @@ const PROJECT_SENSITIVE_GIT_SUBCOMMANDS: ReadonlySet<string> = new Set([
   "clean",
   "commit",
   "config",
+  "fetch",
   "init",
   "merge",
+  "merge-tree",
   "mv",
   "notes",
   "pull",
@@ -1514,10 +2995,13 @@ const segmentHasProjectSensitiveMutation = (segment: Segment): boolean => {
     return false;
   }
   const subcommand = normalized.words[position.index];
-  return (
-    subcommand !== undefined &&
-    PROJECT_SENSITIVE_GIT_SUBCOMMANDS.has(subcommand)
-  );
+  if (subcommand === undefined) return false;
+  const rest = normalized.words.slice(position.index + 1);
+  if (gitReadOnlyModeEligible(subcommand, rest)) return false;
+  if (subcommand === "worktree" && gitWorktreeModeEligible(rest, {})) {
+    return false;
+  }
+  return PROJECT_SENSITIVE_GIT_SUBCOMMANDS.has(subcommand);
 };
 
 const hasProjectSensitiveMutationInner = (

--- a/tests/pi-harness/bash-sandbox.test.ts
+++ b/tests/pi-harness/bash-sandbox.test.ts
@@ -50,7 +50,9 @@ const config = (): HarnessConfig => ({
 
 const profile = (cwd = "/repo"): BashSandboxProfile => ({
   cwd,
+  activeWorktree: cwd,
   writableRoots: [cwd, "/private/scratch"],
+  configuredWriteRoots: [],
   scratchDirectory: "/private/scratch",
   networkMode: "denied",
   fingerprint: "a".repeat(64),
@@ -97,6 +99,7 @@ const setup = (
     attach?: boolean;
     commandPrefix?: string;
     spawnFn?: SpawnFunction;
+    sandboxProfile?: BashSandboxProfile;
     userOwnerOrder?: "before" | "after";
     validateWritableWorktree?: (
       path: string,
@@ -149,7 +152,7 @@ const setup = (
   };
   const controller = setupBashSandbox(pi, config(), {
     loadRuntime: async () => ({ SandboxManager: fakeManager }),
-    buildProfile: async () => profile(),
+    buildProfile: async () => options.sandboxProfile ?? profile(),
     makeTempDirectory: async () => "/private/scratch",
     chmodPath: async () => {},
     accessPath: async () => {},
@@ -195,7 +198,7 @@ describe("Bash sandbox profile", () => {
       undefined,
       {
         home: "/home/test",
-        canonicalize: async () => "/repo/active/subdir",
+        canonicalize: async (path) => path,
         discoverProject: async (_cwd, options) => {
           discoveryTimeoutMs = options?.timeoutMs;
           return {
@@ -225,6 +228,8 @@ describe("Bash sandbox profile", () => {
       "/private/scratch",
       "/home/test/trusted-output",
     ]);
+    expect(result.activeWorktree).toBe("/repo/active");
+    expect(result.configuredWriteRoots).toEqual(["/home/test/trusted-output"]);
     expect(result.writableRoots).not.toContain("/repo/other-worktree");
     expect(result.runtimeConfig.filesystem.allowWrite).toEqual([
       ...result.writableRoots,
@@ -234,6 +239,40 @@ describe("Bash sandbox profile", () => {
         "/repo/common.git/config",
         "/repo/common.git/hooks",
       ]),
+    );
+  });
+
+  test("canonicalizes configured write roots while preserving a missing tail", async () => {
+    const sandboxConfig = structuredClone(DEFAULT_BASH_SANDBOX_CONFIG);
+    sandboxConfig.filesystem.allowWrite.push("/tmp/missing-parent/worktrees");
+    const result = await buildBashSandboxProfile(
+      "/repo",
+      "/private/scratch",
+      sandboxConfig,
+      undefined,
+      {
+        canonicalize: async (path) => {
+          if (
+            path === "/tmp/missing-parent/worktrees" ||
+            path === "/tmp/missing-parent"
+          ) {
+            throw Object.assign(new Error("missing"), { code: "ENOENT" });
+          }
+          return path === "/tmp" ? "/private/tmp" : path;
+        },
+        discoverProject: async () => ({
+          kind: "non-git",
+          cwd: "/repo",
+          fingerprint: "project-fingerprint",
+        }),
+      },
+    );
+
+    expect(result.configuredWriteRoots).toEqual([
+      "/private/tmp/missing-parent/worktrees",
+    ]);
+    expect(result.runtimeConfig.filesystem.allowWrite).toContain(
+      "/private/tmp/missing-parent/worktrees",
     );
   });
 
@@ -301,6 +340,8 @@ describe("Bash effect sandbox lifecycle", () => {
       mode: "sandboxed",
       network: "denied",
       profileFingerprint: "a".repeat(64),
+      writableWorktrees: ["/repo"],
+      worktreeCreateRoots: [],
     });
     expect(runtime.pi.tools.map((tool) => tool.name)).toContain(
       "bash_escalated",
@@ -343,6 +384,10 @@ describe("Bash effect sandbox lifecycle", () => {
     expect(runtime.controller.boundaryFor("bash")?.profileFingerprint).not.toBe(
       initialFingerprint,
     );
+    expect(runtime.controller.boundaryFor("bash")?.writableWorktrees).toEqual([
+      "/repo",
+      "/repo/linked",
+    ]);
 
     await runtime.controller.registerWritableWorktree("/repo/linked");
     expect(runtime.fakeManager.updates).toHaveLength(1);
@@ -353,6 +398,55 @@ describe("Bash effect sandbox lifecycle", () => {
       "/repo",
       "/private/scratch",
     ]);
+    expect(runtime.controller.boundaryFor("bash")?.writableWorktrees).toEqual([
+      "/repo",
+    ]);
+  });
+
+  test("registers an already-configured writable worktree as a capability", async () => {
+    const configuredRoot = "/repo/configured";
+    const baseProfile = profile();
+    const sandboxProfile: BashSandboxProfile = {
+      ...baseProfile,
+      writableRoots: [...baseProfile.writableRoots, configuredRoot],
+      configuredWriteRoots: [configuredRoot],
+      runtimeConfig: {
+        ...baseProfile.runtimeConfig,
+        filesystem: {
+          ...baseProfile.runtimeConfig.filesystem,
+          allowWrite: [...baseProfile.writableRoots, configuredRoot],
+        },
+      },
+    };
+    const runtime = setup({
+      sandboxProfile,
+      validateWritableWorktree: async () => ({
+        ok: true,
+        canonicalCwd: configuredRoot,
+      }),
+    });
+    await runtime.pi.emitSessionStart({
+      type: "session_start",
+      reason: "startup",
+    });
+
+    await runtime.controller.registerWritableWorktree(configuredRoot);
+    expect(runtime.fakeManager.updates).toHaveLength(0);
+    expect(runtime.controller.boundaryFor("bash")).toEqual(
+      expect.objectContaining({
+        writableWorktrees: ["/repo", configuredRoot],
+        worktreeCreateRoots: [configuredRoot],
+      }),
+    );
+
+    await runtime.controller.revokeWritableWorktree(configuredRoot);
+    expect(runtime.fakeManager.updates).toHaveLength(0);
+    expect(runtime.controller.boundaryFor("bash")?.writableWorktrees).toEqual([
+      "/repo",
+    ]);
+    expect(sandboxProfile.runtimeConfig.filesystem.allowWrite).toContain(
+      configuredRoot,
+    );
   });
 
   test("merges concurrent registrations in the same session", async () => {
@@ -666,6 +760,7 @@ describe("controlled Bash launcher", () => {
         BASH_ENV: "/tmp/startup.sh",
         DYLD_INSERT_LIBRARIES: "/tmp/inject.dylib",
         GIT_CONFIG_GLOBAL: "/tmp/gitconfig",
+        GIT_OPTIONAL_LOCKS: "1",
         PI_HARNESS_CODEX_STAGE_CAPABILITY: "prompt,review",
         GH_TOKEN: "secret",
         OPENAI_API_KEY: "secret",
@@ -679,6 +774,7 @@ describe("controlled Bash launcher", () => {
       HOME: "/home/test",
       LANG: "C.UTF-8",
       SHELL: CONTROLLED_BASH_PATH,
+      GIT_OPTIONAL_LOCKS: "0",
       TMPDIR: "/private/scratch",
     });
     expect(env.PATH).toBe("/usr/bin:/bin");

--- a/tests/pi-harness/permission-rules.test.ts
+++ b/tests/pi-harness/permission-rules.test.ts
@@ -6,6 +6,7 @@ import { join, resolve } from "node:path";
 import setupPermissionPolicy from "../../pi/extensions/pi-harness/features/permission-policy";
 import {
   evaluateCommand,
+  evaluateCommandWithAudit,
   gitReadCwdTarget,
   hasProjectSensitiveMutation,
   hasUnverifiedProjectMutationNavigation,
@@ -469,6 +470,481 @@ describe("built-in read-only classification", () => {
       verdict: "ask",
       reason: "confirm search",
     });
+  });
+});
+
+describe("sandbox-only Git classification", () => {
+  const rules = loadRules('{"deny":[],"allow":[],"ask":[]}');
+  const sandboxed = { effectSandboxed: true } as const;
+
+  test.each([
+    "git status --short --branch",
+    "git show --stat HEAD",
+    "git log -1 --oneline",
+    "git merge --no-edit feature/topic",
+    "git merge --continue",
+    "git merge -m --abort feature/topic",
+    "git merge -m message -- --abort",
+    "git switch feature/topic",
+    "git switch -c Cfeature/topic",
+    "git switch -cmfeature/topic",
+    "git merge-tree --write-tree main feature/topic",
+    "git fetch origin main",
+    "git fetch --all --tags",
+    "git fetch --filter=blob:none origin main",
+    "git fetch --filter blob:none origin main",
+    "git fetch -j4 origin main",
+    "git fetch https://github.com/example/repo.git main",
+    "git fetch git@github.com:example/repo.git main",
+    "git fetch git+ssh://github.com/example/repo.git main",
+    "git fetch ssh+git://github.com/example/repo.git main",
+    "git fetch --multiple origin upstream",
+    "git commit -m 'sandboxed commit'",
+    "git commit -m ':(fix parser)'",
+    "git commit -am ':(fix parser)'",
+    "git commit --message ':(fix parser)'",
+    "git commit -m --amend",
+    "git commit --allow-empty -m 'sandboxed commit'",
+    "git commit -m message -- --amend",
+    "git add src/parser.ts",
+    "git add -- -force",
+  ])("mechanically allows a concrete selected command: %s", (command) => {
+    expect(evaluateCommand(command, rules, sandboxed).verdict).toBe("allow");
+    expect(
+      evaluateCommandWithAudit(command, rules, sandboxed).audit.basis,
+    ).toBe("sandbox-git-allow");
+    expect(evaluateCommand(command, rules).verdict).toBe("default-continue");
+  });
+
+  test.each([
+    "git fetch --force origin main",
+    "git fetch -fp origin main:main",
+    "git fetch --for origin main",
+    "git fetch --stdin origin",
+    String.raw`printf '%s\n' '+refs/heads/main:refs/remotes/origin/main' | git fetch --stdin origin`,
+    "git fetch --upload-pack=/tmp/helper ssh://host/repo",
+    "git fetch --upload-pack /tmp/helper . HEAD",
+    "git fetch -u origin main:main",
+    "git fetch --server-option=execute-this origin main",
+    "git fetch custom://payload",
+    "git fetch --multiple custom://payload origin",
+    "git fetch --prune origin",
+    "git fetch --refmap=refs/heads/*:refs/remotes/origin/* origin",
+    "git fetch --update-head-ok origin main:main",
+    "git fetch origin main:refs/notes/review",
+    "git fetch --filter blob:none origin main:refs/notes/review",
+    "git fetch git@github.com:example/repo.git main:refs/notes/review",
+    "git switch --force main",
+    "git switch --discard-changes main",
+    "git switch -C main HEAD~5",
+    "git switch --force-create main HEAD~5",
+    "git switch --orphan scratch",
+    "git switch -m main",
+    "git switch --merge main",
+    "git switch --conflict=diff3 main",
+    "git switch --ignore-other-worktrees main",
+    "git commit --amend -m message",
+    "git commit -m -- --amend",
+    "git commit --message -- --amend",
+    "git commit --pathspec-from-file=paths.txt -m message",
+    "git commit -m message -- ':(glob)*.ts'",
+    "git merge --abort",
+    "git merge --quit",
+    "git merge -m -- --abort",
+    "git merge --message -- --quit",
+    "git add -f .env",
+    "git add --force secrets.pem",
+    "git add --pathspec-from-file=paths.txt",
+    "git add -- ':(glob)*.ts'",
+    "git add ../../outside.txt",
+    "git show HEAD:.ssh/id_ed25519",
+    "git show --all -- ':(top).ssh/id_ed25519'",
+    "git show -- ':(glob)*.ts'",
+    "git log -p -- .ssh/id_ed25519",
+    "git log -p -- ':(glob)*.ts'",
+    "git log -p ':(glob)*.ts'",
+    "git log --grep needle ':(glob)*.ts'",
+    "git --git-dir=/tmp/repo/.git status --short",
+    "git -c core.hooksPath=/tmp/hooks commit -m message",
+    "git --future-option status --short",
+  ])("preserves a higher-priority deterministic ASK: %s", (command) => {
+    expect(evaluateCommand(command, rules, sandboxed).verdict).toBe("ask");
+  });
+
+  test.each([
+    "/usr/bin/git status --short",
+    "sudo git status --short",
+    "git checkout -b Branch HEAD",
+    'git add "$path"',
+    String.raw`git $'status' --short`,
+    "git log --textconv -1",
+    "git show --ext-diff HEAD",
+    "git show --output=show.txt HEAD",
+    "git status --help",
+    "git commit --help",
+    "git show --ext-diff HEAD > show.txt",
+    "git status --short &",
+    "git status --short && echo done",
+  ])("keeps an indirect or non-concrete shape residual: %s", (command) => {
+    expect(evaluateCommand(command, rules, sandboxed).verdict).toBe(
+      "default-continue",
+    );
+  });
+
+  test.each([
+    "git log --textconv -1",
+    "git show --ext-diff HEAD",
+    "git show --output=show.txt HEAD",
+    "git status --help",
+    "git commit --help",
+  ])(
+    "keeps Git helper/output execution on the sandbox judge route: %s",
+    (command) => {
+      expect(evaluateCommandWithAudit(command, rules, sandboxed)).toEqual({
+        verdict: "default-continue",
+        audit: expect.objectContaining({ basis: "sandbox-residual" }),
+      });
+    },
+  );
+
+  test("allows a compound command only when every segment is selected", () => {
+    expect(
+      evaluateCommand(
+        "git status --short && git show --stat HEAD",
+        rules,
+        sandboxed,
+      ).verdict,
+    ).toBe("allow");
+  });
+
+  test("lets a configured ASK override the sandbox Git allow", () => {
+    const askRules = loadRules(
+      String.raw`{"deny":[],"allow":[],"ask":[{"pattern":"^git\\s+status\\b","reason":"confirm status"}]}`,
+    );
+    expect(evaluateCommand("git status --short", askRules, sandboxed)).toEqual({
+      verdict: "ask",
+      reason: "confirm status",
+    });
+  });
+});
+
+describe("expanded sandbox-only mechanical classification", () => {
+  const rules = loadRules('{"deny":[],"allow":[],"ask":[]}');
+  const sandboxed = { effectSandboxed: true } as const;
+
+  test.each([
+    "git diff --check",
+    "git diff --quiet --exit-code",
+    "git diff --stat -- src/parser.ts",
+    "git rev-parse --show-toplevel",
+    "git merge-base --is-ancestor main HEAD",
+    "git ls-files --cached -- src",
+    "git ls-tree --name-only HEAD",
+    "git show-ref --verify refs/heads/main",
+    "git for-each-ref --format='%(refname)' refs/heads",
+    "git describe --always HEAD",
+    "git name-rev --name-only HEAD",
+    "git rev-list --count main",
+    "git branch --show-current",
+    "git branch --list main",
+    "git branch --list -- --list",
+    "git worktree list --porcelain",
+    "git remote",
+    "git stash list --oneline",
+    "git stash show --stat stash@{0}",
+    "git tag --list v1.0.0",
+    "git tag --list -- --list",
+  ])("allows a concrete expanded Git read: %s", (command) => {
+    expect(evaluateCommandWithAudit(command, rules, sandboxed)).toEqual({
+      verdict: "allow",
+      audit: expect.objectContaining({ basis: "sandbox-git-allow" }),
+    });
+    expect(evaluateCommand(command, rules).verdict).not.toBe("allow");
+  });
+
+  test.each([
+    "git diff --no-index left right",
+    "git diff --future-option",
+    "git rev-parse --parseopt",
+    "git for-each-ref --stdin",
+    "git name-rev --stdin",
+    "git rev-list --stdin",
+    "git branch feature/new",
+    "git branch -- --list",
+    "git branch --list --contains --delete victim",
+    "git branch --color victim",
+    "git tag --color -f --column existing",
+    "git remote -v",
+    "git remote get-url origin",
+    "git stash pop",
+    "git tag v1.0.0",
+    "git tag -- --list",
+    "git tag --list --contains --delete v1.0.0",
+    "git tag --color victim",
+    "git worktree add /tmp/unverified",
+    "git worktree remove /tmp/worktree",
+    "git pull --ff-only",
+    "git pull --ff-only --no-rebase --no-autostash origin main",
+    "git pull --ff-only --no-rebase https://github.com/example/repo.git main",
+    "git pull --ff-only --no-rebase --no-autostash https://github.com/example/repo.git main",
+  ])(
+    "keeps an unsafe or unproven expanded Git form off ALLOW: %s",
+    (command) => {
+      expect(evaluateCommand(command, rules, sandboxed).verdict).not.toBe(
+        "allow",
+      );
+    },
+  );
+
+  test("separates verified git -C read and mutation capabilities", async () => {
+    const base = await mkdtemp(join(tmpdir(), "sandbox-git-c-expanded-"));
+    const active = join(base, "active");
+    const sibling = join(base, "sibling");
+    const createRoot = join(base, "managed");
+    const newWorktree = join(createRoot, "feature");
+    await mkdir(active);
+    await mkdir(sibling);
+    await mkdir(createRoot);
+    try {
+      const canonicalActive = realpathSync(active);
+      const canonicalSibling = realpathSync(sibling);
+      const canonicalCreateRoot = realpathSync(createRoot);
+      const context = {
+        cwd: canonicalActive,
+        navigableRoots: [canonicalActive, canonicalSibling],
+      };
+      const activeOptions = {
+        effectSandboxed: true,
+        trustedGitCwdTarget: canonicalActive,
+        trustedReadContext: context,
+        trustedWritableWorktrees: [canonicalActive],
+        trustedWorktreeCreateRoots: [canonicalCreateRoot],
+      } as const;
+      expect(
+        evaluateCommand(
+          `git -C ${canonicalActive} rev-parse HEAD`,
+          rules,
+          activeOptions,
+        ).verdict,
+      ).toBe("allow");
+      expect(
+        evaluateCommand(
+          `git -C ${canonicalActive} commit -m message`,
+          rules,
+          activeOptions,
+        ).verdict,
+      ).toBe("allow");
+      expect(
+        evaluateCommand(
+          `git -C ${canonicalActive} worktree add -b feature/new ${newWorktree}`,
+          rules,
+          activeOptions,
+        ).verdict,
+      ).toBe("allow");
+      expect(
+        evaluateCommand(
+          `git worktree lock ${canonicalActive}`,
+          rules,
+          activeOptions,
+        ).verdict,
+      ).toBe("allow");
+      expect(
+        evaluateCommand(
+          `git worktree unlock ${canonicalActive}`,
+          rules,
+          activeOptions,
+        ).verdict,
+      ).toBe("allow");
+
+      const siblingOptions = {
+        ...activeOptions,
+        trustedGitCwdTarget: canonicalSibling,
+      } as const;
+      expect(
+        evaluateCommand(
+          `git -C ${canonicalSibling} rev-parse HEAD`,
+          rules,
+          siblingOptions,
+        ).verdict,
+      ).toBe("allow");
+      expect(
+        evaluateCommand(
+          `git -C ${canonicalSibling} status --short`,
+          rules,
+          siblingOptions,
+        ).verdict,
+      ).toBe("allow");
+      expect(
+        evaluateCommand(
+          `git -C ${canonicalSibling} commit -m message`,
+          rules,
+          siblingOptions,
+        ).verdict,
+      ).not.toBe("allow");
+      const siblingLeadingCdOptions = {
+        ...activeOptions,
+        trustedLeadingCdTarget: canonicalSibling,
+        trustedReadContext: {
+          ...context,
+          cwd: canonicalSibling,
+        },
+      } as const;
+      expect(
+        evaluateCommand(
+          `cd ${canonicalSibling} && git commit -m message`,
+          rules,
+          siblingLeadingCdOptions,
+        ).verdict,
+      ).not.toBe("allow");
+      expect(
+        evaluateCommand(
+          `git worktree add --force ${newWorktree}`,
+          rules,
+          activeOptions,
+        ).verdict,
+      ).not.toBe("allow");
+      expect(
+        evaluateCommand(
+          `git worktree add -B main ${newWorktree}`,
+          rules,
+          activeOptions,
+        ).verdict,
+      ).not.toBe("allow");
+      expect(
+        evaluateCommand(
+          `git worktree add ${join(base, "outside")}`,
+          rules,
+          activeOptions,
+        ).verdict,
+      ).not.toBe("allow");
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  test("requires verified scope and preserves configured ASK for project readers", () => {
+    const cwd = realpathSync(resolve(import.meta.dir, "../.."));
+    expect(evaluateCommand("pwd -P", rules, sandboxed).verdict).not.toBe(
+      "allow",
+    );
+    expect(
+      evaluateCommand("cat package.json", rules, sandboxed).verdict,
+    ).not.toBe("allow");
+    const askRules = loadRules(
+      String.raw`{"deny":[],"allow":[],"ask":[{"pattern":"^cat\\s","reason":"confirm cat"}]}`,
+    );
+    expect(
+      evaluateCommand("cat package.json", askRules, {
+        effectSandboxed: true,
+        trustedReadContext: { cwd, navigableRoots: [cwd] },
+      }),
+    ).toEqual({ verdict: "ask", reason: "confirm cat" });
+  });
+
+  test("allows path-free project readers and keeps pathname reads residual", async () => {
+    const base = await mkdtemp(join(tmpdir(), "sandbox-project-readers-"));
+    const project = join(base, "project");
+    const outside = join(base, "outside.txt");
+    const source = join(project, "source.txt");
+    const data = join(project, "data.json");
+    const hidden = join(project, ".env");
+    const credentials = join(project, "credentials.json");
+    const privateKey = join(project, "server.key");
+    const insideLink = join(project, "inside-link");
+    const outsideLink = join(project, "outside-link");
+    const dashLink = join(project, "-");
+    await mkdir(project);
+    await writeFile(source, "needle\n");
+    await writeFile(data, '{"name":"demo","env":"field"}\n');
+    await writeFile(hidden, "SECRET=value\n");
+    await writeFile(credentials, '{"token":"secret"}\n');
+    await writeFile(privateKey, "private key\n");
+    await writeFile(outside, "outside\n");
+    await symlink(source, insideLink);
+    await symlink(outside, outsideLink);
+    await symlink(outside, dashLink);
+    const options = {
+      effectSandboxed: true,
+      trustedReadContext: {
+        cwd: project,
+        navigableRoots: [realpathSync(project)],
+      },
+    } as const;
+    try {
+      for (const command of ["pwd -P", "jq -n '1 + 1'"]) {
+        expect(evaluateCommandWithAudit(command, rules, options)).toEqual({
+          verdict: "allow",
+          audit: expect.objectContaining({ basis: "sandbox-read-allow" }),
+        });
+        expect(evaluateCommand(command, rules).verdict).not.toBe("allow");
+      }
+
+      expect(
+        evaluateCommand("pwd && cat source.txt", rules, options).verdict,
+      ).not.toBe("allow");
+      const writableOptions = {
+        ...options,
+        trustedWritableWorktrees: [realpathSync(project)],
+      };
+      expect(
+        evaluateCommand("git switch attacker", rules, writableOptions).verdict,
+      ).toBe("allow");
+      expect(
+        evaluateCommand(
+          "git switch attacker && cat source.txt",
+          rules,
+          writableOptions,
+        ).verdict,
+      ).not.toBe("allow");
+      expect(
+        evaluateCommand("git status && cat source.txt", rules, options).verdict,
+      ).not.toBe("allow");
+
+      for (const command of [
+        "ls -la .",
+        "stat source.txt",
+        "readlink inside-link",
+        "realpath source.txt",
+        "cat source.txt",
+        "head -n 1 source.txt",
+        "tail -n 1 source.txt",
+        "wc -l source.txt",
+        "grep -n needle source.txt",
+        "grep --color=never needle source.txt",
+        "jq '.name' data.json",
+        "jq '.env' data.json",
+        "ls -H -- -",
+        "ls -R .",
+        "ls -L .",
+        "cat .env",
+        "cat credentials.json",
+        "cat server.key",
+        "jq . credentials.json",
+        "cat outside-link",
+        `cat ${outside}`,
+        "cat ../outside.txt",
+        "cat .",
+        "grep needle .",
+        "grep -R needle .",
+        "grep -ne needle /etc/passwd",
+        "grep --color needle /etc/passwd",
+        "grep --recursive needle .",
+        "jq -n env",
+        "jq -n '$ENV'",
+        `jq -n '"\\(env)"'`,
+        `jq -n '"\\($ENV)"'`,
+        "jq 'include \"module\"' data.json",
+        "jq --rawfile secret .env '.name' data.json",
+        "cat source.txt > copy.txt",
+        `cat ${Array.from({ length: 65 }, () => "source.txt").join(" ")}`,
+      ]) {
+        expect(evaluateCommand(command, rules, options).verdict).not.toBe(
+          "allow",
+        );
+      }
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
   });
 });
 

--- a/tests/pi-harness/permission-sandbox-git-allow.test.ts
+++ b/tests/pi-harness/permission-sandbox-git-allow.test.ts
@@ -1,0 +1,389 @@
+import { describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+import {
+  DEFAULT_PERMISSION_JUDGE_CONFIG,
+  type HarnessConfig,
+} from "../../pi/extensions/pi-harness/config";
+import setupPermissionPolicy from "../../pi/extensions/pi-harness/features/permission-policy";
+import type { PermissionAuditIntegration } from "../../pi/extensions/pi-harness/features/permission-audit";
+import type { PermissionAuditStage } from "../../pi/extensions/pi-harness/features/permission-audit/model";
+import type { PermissionProjectContext } from "../../pi/extensions/pi-harness/features/permission-policy/context";
+import { resolvePaths } from "../../pi/extensions/pi-harness/lib/paths";
+import type { ToolCallEvent } from "../../pi/extensions/pi-harness/lib/pi-like";
+import { createFakePi } from "./fake-pi";
+
+const JUDGE_SENTINEL = "test judge must not be reached";
+
+const config: HarnessConfig = {
+  isChild: false,
+  features: {
+    "hook-bridge": true,
+    subagent: true,
+    workflow: true,
+    "bit-task": true,
+    statusline: true,
+    "provider-log": false,
+    "asuku-notify": true,
+    "ask-user-question": true,
+  },
+  trust: { trustedRoots: [] },
+  paths: resolvePaths("/tmp/pi-sandbox-git-allow-test"),
+  permissionJudge: {
+    ...DEFAULT_PERMISSION_JUDGE_CONFIG,
+    configurationError: JUDGE_SENTINEL,
+  },
+};
+
+const REPOSITORY_CWD = resolve(import.meta.dir, "../..");
+
+const executionBoundary = (toolName: string) => ({
+  mode:
+    toolName === "bash_escalated"
+      ? ("escalated" as const)
+      : ("sandboxed" as const),
+  network: "allowlisted" as const,
+  profileFingerprint: "b".repeat(64),
+  ...(toolName === "bash_escalated"
+    ? {}
+    : {
+        writableWorktrees: [REPOSITORY_CWD],
+        worktreeCreateRoots: [resolve(REPOSITORY_CWD, "..")],
+      }),
+});
+
+const verifiedProject = (cwd: string): PermissionProjectContext => ({
+  kind: "git",
+  name: "dotfiles",
+  cwd,
+  activeWorktree: cwd,
+  navigableRoots: [cwd],
+  worktrees: [cwd],
+  fingerprint: `project:${cwd}`,
+});
+
+const captureAuditStages = () => {
+  const stages: { toolCallId: string; stage: PermissionAuditStage }[] = [];
+  const integration: PermissionAuditIntegration = {
+    lineageId: "sandbox-git-allow-test",
+    addStage(toolCallId, stage) {
+      stages.push({ toolCallId, stage });
+    },
+    updateContext() {},
+    async finalizeBlock() {
+      return true;
+    },
+    registerTail() {},
+    childEnvironment() {
+      return {};
+    },
+  };
+  return { integration, stages };
+};
+
+const bashCall = (command: string, id: string): ToolCallEvent => ({
+  type: "tool_call",
+  toolName: "bash",
+  toolCallId: id,
+  input: { command },
+});
+
+const escalatedCall = (command: string, id: string): ToolCallEvent => ({
+  type: "tool_call",
+  toolName: "bash_escalated",
+  toolCallId: id,
+  input: { command },
+});
+
+describe("sandbox Git deterministic allow routing", () => {
+  test("bypasses the local judge for every selected command", async () => {
+    const cwd = resolve(import.meta.dir, "../..");
+    const pi = createFakePi({ cwd, hasUI: false });
+    const audit = captureAuditStages();
+    let discoveries = 0;
+    setupPermissionPolicy(pi, config, {
+      executionBoundary,
+      permissionAudit: audit.integration,
+      discoverProject: async () => {
+        discoveries += 1;
+        return verifiedProject(cwd);
+      },
+    });
+
+    const commands = [
+      "git status --short --branch",
+      "git show --stat HEAD",
+      "git log -1 --oneline",
+      "git diff --check",
+      "git rev-parse --show-toplevel",
+      "git merge-base main HEAD",
+      "git ls-files --cached",
+      "git ls-tree --name-only HEAD",
+      "git show-ref --head",
+      "git for-each-ref --format='%(refname)' refs/heads",
+      "git describe --always HEAD",
+      "git name-rev --name-only HEAD",
+      "git rev-list --count main",
+      "git branch --show-current",
+      "git worktree list --porcelain",
+      "git remote",
+      "git stash list --oneline",
+      "git tag --list v1.0.0",
+      "git merge --no-edit feature/topic",
+      "git switch feature/topic",
+      "git merge-tree --write-tree main feature/topic",
+      "git fetch origin main",
+      "git commit -m 'sandboxed commit'",
+      "git add src/parser.ts",
+    ];
+    for (const [index, command] of commands.entries()) {
+      expect(
+        await pi.emitToolCall(bashCall(command, `sandbox-git-${index}`)),
+      ).toBeUndefined();
+    }
+
+    expect(discoveries).toBe(6);
+    expect(
+      audit.stages.filter(({ stage }) => stage.type === "judge"),
+    ).toHaveLength(0);
+    expect(
+      audit.stages.filter(
+        ({ stage }) =>
+          stage.type === "deterministic" &&
+          stage.reasonCode === "sandbox-git-allow",
+      ),
+    ).toHaveLength(commands.length);
+  });
+
+  test("retains deterministic confirmation for dangerous variants", async () => {
+    const cwd = resolve(import.meta.dir, "../..");
+    const pi = createFakePi({ cwd, hasUI: false });
+    const audit = captureAuditStages();
+    setupPermissionPolicy(pi, config, {
+      executionBoundary,
+      permissionAudit: audit.integration,
+      discoverProject: async () => verifiedProject(cwd),
+    });
+
+    const commands = [
+      "git fetch --force origin main",
+      "git fetch -fp origin main:main",
+      "git fetch --stdin origin",
+      "git fetch --upload-pack=/tmp/helper . HEAD",
+      "git fetch custom://payload",
+      "git fetch origin main:refs/notes/review",
+      "git switch --force main",
+      "git switch -C main HEAD~5",
+      "git switch --merge main",
+      "git commit --amend -m message",
+      "git commit --pathspec-from-file=paths.txt -m message",
+      "git merge --abort",
+      "git add -f .env",
+      "git add --pathspec-from-file=paths.txt",
+      "git add ../../outside.txt",
+      "git show HEAD:.ssh/id_ed25519",
+      "git show --all -- ':(top).ssh/id_ed25519'",
+      "git --git-dir=/tmp/unrelated/.git status --short",
+    ];
+    for (const [index, command] of commands.entries()) {
+      expect(
+        await pi.emitToolCall(bashCall(command, `dangerous-git-${index}`)),
+      ).toEqual({ block: true, reason: expect.any(String) });
+    }
+
+    expect(
+      audit.stages.filter(({ stage }) => stage.type === "judge"),
+    ).toHaveLength(0);
+  });
+
+  test("bypasses the judge for verified path-free project readers", async () => {
+    const cwd = resolve(import.meta.dir, "../..");
+    const pi = createFakePi({ cwd, hasUI: false });
+    const audit = captureAuditStages();
+    let discoveries = 0;
+    setupPermissionPolicy(pi, config, {
+      executionBoundary,
+      permissionAudit: audit.integration,
+      discoverProject: async () => {
+        discoveries += 1;
+        return verifiedProject(cwd);
+      },
+    });
+
+    const commands = ["pwd -P", "jq -n '1 + 1'"];
+    for (const [index, command] of commands.entries()) {
+      expect(
+        await pi.emitToolCall(bashCall(command, `sandbox-reader-${index}`)),
+      ).toBeUndefined();
+    }
+
+    expect(discoveries).toBe(commands.length);
+    expect(
+      audit.stages.filter(({ stage }) => stage.type === "judge"),
+    ).toHaveLength(0);
+    expect(
+      audit.stages.filter(
+        ({ stage }) =>
+          stage.type === "deterministic" &&
+          stage.reasonCode === "sandbox-read-allow",
+      ),
+    ).toHaveLength(commands.length);
+  });
+
+  test("requires verified writable capabilities for git -C and worktree lifecycle", async () => {
+    const cwd = resolve(import.meta.dir, "../..");
+    const pi = createFakePi({ cwd, hasUI: false });
+    const audit = captureAuditStages();
+    let discoveries = 0;
+    setupPermissionPolicy(pi, config, {
+      executionBoundary,
+      permissionAudit: audit.integration,
+      discoverProject: async () => {
+        discoveries += 1;
+        return {
+          ...verifiedProject(cwd),
+          leadingNavigation: {
+            scope: "listed-worktree" as const,
+            sameRepository: true,
+          },
+        };
+      },
+    });
+
+    const target = resolve(cwd, "../sandbox-worktree-new");
+    const commands = [
+      `git -C ${cwd} rev-parse HEAD`,
+      `git -C ${cwd} commit -m message`,
+      `git worktree add -b feature/sandbox ${target}`,
+      `git worktree lock ${cwd}`,
+      `git worktree unlock ${cwd}`,
+    ];
+    for (const [index, command] of commands.entries()) {
+      expect(
+        await pi.emitToolCall(bashCall(command, `sandbox-worktree-${index}`)),
+      ).toBeUndefined();
+    }
+
+    expect(discoveries).toBe(commands.length);
+    expect(
+      audit.stages.filter(({ stage }) => stage.type === "judge"),
+    ).toHaveLength(0);
+    expect(
+      audit.stages.filter(
+        ({ stage }) =>
+          stage.type === "deterministic" &&
+          stage.reasonCode === "sandbox-git-allow",
+      ),
+    ).toHaveLength(commands.length);
+  });
+
+  test("keeps unproven reader and Git modes on the judge route", async () => {
+    const cwd = resolve(import.meta.dir, "../..");
+    const pi = createFakePi({ cwd, hasUI: false });
+    const audit = captureAuditStages();
+    setupPermissionPolicy(pi, config, {
+      executionBoundary,
+      permissionAudit: audit.integration,
+      discoverProject: async () => verifiedProject(cwd),
+    });
+
+    const commands = [
+      "git branch -- --list",
+      "git tag -- --list",
+      "git remote -v",
+      "git pull --ff-only",
+      "git pull --ff-only --no-rebase --no-autostash https://github.com/example/repo.git main",
+      "ls -la .",
+      "stat package.json",
+      "cat package.json",
+      "grep -n scripts package.json",
+      "jq '.scripts' package.json",
+      "cat .env",
+      "grep -R token .",
+      "jq -n env",
+      `jq -n '"\\(env)"'`,
+    ];
+    for (const [index, command] of commands.entries()) {
+      expect(
+        await pi.emitToolCall(bashCall(command, `sandbox-residual-${index}`)),
+      ).toEqual({
+        block: true,
+        reason: expect.stringContaining(JUDGE_SENTINEL),
+      });
+    }
+    expect(
+      audit.stages.filter(
+        ({ stage }) =>
+          stage.type === "judge" && stage.outcome === "unavailable",
+      ),
+    ).toHaveLength(commands.length);
+  });
+
+  test("does not bypass verified-project or sandbox boundaries", async () => {
+    const cwd = resolve(import.meta.dir, "../..");
+    const unavailable = createFakePi({ cwd, hasUI: false });
+    setupPermissionPolicy(unavailable, config, {
+      executionBoundary,
+      discoverProject: async () => ({
+        kind: "unavailable",
+        cwd,
+        reason: "test discovery failure",
+        fingerprint: "project:unavailable",
+      }),
+    });
+
+    expect(
+      await unavailable.emitToolCall(
+        bashCall("git commit -m message", "unavailable-project"),
+      ),
+    ).toEqual({
+      block: true,
+      reason: expect.stringContaining(
+        "プロジェクト境界を検証できないため変更コマンドには確認が必要です",
+      ),
+    });
+
+    const unverifiedGitC = createFakePi({ cwd, hasUI: false });
+    setupPermissionPolicy(unverifiedGitC, config, {
+      executionBoundary,
+      discoverProject: async () => ({
+        ...verifiedProject(cwd),
+        leadingNavigation: {
+          scope: "outside-listed-worktrees" as const,
+          sameRepository: false,
+        },
+      }),
+    });
+    expect(
+      await unverifiedGitC.emitToolCall(
+        bashCall("git -C /tmp/unrelated rev-parse HEAD", "unverified-git-c"),
+      ),
+    ).toEqual({
+      block: true,
+      reason: expect.stringContaining(
+        "git -C の対象を登録済みの同一リポジトリworktree内と確認できませんでした",
+      ),
+    });
+
+    const escalated = createFakePi({ cwd, hasUI: false });
+    const audit = captureAuditStages();
+    setupPermissionPolicy(escalated, config, {
+      executionBoundary,
+      permissionAudit: audit.integration,
+      discoverProject: async () => verifiedProject(cwd),
+    });
+    expect(
+      await escalated.emitToolCall(
+        escalatedCall("git status --short", "outside-sandbox"),
+      ),
+    ).toEqual({
+      block: true,
+      reason: expect.stringContaining(JUDGE_SENTINEL),
+    });
+    expect(
+      audit.stages.some(
+        ({ stage }) =>
+          stage.type === "judge" && stage.outcome === "unavailable",
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- expand sandbox-only mechanical ALLOW coverage for proven-safe Git reads, bounded worktree lifecycle operations, and path-free project readers
- propagate verified active, dynamic, and configured worktree capabilities through the Bash sandbox and permission policy
- keep unproven transports, credential-bearing output, pathname readers, unknown syntax, and unsafe mutations on ASK or residual judge routing
- add adversarial classification, routing, sandbox lifecycle, and qualification regressions

## Safety boundaries
- mechanical ALLOW applies only when effectSandboxed is true
- DENY, configured ASK, structural ASK, sensitive-path, project-scope, writable-capability, and concrete-shell checks retain precedence
- optional Git locking is disabled with GIT_OPTIONAL_LOCKS=0

## Validation
- focused suite: 608 pass, 0 fail
- bun run tsc
- bun run lint: 0 errors, 9 unrelated existing warnings
- Prettier, shell lint, check:pi-rules, check:pi-imports, and git diff --check