### PR TITLE
feat(pi): kill child sessions from TUI

### DIFF
--- a/pi/extensions/pi-harness/features/child-runs/README.md
+++ b/pi/extensions/pi-harness/features/child-runs/README.md
@@ -49,14 +49,18 @@ uses one `belowEditor` widget and one focus owner for both sources.
   hidden browser. A new child run or either explicit browser command shows it
   again.
 - In the resident list, Up/Down, `j`/`k`, and PageUp/PageDown select across both
-  row kinds. Enter or Right opens the selected child or issue. `r` refreshes
-  open issues without polling or relay-backed watch behavior.
+  row kinds. Enter or Right opens the selected child or issue. `x` aborts the
+  selected active child invocation; parallel, chain, and workflow siblings in
+  that invocation stop together. Completed children and issue rows remain
+  unchanged. `r` refreshes open issues without polling or relay-backed watch
+  behavior.
 - Child and issue details use the same focused, zero-margin full-terminal
   overlay, covering the resident panes in both dimensions. PageUp/PageDown move
   by a viewport, Home/End jump to the ends, and Escape, Left, `b`, or `q` closes
-  the overlay and returns to the list. Child details retain live-follow
-  behavior. Transcript text, issue bodies, and comments use the theme's primary
-  `text` color rather than the secondary tool-output color.
+  the overlay and returns to the list. Child details retain live-follow behavior
+  and accept the same `x` kill action while the invocation is active. Transcript
+  text, issue bodies, and comments use the theme's primary `text` color rather
+  than the secondary tool-output color.
 - Issue detail is loaded lazily with `bit issue get <id> --format json`, then
   bounded raw output from `bit issue comment list <id>`. It shows metadata,
   labels, body, and comments read-only. Human-readable comment output is not
@@ -65,7 +69,9 @@ uses one `belowEditor` widget and one focus owner for both sources.
   live-follow mode; scrolling upward pauses follow until End is pressed.
 - The normal subagent/workflow tool row remains a compact status summary.
 
-Closing, hiding, or unfocusing the browser never cancels child execution.
+Closing, hiding, or unfocusing the browser never cancels child execution. Only
+an explicit `x` on an active child requests termination, records
+`user-killed`, and preserves normal persistence and parent completion delivery.
 Issue refresh also runs after the agent settles, when the panel gains focus,
 on explicit refresh, and immediately before issue detail loading. Refresh is
 single-flight and session-generation guarded; failures retain a stale
@@ -179,5 +185,8 @@ raw source data.
    hidden; then run `/subagents` or `/bit-issues` and confirm it reappears.
 9. With the private focus capability disabled in a test runtime, confirm Down
    remains native and `/subagents` opens/closes the public overlay fallback.
-10. Resume the parent session and confirm completed transcripts open from the
+10. Start a disposable child invocation, select one of its rows, press `x`, and
+    confirm every active sibling in that invocation changes to `user-killed`
+    after SIGTERM/SIGKILL cleanup while a completion reaches the parent.
+11. Resume the parent session and confirm completed transcripts open from the
     beginning and remain scrollable within the documented retention bounds.

--- a/pi/extensions/pi-harness/features/child-runs/background.ts
+++ b/pi/extensions/pi-harness/features/child-runs/background.ts
@@ -44,6 +44,18 @@ export interface BackgroundSchedule {
   run(signal: AbortSignal): Promise<BackgroundWorkResult>;
 }
 
