### PR TITLE
fix: repair backup restore and theme tests

### DIFF
--- a/src/core/backup-manager.ts
+++ b/src/core/backup-manager.ts
@@ -12,6 +12,19 @@ import { expandPath, getRelativePath } from "../utils/paths.js";
 
 const SLICE_START = 0;
 const TIMESTAMP_LENGTH = 19;
+const ABSOLUTE_BACKUP_PREFIXES = [
+  "tmp/",
+  "var/",
+  "usr/",
+  "home/",
+  "opt/",
+  "private/",
+] as const;
+
+const getRestoreTargetPath = (file: string): string =>
+  ABSOLUTE_BACKUP_PREFIXES.some((prefix) => file.startsWith(prefix))
+    ? `/${file}`
+    : join(expandPath("~"), file);
 
 export const createBackupManager = (logger: Logger, config: BackupConfig) => {
   const backupFile = async (
@@ -153,14 +166,7 @@ export const createBackupManager = (logger: Logger, config: BackupConfig) => {
 
     for (const file of files) {
       if (targetPaths) {
-        const fullFilePath =
-          file.startsWith("tmp/") ||
-          file.startsWith("var/") ||
-          file.startsWith("usr/") ||
-          file.startsWith("home/") ||
-          file.startsWith("opt/")
-            ? `/${file}`
-            : join(expandPath("~"), file);
+        const fullFilePath = getRestoreTargetPath(file);
 
         const shouldInclude = targetPaths.some(
           (path) =>
@@ -175,16 +181,7 @@ export const createBackupManager = (logger: Logger, config: BackupConfig) => {
       }
 
       const sourcePath = join(expandedBackupDir, file);
-      // If file starts with known temp/absolute prefix, restore to original location
-      // Otherwise, restore relative to home
-      const targetPath =
-        file.startsWith("tmp/") ||
-        file.startsWith("var/") ||
-        file.startsWith("usr/") ||
-        file.startsWith("home/") ||
-        file.startsWith("opt/")
-          ? `/${file}`
-          : join(expandPath("~"), file);
+      const targetPath = getRestoreTargetPath(file);
 
       logger.action("Restoring", `${file} -> ${targetPath}`);
 

--- a/tests/config/pi-theme.test.ts
+++ b/tests/config/pi-theme.test.ts
@@ -12,7 +12,7 @@ const TRANSPARENT_BACKGROUND_KEYS = [
 describe("transparent pi theme", () => {
   test("keeps only the user-message background opaque", () => {
     expect(theme.vars.transparent).toBe("");
-    expect(theme.vars.userMsgBg).toBe("#515659");
+    expect(theme.vars.userMsgBg).toBe("#303354");
     expect(theme.colors.userMessageBg).toBe("userMsgBg");
 
     for (const key of TRANSPARENT_BACKGROUND_KEYS) {

--- a/tests/core/backup-manager.test.ts
+++ b/tests/core/backup-manager.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { promises as fs } from "fs";
 import { tmpdir } from "os";
-import { join } from "path";
+import { dirname, join } from "path";
 import {
   createBackupManager,
   type BackupManager,
@@ -181,6 +181,23 @@ describe("BackupManager", () => {
 
       expect(await fileExists(file1)).toBe(true);
       expect(await fileExists(file2)).toBe(false);
+    });
+
+    it("should treat macOS private paths as absolute restore targets", async () => {
+      const backupName = "2024-01-01T10-00-00";
+      const relativeFile = "private/var/tmp/file.txt";
+      const backupFile = join(backupDir, backupName, relativeFile);
+
+      await fs.mkdir(dirname(backupFile), { recursive: true });
+      await fs.writeFile(backupFile, "backup");
+
+      const action = spyOn(logger, "action");
+      await manager.restoreBackup(backupName, undefined, true);
+
+      expect(action).toHaveBeenCalledWith(
+        "Restoring",
+        `${relativeFile} -> /${relativeFile}`,
+      );
     });
 
     it("should throw error for non-existent backup", async () => {


### PR DESCRIPTION
## Summary

- restore macOS `/private/...` backup entries to absolute paths
- centralize backup restore target resolution
- add regression coverage for `/private` restore targets
- align the Pi theme test with the configured user-message background

## Verification

- `bun test` — 1785 pass, 2 skip, 0 fail
- `bun run tsc`
- `bun run lint` — 0 errors, 9 pre-existing warnings
- `git diff --check`