+export type ChildRunKillResult =
+  | {
+      status: "requested";
+      invocationId: string;
+      affectedRuns: number;
+    }
+  | { status: "not-found" }
+  | {
+      status: "not-active" | "already-requested";
+      invocationId: string;
+    };
+
 interface AbortControllerLike {
   signal: AbortSignal;
   abort(): void;
@@ -408,6 +420,30 @@ export class BackgroundInvocationManager {
 
   hasActiveInvocations(): boolean {
     return this.records.size > 0;
+  }
+
+  killInvocationForRun(runId: string): ChildRunKillResult {
+    const invocationId = this.registry.getInvocationIdForRun(runId);
+    if (invocationId === undefined) return { status: "not-found" };
+
+    const record = this.records.get(invocationId);
+    if (record === undefined) return { status: "not-active", invocationId };
+    if (isAborted(record.controller.signal)) {
+      return { status: "already-requested", invocationId };
+    }
+
+    const activeRunIds = this.registry.getNonTerminalRunIds(invocationId);
+    if (activeRunIds.length === 0) {
+      return { status: "not-active", invocationId };
+    }
+    record.abortRunIds = activeRunIds;
+    record.abortReason = "user-killed";
+    record.controller.abort();
+    return {
+      status: "requested",
+      invocationId,
+      affectedRuns: activeRunIds.length,
+    };
   }
 
   async acquireChildSlot(signal?: AbortSignal): Promise<() => void> {

--- a/pi/extensions/pi-harness/features/child-runs/index.ts
+++ b/pi/extensions/pi-harness/features/child-runs/index.ts
@@ -146,6 +146,7 @@ const setupChildRuns = (
     : undefined;
   let activeContext: RuntimeContextLike | undefined;
   let lastExplicitWarning: string | undefined;
+  let panel: ChildRunsPanelController;
   const refreshBitIssues = async (
     ctx: RuntimeContextLike,
     explicit = false,
@@ -169,12 +170,6 @@ const setupChildRuns = (
       }
     }
   };
-  const panel = new ChildRunsPanelController(registry, {
-    bitIssues,
-    refreshBitIssues: async () => {
-      if (activeContext !== undefined) await refreshBitIssues(activeContext);
-    },
-  });
   const invalidateHearthCaches = async (): Promise<void> => {
     const pending: Promise<void>[] = [];
     runtime.events?.emit(HEARTH_INVALIDATE_REQUEST, {
@@ -225,6 +220,16 @@ const setupChildRuns = (
             : { drainTimeoutMs: options.backgroundDrainTimeoutMs },
         )
       : undefined;
+  panel = new ChildRunsPanelController(registry, {
+    bitIssues,
+    refreshBitIssues: async () => {
+      if (activeContext !== undefined) await refreshBitIssues(activeContext);
+    },
+    killRun:
+      background === undefined
+        ? undefined
+        : (runId) => background.killInvocationForRun(runId),
+  });
   const pendingTreeTransitions: PendingTreeTransition[] = [];
   const releaseTreeTransition = (entry: PendingTreeTransition): void => {
     if (entry.released) return;

--- a/pi/extensions/pi-harness/features/child-runs/model.ts
+++ b/pi/extensions/pi-harness/features/child-runs/model.ts
@@ -31,6 +31,7 @@ export type ChildRunTerminalReason =
   | "setup-error"
   | "fail-fast"
   | "parent-abort"
+  | "user-killed"
   | "branch-change"
   | "shutdown"
   | "dependency-failed";

--- a/pi/extensions/pi-harness/features/child-runs/persistence.ts
+++ b/pi/extensions/pi-harness/features/child-runs/persistence.ts
@@ -60,6 +60,7 @@ const terminalReasons: ReadonlySet<string> = new Set([
   "setup-error",
   "fail-fast",
   "parent-abort",
+  "user-killed",
   "branch-change",
   "shutdown",
   "dependency-failed",

--- a/pi/extensions/pi-harness/features/child-runs/registry.ts
+++ b/pi/extensions/pi-harness/features/child-runs/registry.ts
@@ -305,6 +305,10 @@ export class ChildRunRegistry {
     return this.toolCallToInvocation.get(toolCallId);
   }
 
+  getInvocationIdForRun(runId: string): string | undefined {
+    return this.runToInvocation.get(runId);
+  }
+
   getRunIds(invocationId: string): string[] {
     return (
       this.invocations.get(invocationId)?.runs.map((run) => run.runId) ?? []

--- a/pi/extensions/pi-harness/features/child-runs/ui.ts
+++ b/pi/extensions/pi-harness/features/child-runs/ui.ts
@@ -30,6 +30,7 @@ import {
   setFocusSafely,
   type FocusTuiLike,
 } from "./focus-capability";
+import type { ChildRunKillResult } from "./background";
 import { statusIcon, type ComponentLike } from "./presentation";
 import { ChildRunRegistry } from "./registry";
 
@@ -224,6 +225,7 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
     private readonly onHide: () => void,
     private readonly bitIssues?: BitIssueBrowserBindings,
     theme?: unknown,
+    private readonly onKill?: (runId: string) => void,
   ) {
     this.theme = resolveTheme(theme);
     this.unsubscribeChild = registry.subscribe(() => this.requestRender());
@@ -275,6 +277,12 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
     }
     if (data === "r" && this.bitIssues !== undefined) {
       void this.bitIssues.onRefresh();
+      return;
+    }
+    if (data === "x") {
+      if (this.selection?.kind === "child") {
+        this.onKill?.(this.selection.id);
+      }
       return;
     }
     if (this.matches(data, "tui.select.cancel")) {
@@ -634,6 +642,7 @@ export class ChildRunDetailComponent implements ComponentLike {
     private readonly keybindings: KeybindingsLike,
     private readonly onClose: () => void,
     theme?: unknown,
+    private readonly onKill?: (runId: string) => void,
   ) {
     this.theme = resolveTheme(theme);
     const initialStatus = findRun(this.registry.getSnapshots(), this.runId)?.run
@@ -691,9 +700,13 @@ export class ChildRunDetailComponent implements ComponentLike {
     }
     output.push(...visible.map((item) => styledLine(item, safeWidth)));
     if (showHint) {
+      const killHint =
+        selected?.run.status === "queued" || selected?.run.status === "running"
+          ? "x kill  "
+          : "";
       const hint = this.theme.fg(
         "dim",
-        "↑↓ scroll  PgUp/PgDn page  Home/End  Esc/←/b close  ",
+        `↑↓ scroll  PgUp/PgDn page  Home/End  ${killHint}Esc/←/b close  `,
       );
       output.push(
         styledLine(`${hint}${this.theme.fg("muted", position)}`, safeWidth),
@@ -703,6 +716,10 @@ export class ChildRunDetailComponent implements ComponentLike {
   }
 
   handleInput(data: string): void {
+    if (data === "x") {
+      this.onKill?.(this.runId);
+      return;
+    }
     if (
       data === "q" ||
       data === "b" ||
@@ -1101,6 +1118,7 @@ const sameCursor = (
 export interface ChildRunsPanelOptions {
   readonly bitIssues?: BitIssueRegistry;
   readonly refreshBitIssues?: () => void | Promise<unknown>;
+  readonly killRun?: (runId: string) => ChildRunKillResult;
 }
 
 export class ChildRunsPanelController {
@@ -1211,6 +1229,7 @@ export class ChildRunsPanelController {
             () => this.hide(),
             this.bitIssueBindings(),
             theme,
+            (runId) => this.killRun(runId),
           );
           if (preferred !== undefined) component.prefer(preferred);
           this.component = component;
@@ -1275,6 +1294,7 @@ export class ChildRunsPanelController {
             },
             this.bitIssueBindings(),
             theme,
+            (runId) => this.killRun(runId),
           );
           if (preferred !== undefined) component.prefer(preferred);
           if (refreshOnFocus) void this.options.refreshBitIssues?.();
@@ -1342,6 +1362,7 @@ export class ChildRunsPanelController {
             keybindings,
             close,
             theme,
+            (selectedRunId) => this.killRun(selectedRunId),
           );
         },
         {
@@ -1456,6 +1477,34 @@ export class ChildRunsPanelController {
         this.detailClose = undefined;
         this.detailIssueId = undefined;
       });
+  }
+
+  private killRun(runId: string): void {
+    const result = this.options.killRun?.(runId);
+    if (result === undefined) {
+      this.ui?.notify(
+        "Child-session kill is unavailable in this runtime.",
+        "warning",
+      );
+      return;
+    }
+    if (result.status === "requested") {
+      const runs = result.affectedRuns === 1 ? "run" : "runs";
+      this.ui?.notify(
+        `Kill requested for child invocation ${result.invocationId.slice(0, 8)} (${result.affectedRuns} active ${runs}).`,
+        "warning",
+      );
+      return;
+    }
+    if (result.status === "already-requested") {
+      this.ui?.notify("Kill was already requested for this child invocation.");
+      return;
+    }
+    if (result.status === "not-active") {
+      this.ui?.notify("The selected child invocation is no longer active.");
+      return;
+    }
+    this.ui?.notify("The selected child session is no longer available.");
   }
 
   private bitIssueBindings(): BitIssueBrowserBindings | undefined {

--- a/tests/pi-harness/background-child-runs.test.ts
+++ b/tests/pi-harness/background-child-runs.test.ts
@@ -191,6 +191,83 @@ describe("background child-run manager", () => {
     );
   });
 
+  test("kills the selected run's active invocation and reports user-killed", async () => {
+    const { registry, manager, entries, messages } = runtime();
+    const started = registry.beginInvocation({
+      toolCallId: "tool-1",
+      source: "subagent",
+      mode: "parallel",
+      label: "subagent parallel",
+      runs: [
+        { agent: "worker-1", task: "inspect first", taskIndex: 0 },
+        { agent: "worker-2", task: "inspect second", taskIndex: 1 },
+      ],
+    });
+    const [, selectedRunId] = started.runIds;
+    if (selectedRunId === undefined) throw new Error("missing selected run");
+    manager.markAgentStarted();
+    manager.schedule({
+      invocationId: started.invocationId,
+      toolCallId: "tool-1",
+      source: "subagent",
+      run(signal) {
+        for (const runId of started.runIds) {
+          registry.observe(runId, { type: "process_started", at: 1 });
+        }
+        return new Promise((_resolve, reject) => {
+          if (
+            !("addEventListener" in signal) ||
+            typeof signal.addEventListener !== "function"
+          ) {
+            reject(new Error("AbortSignal listener API unavailable"));
+            return;
+          }
+          signal.addEventListener(
+            "abort",
+            () => reject(new Error("killed from TUI")),
+            { once: true },
+          );
+        });
+      },
+    });
+    manager.acknowledgeToolResult("tool-1");
+    await Promise.resolve();
+
+    expect(manager.killInvocationForRun(selectedRunId)).toEqual({
+      status: "requested",
+      invocationId: started.invocationId,
+      affectedRuns: 2,
+    });
+    expect(manager.killInvocationForRun(selectedRunId)).toEqual({
+      status: "already-requested",
+      invocationId: started.invocationId,
+    });
+
+    await manager.drain(started.invocationId);
+    expect(entries).toHaveLength(1);
+    expect(messages).toEqual([]);
+    expect(registry.getInvocation(started.invocationId)?.runs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          status: "aborted",
+          terminalReason: "user-killed",
+        }),
+        expect.objectContaining({
+          status: "aborted",
+          terminalReason: "user-killed",
+        }),
+      ]),
+    );
+    expect(manager.killInvocationForRun(selectedRunId)).toEqual({
+      status: "not-active",
+      invocationId: started.invocationId,
+    });
+
+    manager.markAgentSettled();
+    expect(messages).toHaveLength(1);
+    expect(JSON.stringify(messages[0])).toContain("was aborted");
+  });
+
   test("shutdown awaits settlement invalidation even when notification is suppressed", async () => {
     const invalidationStarted = deferred<void>();
     const invalidated = deferred<void>();

--- a/tests/pi-harness/child-run-integration.test.ts
+++ b/tests/pi-harness/child-run-integration.test.ts
@@ -381,6 +381,7 @@ const controlledSpawn = () => {
     startedResolve = resolve;
   });
   let finished = false;
+  const killSignals: NodeJS.Signals[] = [];
   const spawnFn: SpawnFunction = () => {
     startedResolve();
     return {
@@ -400,7 +401,10 @@ const controlledSpawn = () => {
         if (event === "close") close.push(listener as never);
         return this;
       },
-      kill: () => true,
+      kill: (signal = "SIGTERM") => {
+        killSignals.push(signal);
+        return true;
+      },
       killed: false,
     };
   };
@@ -408,6 +412,7 @@ const controlledSpawn = () => {
     spawnFn,
     started,
     isFinished: () => finished,
+    getKillSignals: () => [...killSignals],
     finish(text: string) {
       finished = true;
       const line = JSON.stringify({
@@ -743,6 +748,59 @@ describe("child-run subagent integration", () => {
     expect(notification).toContain(invocationId);
     expect(notification).toContain("background answer 界");
     expect(notification).toContain("untrusted child output");
+  });
+
+  test("kills a production subagent with x from the child-session browser", async () => {
+    const home = await setupTestDirectory("pi-child-background-tui-kill");
+    tempDirectories.push(home);
+    await writeAgent(home);
+    const runtime = createRuntime(home, { background: true });
+    const childRuns = setupChildRuns(runtime.pi);
+    const controlled = controlledSpawn();
+    setupSubagent(runtime.pi, makeConfig(home), {
+      childRuns,
+      spawnFn: controlled.spawnFn,
+      termGraceMs: 0,
+    });
+    const { background } = childRuns;
+    if (background === undefined) throw new Error("background unavailable");
+    const tool = findTool(runtime.tools, "subagent");
+    await runtime.emit("agent_start", { type: "agent_start" });
+
+    const accepted = (await Reflect.apply(tool.execute, undefined, [
+      "tui-kill-parent",
+      { agent: "worker", task: "wait until killed" },
+      undefined,
+      undefined,
+      runtime.ctx,
+    ])) as { details: { background: { invocationId: string } } };
+    const { invocationId } = accepted.details.background;
+    await controlled.started;
+    await runtime.emit("message_end", {
+      type: "message_end",
+      message: { role: "toolResult", toolCallId: "tui-kill-parent" },
+    });
+
+    const command = runtime.commands.get("subagents");
+    if (command === undefined) throw new Error("subagents command missing");
+    await command.handler("", runtime.ctx);
+    const panel = runtime.getComponent();
+    if (panel === undefined) throw new Error("child-run panel did not mount");
+    panel.handleInput?.("x");
+
+    expect(runtime.getNotifications()).toContain(
+      `Kill requested for child invocation ${invocationId.slice(0, 8)} (1 active run).`,
+    );
+    await background.drain(invocationId);
+    expect(controlled.getKillSignals()).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(JSON.stringify(runtime.getAppendedEntries())).toContain(
+      "user-killed",
+    );
+    expect(background.hasActiveInvocations()).toBe(false);
+
+    await runtime.emit("agent_settled", { type: "agent_settled" });
+    expect(runtime.getSentMessages()).toHaveLength(1);
+    expect(JSON.stringify(runtime.getSentMessages())).toContain("was aborted");
   });
 
   test("cancels tree navigation while a handed-off completion turn is active", async () => {

--- a/tests/pi-harness/child-run-persistence.test.ts
+++ b/tests/pi-harness/child-run-persistence.test.ts
@@ -106,16 +106,21 @@ describe("child-run persisted details", () => {
     });
   });
 
-  test("preserves the permission-blocked terminal reason", () => {
-    const blocked = payload();
-    const blockedRun = firstRun(blocked);
-    blockedRun.status = "failed";
-    blockedRun.terminalReason = "permission-blocked";
+  test("preserves permission-blocked and user-killed terminal reasons", () => {
+    for (const [status, terminalReason] of [
+      ["failed", "permission-blocked"],
+      ["aborted", "user-killed"],
+    ] as const) {
+      const retained = payload();
+      const retainedRun = firstRun(retained);
+      retainedRun.status = status;
+      retainedRun.terminalReason = terminalReason;
 
-    expect(decodePersistedChildRuns(blocked)?.runs[0]).toMatchObject({
-      status: "failed",
-      terminalReason: "permission-blocked",
-    });
+      expect(decodePersistedChildRuns(retained)?.runs[0]).toMatchObject({
+        status,
+        terminalReason,
+      });
+    }
   });
 
   test("rejects future, malformed, nonterminal, and oversized data", () => {

--- a/tests/pi-harness/child-run-ui.test.ts
+++ b/tests/pi-harness/child-run-ui.test.ts
@@ -132,6 +132,7 @@ const setup = (rows = 20, theme?: unknown) => {
     },
   };
   const inspected: string[] = [];
+  const killed: string[] = [];
   let unfocused = 0;
   let hidden = 0;
   const component = new ChildRunsBrowserComponent(
@@ -143,6 +144,7 @@ const setup = (rows = 20, theme?: unknown) => {
     () => hidden++,
     undefined,
     theme,
+    (runId) => killed.push(runId),
   );
   return {
     registry,
@@ -151,6 +153,7 @@ const setup = (rows = 20, theme?: unknown) => {
     keybindings,
     renders,
     inspected,
+    killed,
     getUnfocused: () => unfocused,
     getHidden: () => hidden,
   };
@@ -242,6 +245,18 @@ describe("child-session browser component", () => {
     component.handleInput("\r");
     expect(inspected).toEqual([runIds[1]]);
     expect(component.getSelectedRunId()).toBe(runIds[1]);
+  });
+
+  test("routes x to the selected child without changing its registry state", () => {
+    const { registry, component, killed } = setup();
+    const runIds = addRuns(registry, 2);
+    component.render(80);
+    component.handleInput("down");
+    component.handleInput("x");
+
+    expect(killed).toEqual([runIds[1]]);
+    expect(component.getSelectedRunId()).toBe(runIds[1]);
+    expect(registry.getRunStatus(runAt(runIds, 1))).toBe("queued");
   });
 
   test("keeps selection stable by run id while opening its detail viewer", () => {
@@ -618,7 +633,7 @@ describe("child-session detail component", () => {
       keybindings,
       () => {},
     );
-    detail.render(40);
+    expect(detail.render(80).at(-1)).toContain("x kill");
 
     detail.handleInput("up");
     expect(detail.render(40)[0]).toContain("PAUSED");
@@ -626,22 +641,27 @@ describe("child-session detail component", () => {
     expect(detail.render(40)[0]).toContain("LIVE");
   });
 
-  test("Escape, Left, and b close the detail viewer", () => {
+  test("x kills the fixed run while Escape, Left, and b close the detail", () => {
     const { registry, tui, keybindings } = setup();
     const [runId] = addRuns(registry, 1);
     if (runId === undefined) throw new Error("run did not initialize");
     let closes = 0;
+    const killed: string[] = [];
     const detail = new ChildRunDetailComponent(
       registry,
       runId,
       tui,
       keybindings,
       () => closes++,
+      undefined,
+      (selectedRunId) => killed.push(selectedRunId),
     );
 
+    detail.handleInput("x");
     detail.handleInput("escape");
     detail.handleInput("left");
     detail.handleInput("b");
+    expect(killed).toEqual([runId]);
     expect(closes).toBe(3);
   });
 });
@@ -708,6 +728,8 @@ const setupCombined = async (issueIds: string[], childCount = 0) => {
         refreshes += 1;
       },
     },
+    undefined,
+    (runId) => base.killed.push(runId),
   );
   return {
     ...base,
@@ -749,13 +771,17 @@ describe("combined coordination browser", () => {
     expect(combined.component.getSelectedRunId()).toBe(runId?.runId);
 
     combined.component.handleInput("down");
+    combined.component.handleInput("x");
     combined.component.handleInput("enter");
     expect(combined.inspectedIssues).toEqual(["issue-a"]);
     expect(combined.inspected).toEqual([]);
+    expect(combined.killed).toEqual([]);
 
     combined.component.handleInput("up");
+    combined.component.handleInput("x");
     combined.component.handleInput("right");
     expect(combined.inspected).toEqual([runId?.runId]);
+    expect(combined.killed).toEqual([runId?.runId]);
   });
 
   test("keeps issue-id selection stable and chooses the nearby row after close", async () => {


### PR DESCRIPTION
## Summary

- bind `x` in the resident child-session browser and child detail overlay
- abort the selected active invocation through the background manager
- record and replay the `user-killed` terminal reason
- document that parallel, chain, and workflow siblings stop together
- keep completed children and bit issue rows unchanged

## Verification

- `bun test`: 1794 passed, 2 skipped, 0 failed
- focused child-run tests: 86 passed
- `bun run tsc`
- `bun run check:pi-imports`
- `bun run lint` (9 pre-existing warnings outside this diff)
- `git diff --check`

## Review

Two fresh-context reviewers identified the replay allowlist for `user-killed`; the decoder allowlist and regression coverage were updated before the final full-suite run.