### PR TITLE
feat(pi): show project memory in coordination browser

### DIFF
--- a/pi/extensions/pi-harness/features/agent-memory/index.ts
+++ b/pi/extensions/pi-harness/features/agent-memory/index.ts
@@ -1,11 +1,8 @@
 import type { HarnessConfig } from "../../config";
 import type { CtxLike, PiLike } from "../../lib/pi-like";
 import { capUtf8, stripTerminalControls } from "../../lib/terminal-text";
-import {
-  AgentMemoryCli,
-  AgentMemoryCliError,
-  type MemoryAggregate,
-} from "./cli";
+import { AgentMemoryCliError, type MemoryAggregate } from "./cli";
+import { AgentMemoryRegistry, type AgentMemoryDataSource } from "./registry";
 import {
   MEMORY_INDEX_ITEM_LIMIT,
   MEMORY_INDEX_MAX_BYTES,
@@ -17,6 +14,8 @@ import {
   MemoryRecallParameters,
   MemoryUpdateParameters,
 } from "./parameters.generated";
+
+export type { AgentMemoryDataSource } from "./registry";
 
 export const AGENT_MEMORY_RECALL_TYPE = "pi-harness-agent-memory-index";
 
@@ -37,31 +36,14 @@ const DATA_PREAMBLE =
 const BEGIN_DATA = "BEGIN_UNTRUSTED_PROJECT_MEMORY_JSON";
 const END_DATA = "END_UNTRUSTED_PROJECT_MEMORY_JSON";
 
-export interface AgentMemoryDataSource {
-  aggregate(
-    cwd: string,
-    trust: HarnessConfig["trust"],
-    signal?: AbortSignal,
-  ): Promise<MemoryAggregate>;
-  update(
-    cwd: string,
-    trust: HarnessConfig["trust"],
-    sessionId: string,
-    input:
-      | {
-          readonly action: "put";
-          readonly path: string;
-          readonly description: string;
-          readonly content: string;
-        }
-      | { readonly action: "remove"; readonly path: string },
-    signal?: AbortSignal,
-  ): ReturnType<AgentMemoryCli["update"]>;
-}
-
 interface AgentMemoryDeps {
   readonly cli?: AgentMemoryDataSource;
+  readonly registry?: AgentMemoryRegistry;
   readonly cwd?: string;
+}
+
+export interface AgentMemoryIntegration {
+  readonly registry: AgentMemoryRegistry;
 }
 
 interface SessionContextLike {
@@ -224,8 +206,11 @@ export default function setupAgentMemory(
   pi: PiLike,
   config: HarnessConfig,
   deps: AgentMemoryDeps = {},
-): void {
-  const cli = deps.cli ?? new AgentMemoryCli();
+): AgentMemoryIntegration {
+  const ownsRegistry = deps.registry === undefined;
+  const registry =
+    deps.registry ??
+    new AgentMemoryRegistry({ cli: deps.cli, trust: config.trust });
   const attemptedSessions = new Set<string>();
   const warnedSessions = new Set<string>();
 
@@ -252,7 +237,7 @@ export default function setupAgentMemory(
         throw new Error(`memory_recall ${action} does not accept path`);
       }
       const cwd = deps.cwd ?? ctx.cwd ?? process.cwd();
-      const aggregate = await cli.aggregate(cwd, config.trust, signal);
+      const aggregate = await registry.aggregate(cwd, signal);
       if (action === "list") {
         return textResult(
           renderBoundedIndex(aggregate) ??
@@ -350,9 +335,8 @@ export default function setupAgentMemory(
         const cwd = deps.cwd ?? ctx.cwd ?? process.cwd();
         const result =
           action === "put"
-            ? await cli.update(
+            ? await registry.update(
                 cwd,
-                config.trust,
                 sessionId,
                 {
                   action,
@@ -366,13 +350,7 @@ export default function setupAgentMemory(
                 },
                 signal,
               )
-            : await cli.update(
-                cwd,
-                config.trust,
-                sessionId,
-                { action, path },
-                signal,
-              );
+            : await registry.update(cwd, sessionId, { action, path }, signal);
         return textResult(
           result.status === "unchanged"
             ? `Project memory unchanged: ${result.path}`
@@ -393,6 +371,7 @@ export default function setupAgentMemory(
   pi.on("session_start", resetBranchState);
   pi.on("session_before_tree", resetBranchState);
   pi.on("session_compact", resetBranchState);
+  if (ownsRegistry) pi.on("session_shutdown", () => registry.dispose());
 
   pi.on("before_agent_start", async (event, ctx) => {
     const systemPrompt = appendMemoryGuidance(
@@ -408,7 +387,7 @@ export default function setupAgentMemory(
 
     const cwd = deps.cwd ?? ctx.cwd ?? process.cwd();
     try {
-      const aggregate = await cli.aggregate(cwd, config.trust, ctx.signal);
+      const aggregate = await registry.aggregate(cwd, ctx.signal);
       if (aggregate.diagnostics.length > 0 && !warnedSessions.has(sessionKey)) {
         warnedSessions.add(sessionKey);
         ctx.ui.notify(
@@ -439,4 +418,6 @@ export default function setupAgentMemory(
       return { systemPrompt };
     }
   });
+
+  return { registry };
 }

--- a/pi/extensions/pi-harness/features/agent-memory/registry.ts
+++ b/pi/extensions/pi-harness/features/agent-memory/registry.ts
@@ -1,0 +1,403 @@
+import { stripTerminalControls } from "../../lib/terminal-text";
+import type { TrustConfig } from "../../lib/trust";
+import {
+  AgentMemoryCli,
+  AgentMemoryCliError,
+  type AgentMemoryFailureKind,
+  type MemoryAggregate,
+  type MemoryUpdateResult,
+} from "./cli";
+import { MEMORY_INDEX_ITEM_LIMIT, type SourcedMemoryRecord } from "./model";
+
+export interface AgentMemoryDataSource {
+  aggregate(
+    cwd: string,
+    trust: TrustConfig,
+    signal?: AbortSignal,
+  ): Promise<MemoryAggregate>;
+  update(
+    cwd: string,
+    trust: TrustConfig,
+    sessionId: string,
+    input:
+      | {
+          readonly action: "put";
+          readonly path: string;
+          readonly description: string;
+          readonly content: string;
+        }
+      | { readonly action: "remove"; readonly path: string },
+    signal?: AbortSignal,
+  ): Promise<MemoryUpdateResult>;
+}
+
+export interface AgentMemorySummary {
+  readonly path: string;
+  readonly description: string;
+  readonly updatedAt: string;
+  readonly sourceRef: string;
+}
+
+export interface AgentMemorySnapshot {
+  readonly entries: readonly AgentMemorySummary[];
+  readonly truncated: boolean;
+  readonly loading: boolean;
+  readonly stale: boolean;
+  readonly diagnosticCount: number;
+  readonly error?: string;
+  readonly refreshedAt?: number;
+}
+
+export type AgentMemoryRefreshOutcome =
+  | {
+      readonly ok: true;
+      readonly count: number;
+      readonly truncated: boolean;
+      readonly aggregate: MemoryAggregate;
+    }
+  | {
+      readonly ok: false;
+      readonly kind: AgentMemoryFailureKind;
+      readonly message: string;
+      readonly error: AgentMemoryCliError;
+    };
+
+interface AgentMemoryRegistryOptions {
+  readonly cli?: AgentMemoryDataSource;
+  readonly trust: TrustConfig;
+  readonly now?: () => number;
+}
+
+interface AbortSignalLike {
+  readonly aborted: boolean;
+  addEventListener(
+    event: "abort",
+    listener: () => void,
+    options?: { once?: boolean },
+  ): void;
+  removeEventListener(event: "abort", listener: () => void): void;
+}
+
+interface AbortControllerLike {
+  readonly signal: AbortSignal & AbortSignalLike;
+  abort(): void;
+}
+
+const isAbortSignal = (
+  value: unknown,
+): value is AbortSignal & AbortSignalLike =>
+  typeof value === "object" &&
+  value !== null &&
+  "aborted" in value &&
+  typeof value.aborted === "boolean" &&
+  "addEventListener" in value &&
+  typeof value.addEventListener === "function" &&
+  "removeEventListener" in value &&
+  typeof value.removeEventListener === "function";
+
+const createAbortController = (): AbortControllerLike => {
+  const controller: unknown = new AbortController();
+  if (
+    typeof controller !== "object" ||
+    controller === null ||
+    !("abort" in controller) ||
+    typeof controller.abort !== "function" ||
+    !("signal" in controller) ||
+    !isAbortSignal(controller.signal)
+  ) {
+    throw new Error("AbortController is unavailable");
+  }
+  const { abort, signal } = controller;
+  return {
+    signal,
+    abort: () => Reflect.apply(abort, controller, []),
+  };
+};
+
+const abortedOutcome = (message: string): AgentMemoryRefreshOutcome => {
+  const error = new AgentMemoryCliError("aborted", message);
+  return { ok: false, kind: error.kind, message: error.message, error };
+};
+
+const safeMessage = (error: unknown): string =>
+  stripTerminalControls(
+    error instanceof Error ? error.message : String(error),
+    " ",
+  )
+    .replace(/\s+/g, " ")
+    .trim();
+
+const asCliError = (error: unknown): AgentMemoryCliError =>
+  error instanceof AgentMemoryCliError
+    ? error
+    : new AgentMemoryCliError("command-failed", safeMessage(error));
+
+const initialSnapshot = (): AgentMemorySnapshot => ({
+  entries: [],
+  truncated: false,
+  loading: false,
+  stale: false,
+  diagnosticCount: 0,
+});
+
+const cloneSourced = (entry: SourcedMemoryRecord): SourcedMemoryRecord => ({
+  ...entry,
+  record: { ...entry.record },
+});
+
+export class AgentMemoryRegistry {
+  private readonly cli: AgentMemoryDataSource;
+  private readonly trust: TrustConfig;
+  private readonly now: () => number;
+  private readonly subscribers = new Set<() => void>();
+  private readonly details = new Map<string, SourcedMemoryRecord>();
+  private snapshot: AgentMemorySnapshot = initialSnapshot();
+  private cwd: string | undefined;
+  private generation = 0;
+  private refreshController: AbortControllerLike | undefined;
+  private refreshPromise: Promise<AgentMemoryRefreshOutcome> | undefined;
+  private refreshWaiters = 0;
+  private disposed = false;
+
+  constructor(options: AgentMemoryRegistryOptions) {
+    this.cli = options.cli ?? new AgentMemoryCli();
+    this.trust = options.trust;
+    this.now = options.now ?? Date.now;
+  }
+
+  beginSession(cwd: string): void {
+    if (this.disposed) return;
+    this.refreshController?.abort();
+    this.refreshController = undefined;
+    this.refreshPromise = undefined;
+    this.refreshWaiters = 0;
+    this.generation += 1;
+    this.cwd = cwd;
+    this.snapshot = initialSnapshot();
+    this.details.clear();
+    this.publish();
+  }
+
+  getSnapshot(): AgentMemorySnapshot {
+    return {
+      ...this.snapshot,
+      entries: this.snapshot.entries.map((entry) => ({ ...entry })),
+    };
+  }
+
+  getEntry(path: string): SourcedMemoryRecord | undefined {
+    const entry = this.details.get(path);
+    return entry === undefined ? undefined : cloneSourced(entry);
+  }
+
+  async refresh(
+    cwd: string,
+    signal?: AbortSignal,
+  ): Promise<AgentMemoryRefreshOutcome> {
+    if (this.disposed) {
+      return abortedOutcome("project memory registry is disposed");
+    }
+    if (this.cwd !== cwd) this.beginSession(cwd);
+    if (this.refreshPromise !== undefined) {
+      return this.waitForRefresh(this.refreshPromise, signal);
+    }
+
+    const controller = createAbortController();
+    this.refreshController = controller;
+    const { generation } = this;
+    this.snapshot = { ...this.snapshot, loading: true };
+    this.publish();
+
+    const refreshPromise = this.load(
+      cwd,
+      generation,
+      controller.signal,
+    ).finally(() => {
+      if (this.refreshPromise !== refreshPromise) return;
+      this.refreshPromise = undefined;
+      this.refreshController = undefined;
+      this.refreshWaiters = 0;
+    });
+    this.refreshPromise = refreshPromise;
+    return this.waitForRefresh(refreshPromise, signal);
+  }
+
+  async aggregate(cwd: string, signal?: AbortSignal): Promise<MemoryAggregate> {
+    const outcome = await this.refresh(cwd, signal);
+    if (!outcome.ok) throw outcome.error;
+    return outcome.aggregate;
+  }
+
+  async update(
+    cwd: string,
+    sessionId: string,
+    input:
+      | {
+          readonly action: "put";
+          readonly path: string;
+          readonly description: string;
+          readonly content: string;
+        }
+      | { readonly action: "remove"; readonly path: string },
+    signal?: AbortSignal,
+  ): Promise<MemoryUpdateResult> {
+    const result = await this.cli.update(
+      cwd,
+      this.trust,
+      sessionId,
+      input,
+      signal,
+    );
+    const pending = this.refreshPromise;
+    if (pending !== undefined) await pending;
+    await this.refresh(cwd, signal);
+    return result;
+  }
+
+  subscribe(callback: () => void): () => void {
+    if (this.disposed) return () => {};
+    this.subscribers.add(callback);
+    return () => this.subscribers.delete(callback);
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.generation += 1;
+    this.refreshController?.abort();
+    this.refreshController = undefined;
+    this.refreshPromise = undefined;
+    this.refreshWaiters = 0;
+    this.details.clear();
+    this.subscribers.clear();
+  }
+
+  private waitForRefresh(
+    promise: Promise<AgentMemoryRefreshOutcome>,
+    signal?: AbortSignal,
+  ): Promise<AgentMemoryRefreshOutcome> {
+    this.refreshWaiters += 1;
+    let released = false;
+    const release = (aborted: boolean): void => {
+      if (released) return;
+      released = true;
+      if (this.refreshPromise !== promise) return;
+      this.refreshWaiters = Math.max(0, this.refreshWaiters - 1);
+      if (aborted && this.refreshWaiters === 0) {
+        this.refreshController?.abort();
+      }
+    };
+    if (!isAbortSignal(signal)) {
+      return promise.finally(() => release(false));
+    }
+    return new Promise<AgentMemoryRefreshOutcome>((resolve, reject) => {
+      const abort = (): void => {
+        signal.removeEventListener("abort", abort);
+        release(true);
+        resolve(abortedOutcome("project memory refresh aborted"));
+      };
+      signal.addEventListener("abort", abort, { once: true });
+      if (signal.aborted) {
+        abort();
+        return;
+      }
+      void promise.then(
+        (outcome) => {
+          signal.removeEventListener("abort", abort);
+          release(false);
+          resolve(outcome);
+        },
+        (error: unknown) => {
+          signal.removeEventListener("abort", abort);
+          release(false);
+          reject(error);
+        },
+      );
+    });
+  }
+
+  private async load(
+    cwd: string,
+    generation: number,
+    signal: AbortSignal,
+  ): Promise<AgentMemoryRefreshOutcome> {
+    try {
+      const aggregate = await this.cli.aggregate(cwd, this.trust, signal);
+      if (this.disposed || generation !== this.generation) {
+        const error = new AgentMemoryCliError(
+          "aborted",
+          "stale project memory refresh discarded",
+        );
+        return { ok: false, kind: error.kind, message: error.message, error };
+      }
+      const sorted = [...aggregate.merged.entries.values()].sort(
+        (left, right) => left.record.path.localeCompare(right.record.path),
+      );
+      const selected = sorted.slice(0, MEMORY_INDEX_ITEM_LIMIT);
+      const truncated =
+        aggregate.truncated || sorted.length > MEMORY_INDEX_ITEM_LIMIT;
+      this.details.clear();
+      const entries = selected.map((entry): AgentMemorySummary => {
+        this.details.set(entry.record.path, cloneSourced(entry));
+        return {
+          path: entry.record.path,
+          description: entry.record.description,
+          updatedAt: entry.record.updatedAt,
+          sourceRef: entry.sourceRef,
+        };
+      });
+      this.snapshot = {
+        entries,
+        truncated,
+        loading: false,
+        stale: false,
+        diagnosticCount: aggregate.diagnostics.length,
+        refreshedAt: this.now(),
+      };
+      this.publish();
+      return {
+        ok: true,
+        count: entries.length,
+        truncated,
+        aggregate,
+      };
+    } catch (error) {
+      const failure = asCliError(error);
+      if (this.disposed || generation !== this.generation) {
+        return {
+          ok: false,
+          kind: "aborted",
+          message: "stale project memory refresh discarded",
+          error: new AgentMemoryCliError(
+            "aborted",
+            "stale project memory refresh discarded",
+          ),
+        };
+      }
+      this.snapshot = {
+        ...this.snapshot,
+        loading: false,
+        stale: this.snapshot.refreshedAt !== undefined,
+        error: safeMessage(failure),
+      };
+      this.publish();
+      return {
+        ok: false,
+        kind: failure.kind,
+        message: safeMessage(failure),
+        error: failure,
+      };
+    }
+  }
+
+  private publish(): void {
+    if (this.disposed) return;
+    for (const callback of this.subscribers) {
+      try {
+        callback();
+      } catch {
+        // One TUI listener must not poison memory recall or later listeners.
+      }
+    }
+  }
+}

--- a/pi/extensions/pi-harness/features/child-runs/README.md
+++ b/pi/extensions/pi-harness/features/child-runs/README.md
@@ -19,14 +19,14 @@ for all sources.
 - When `bit-task` is enabled, `session_start` refreshes open issues in the
   current Git repository. One or more open issues also mount the browser without
   stealing editor focus. Closed issues are never listed.
-- The header reports `Child sessions: N | Open bit issues: M | Project memory:
-P` for enabled sources. One scrollable list places child rows first, open
-  issue rows second, and project-memory rows last. Issues are sorted by
+- The browser has no aggregate header, source counts, or source section titles.
+  One flat scrollable list places child rows first, open issue rows second, and
+  project-memory rows last at the same visual level. Issues are sorted by
   `updated_at` descending and stable issue id; memory is sorted by path and
   capped to the same 50-entry bounded index used for startup recall. Child
-  status icons use the
-  active theme's semantic status colors (`success`, `error`, and the existing
-  warning/dim mappings), and overlong rows end with a width-safe ellipsis.
+  status icons use the active theme's semantic status colors (`success`,
+  `error`, and the existing warning/dim mappings), and overlong rows end with a
+  width-safe ellipsis.
 - The browser receives the full terminal content width and remains in normal
   layout flow, so it does not cover chat or editor content.
 - Its height is approximately one quarter of the terminal, clamped to 4–10

--- a/pi/extensions/pi-harness/features/child-runs/README.md
+++ b/pi/extensions/pi-harness/features/child-runs/README.md
@@ -1,8 +1,9 @@
 # Coordination browser
 
-pi-harness exposes child runs and open local `bit issue` records in one resident
-full-width TUI browser between the chat editor and statusline. It deliberately
-uses one `belowEditor` widget and one focus owner for both sources.
+pi-harness exposes child runs, open local `bit issue` records, and project
+memory in one resident full-width TUI browser between the chat editor and
+statusline. It deliberately uses one `belowEditor` widget and one focus owner
+for all sources.
 
 ## Behavior
 
@@ -18,9 +19,12 @@ uses one `belowEditor` widget and one focus owner for both sources.
 - When `bit-task` is enabled, `session_start` refreshes open issues in the
   current Git repository. One or more open issues also mount the browser without
   stealing editor focus. Closed issues are never listed.
-- The header reports `Child sessions: N | Open bit issues: M`. One scrollable
-  list places child rows first when present, followed by issue rows sorted by
-  `updated_at` descending and stable issue id. Child status icons use the
+- The header reports `Child sessions: N | Open bit issues: M | Project memory:
+P` for enabled sources. One scrollable list places child rows first, open
+  issue rows second, and project-memory rows last. Issues are sorted by
+  `updated_at` descending and stable issue id; memory is sorted by path and
+  capped to the same 50-entry bounded index used for startup recall. Child
+  status icons use the
   active theme's semantic status colors (`success`, `error`, and the existing
   warning/dim mappings), and overlong rows end with a width-safe ellipsis.
 - The browser receives the full terminal content width and remains in normal
@@ -30,7 +34,8 @@ uses one `belowEditor` widget and one focus owner for both sources.
   24-row and 40-row terminals; extremely short terminals may still be tight.
 - `/subagents` or `Ctrl+Alt+S` shows and focuses the browser with a child row
   preferred. `/bit-issues` or `Ctrl+Alt+I` refreshes and focuses it with an
-  issue row preferred.
+  issue row preferred. `/project-memory` or `Ctrl+Alt+M` refreshes and focuses
+  it with a project-memory row preferred.
 - When a cursor-aware editor has focus, Down keeps its native cursor/history
   behavior. If native Down changes neither editor text nor cursor at the bottom
   boundary, focus moves to the browser with its current run selected.
@@ -48,14 +53,16 @@ uses one `belowEditor` widget and one focus owner for both sources.
 - `q` hides the browser. Automatic issue refresh does not remount an explicitly
   hidden browser. A new child run or either explicit browser command shows it
   again.
-- In the resident list, Up/Down, `j`/`k`, and PageUp/PageDown select across both
-  row kinds. Enter or Right opens the selected child or issue. `x` aborts the
-  selected active child invocation; parallel, chain, and workflow siblings in
-  that invocation stop together. Completed children and issue rows remain
-  unchanged. `r` refreshes open issues without polling or relay-backed watch
-  behavior.
-- Child and issue details use the same focused, zero-margin full-terminal
-  overlay, covering the resident panes in both dimensions. PageUp/PageDown move
+- In the resident list, Up/Down, `j`/`k`, and PageUp/PageDown select across all
+  row kinds. Enter or Right opens the selected child, issue, or project-memory
+  entry. `x` aborts the selected active child invocation; parallel, chain, and
+  workflow siblings in that invocation stop together. Completed children,
+  issue rows, and memory rows remain unchanged. `r` refreshes open issues and
+  project memory without polling or relay-backed watch behavior.
+- Child, issue, and project-memory details use the same focused, zero-margin
+  full-terminal overlay, covering the resident panes in both dimensions.
+  Project-memory detail is read-only and shows its path, description, content,
+  update time, and source-ref provenance. PageUp/PageDown move
   by a viewport, Home/End jump to the ends, and Escape, Left, `b`, or `q` closes
   the overlay and returns to the list. Child details retain live-follow behavior
   and accept the same `x` kill action while the invocation is active. Transcript
@@ -73,7 +80,10 @@ Closing, hiding, or unfocusing the browser never cancels child execution. Only
 an explicit `x` on an active child requests termination, records
 `user-killed`, and preserves normal persistence and parent completion delivery.
 Issue refresh also runs after the agent settles, when the panel gains focus,
-on explicit refresh, and immediately before issue detail loading. Refresh is
+on explicit refresh, and immediately before issue detail loading. Project
+memory refresh is intentionally narrower because its aggregate may invoke many
+bounded Git/bit commands: it runs at session start, on `r`, through the explicit
+memory command/shortcut, and after a successful `memory_update`. Refresh is
 single-flight and session-generation guarded; failures retain a stale
 last-known-good list.
 
@@ -117,11 +127,13 @@ likewise abort active process groups.
 Children still run with `--no-session`; browser entries are view-only and
 cannot be resumed or forked as native pi sessions.
 
-Bit issue rows and detail are also view-only. pi-harness never updates, closes,
-reopens, or comments on an issue from the TUI. Issue bodies and comments remain
-registry-local TUI state: they are not sent to the LLM, appended to pi session
-JSONL, or copied into child transcript persistence. Every untrusted title,
-body, label, author, and comment line is terminal-control sanitized and
+Bit issue and project-memory rows and detail are also view-only. pi-harness
+never updates, closes, reopens, or comments on an issue from the TUI. Memory
+updates remain available only through the parent `memory_update` tool. Issue
+bodies, comments, and memory content remain registry-local TUI state: they are
+not sent to the LLM, appended to pi session JSONL, or copied into child
+transcript persistence. Every untrusted title, body, label, author, comment,
+memory description, and memory content line is terminal-control sanitized and
 Unicode-width bounded before rendering.
 
 The adapter resolves an absolute Git common directory first, then directly

--- a/pi/extensions/pi-harness/features/child-runs/index.ts
+++ b/pi/extensions/pi-harness/features/child-runs/index.ts
@@ -1,4 +1,5 @@
 import type { CtxLike, PiLike } from "../../lib/pi-like";
+import type { AgentMemoryRegistry } from "../agent-memory/registry";
 import { BitIssueCli } from "../bit-issues/cli";
 import { BitIssueRegistry } from "../bit-issues/registry";
 import {
@@ -109,6 +110,7 @@ const appendBackgroundAgentSystemPrompt = (systemPrompt: string): string =>
 export interface ChildRunsIntegration {
   registry: ChildRunRegistry;
   bitIssues?: BitIssueRegistry;
+  agentMemory?: AgentMemoryRegistry;
   background?: BackgroundInvocationManager;
   ensureVisible(ctx: CtxLike): void;
 }
@@ -116,6 +118,7 @@ export interface ChildRunsIntegration {
 export interface SetupChildRunsOptions {
   readonly bitIssues?: boolean;
   readonly bitIssueCli?: BitIssueCli;
+  readonly agentMemory?: AgentMemoryRegistry;
   readonly childExecution?: boolean;
   readonly backgroundDrainTimeoutMs?: number;
 }
@@ -144,8 +147,10 @@ const setupChildRuns = (
   const bitIssues = options.bitIssues
     ? new BitIssueRegistry({ cli: options.bitIssueCli })
     : undefined;
+  const { agentMemory } = options;
   let activeContext: RuntimeContextLike | undefined;
-  let lastExplicitWarning: string | undefined;
+  let lastExplicitIssueWarning: string | undefined;
+  let lastExplicitMemoryWarning: string | undefined;
   let panel: ChildRunsPanelController;
   const refreshBitIssues = async (
     ctx: RuntimeContextLike,
@@ -155,20 +160,52 @@ const setupChildRuns = (
     const cwd = ctx.cwd ?? process.cwd();
     const outcome = await bitIssues.refresh(cwd);
     if (outcome.ok) {
-      lastExplicitWarning = undefined;
+      lastExplicitIssueWarning = undefined;
       if (outcome.count > 0) panel.ensureVisibleForIssues(ctx);
       return;
     }
     if (explicit) {
       const warning = `${outcome.kind}:${outcome.message}`;
-      if (warning !== lastExplicitWarning) {
-        lastExplicitWarning = warning;
+      if (warning !== lastExplicitIssueWarning) {
+        lastExplicitIssueWarning = warning;
         ctx.ui.notify(
           `Open bit issues unavailable: ${outcome.message}`,
           "warning",
         );
       }
     }
+  };
+  const refreshAgentMemory = async (
+    ctx: RuntimeContextLike,
+    explicit = false,
+  ): Promise<void> => {
+    if (agentMemory === undefined) return;
+    const cwd = ctx.cwd ?? process.cwd();
+    const outcome = await agentMemory.refresh(cwd);
+    if (outcome.ok) {
+      lastExplicitMemoryWarning = undefined;
+      if (outcome.count > 0) panel.ensureVisibleForMemory(ctx);
+      return;
+    }
+    if (explicit) {
+      const warning = `${outcome.kind}:${outcome.message}`;
+      if (warning !== lastExplicitMemoryWarning) {
+        lastExplicitMemoryWarning = warning;
+        ctx.ui.notify(
+          `Project memory unavailable: ${outcome.message}`,
+          "warning",
+        );
+      }
+    }
+  };
+  const refreshCoordination = async (
+    ctx: RuntimeContextLike,
+    explicit = false,
+  ): Promise<void> => {
+    await Promise.all([
+      refreshBitIssues(ctx, explicit),
+      refreshAgentMemory(ctx, explicit),
+    ]);
   };
   const invalidateHearthCaches = async (): Promise<void> => {
     const pending: Promise<void>[] = [];
@@ -222,8 +259,13 @@ const setupChildRuns = (
       : undefined;
   panel = new ChildRunsPanelController(registry, {
     bitIssues,
+    agentMemory,
     refreshBitIssues: async () => {
       if (activeContext !== undefined) await refreshBitIssues(activeContext);
+    },
+    refreshCoordination: async () => {
+      if (activeContext !== undefined)
+        await refreshCoordination(activeContext, true);
     },
     killRun:
       background === undefined
@@ -309,6 +351,35 @@ const setupChildRuns = (
     });
   }
 
+  if (agentMemory !== undefined) {
+    runtime.registerCommand("project-memory", {
+      description: "Refresh, show, and focus project memory",
+      handler: async (_args, ctx) => {
+        activeContext = ctx;
+        if (ctx.mode !== "tui") {
+          if (ctx.hasUI) {
+            ctx.ui.notify(
+              "The project memory browser requires TUI mode.",
+              "warning",
+            );
+          }
+          return;
+        }
+        await refreshAgentMemory(ctx, true);
+        await panel.showAndFocus(ctx, "memory", false);
+      },
+    });
+
+    runtime.registerShortcut("ctrl+alt+m", {
+      description: "Refresh, show, and focus project memory",
+      handler: async (ctx) => {
+        activeContext = ctx;
+        await refreshAgentMemory(ctx, true);
+        await panel.showAndFocus(ctx, "memory", false);
+      },
+    });
+  }
+
   runtime.on("tool_result", (rawEvent) => {
     const event = rawEvent as RuntimeToolResultEvent;
     if (
@@ -376,10 +447,10 @@ const setupChildRuns = (
     activeContext = ctx;
     clearTreeTransitions();
     replayBranch(registry, ctx);
-    if (bitIssues !== undefined) {
-      bitIssues.beginSession(ctx.cwd ?? process.cwd());
-      void refreshBitIssues(ctx);
-    }
+    const cwd = ctx.cwd ?? process.cwd();
+    if (bitIssues !== undefined) bitIssues.beginSession(cwd);
+    if (agentMemory !== undefined) agentMemory.beginSession(cwd);
+    void refreshCoordination(ctx);
   });
   runtime.on("session_before_tree", async (rawEvent) => {
     // Serialize navigation boundaries. Pi does not correlate session_tree with
@@ -453,12 +524,14 @@ const setupChildRuns = (
     await background?.shutdown();
     panel.dispose();
     bitIssues?.dispose();
+    agentMemory?.dispose();
     registry.dispose();
   });
 
   return {
     registry,
     bitIssues,
+    agentMemory,
     background,
     ensureVisible(ctx) {
       panel.ensureVisible(ctx as RuntimeContextLike);

--- a/pi/extensions/pi-harness/features/child-runs/ui.ts
+++ b/pi/extensions/pi-harness/features/child-runs/ui.ts
@@ -19,6 +19,11 @@ import type {
   BitIssueSummary,
 } from "../bit-issues/model";
 import { BitIssueRegistry } from "../bit-issues/registry";
+import type { SourcedMemoryRecord } from "../agent-memory/model";
+import {
+  AgentMemoryRegistry,
+  type AgentMemorySummary,
+} from "../agent-memory/registry";
 import type {
   ChildInvocationSnapshot,
   ChildRunStatus,
@@ -184,7 +189,8 @@ const transcriptComponent = (
 
 type BrowserSelection =
   | { readonly kind: "child"; readonly id: string }
-  | { readonly kind: "issue"; readonly id: string };
+  | { readonly kind: "issue"; readonly id: string }
+  | { readonly kind: "memory"; readonly id: string };
 
 interface BrowserRow {
   readonly text: string;
@@ -194,6 +200,12 @@ interface BrowserRow {
 export interface BitIssueBrowserBindings {
   readonly registry: BitIssueRegistry;
   readonly onInspect: (issueId: string) => void;
+  readonly onRefresh: () => void | Promise<void>;
+}
+
+export interface AgentMemoryBrowserBindings {
+  readonly registry: AgentMemoryRegistry;
+  readonly onInspect: (path: string) => void;
   readonly onRefresh: () => void | Promise<void>;
 }
 
@@ -215,6 +227,7 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
   private listOffset = 0;
   private readonly unsubscribeChild: () => void;
   private readonly unsubscribeIssues: (() => void) | undefined;
+  private readonly unsubscribeMemory: (() => void) | undefined;
 
   constructor(
     private readonly registry: ChildRunRegistry,
@@ -226,10 +239,14 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
     private readonly bitIssues?: BitIssueBrowserBindings,
     theme?: unknown,
     private readonly onKill?: (runId: string) => void,
+    private readonly agentMemory?: AgentMemoryBrowserBindings,
   ) {
     this.theme = resolveTheme(theme);
     this.unsubscribeChild = registry.subscribe(() => this.requestRender());
     this.unsubscribeIssues = bitIssues?.registry.subscribe(() =>
+      this.requestRender(),
+    );
+    this.unsubscribeMemory = agentMemory?.registry.subscribe(() =>
       this.requestRender(),
     );
   }
@@ -246,12 +263,15 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
     const runs = flattenRuns(snapshots);
     const issueSnapshot = this.bitIssues?.registry.getSnapshot();
     const issues = issueSnapshot?.issues ?? [];
-    this.syncSelection(runs, issues);
+    const memorySnapshot = this.agentMemory?.registry.getSnapshot();
+    const memories = memorySnapshot?.entries ?? [];
+    this.syncSelection(runs, issues, memories);
 
     const body = this.renderList(
       snapshots,
       runs,
       issues,
+      memories,
       safeWidth,
       height - 1,
     );
@@ -259,10 +279,24 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
     if (issueSnapshot?.loading === true) issueState = " · refreshing";
     else if (issueSnapshot?.stale === true) issueState = " · stale";
     else if (issueSnapshot?.error !== undefined) issueState = " · unavailable";
-    const title =
+    let memoryState = "";
+    if (memorySnapshot?.loading === true) memoryState = " · refreshing";
+    else if (memorySnapshot?.stale === true) memoryState = " · stale";
+    else if (memorySnapshot?.error !== undefined)
+      memoryState = " · unavailable";
+    const counts = [
+      `Child sessions: ${runs.length}`,
       this.bitIssues === undefined
+        ? undefined
+        : `Open bit issues: ${issues.length}${issueState}`,
+      this.agentMemory === undefined
+        ? undefined
+        : `Project memory: ${memories.length}${memoryState}`,
+    ].filter((item): item is string => item !== undefined);
+    const title =
+      this.bitIssues === undefined && this.agentMemory === undefined
         ? " Child sessions "
-        : ` Child sessions: ${runs.length} | Open bit issues: ${issues.length}${issueState} `;
+        : ` ${counts.join(" | ")} `;
     const borderWidth = Math.max(1, safeWidth - visibleWidth(title));
     return [
       line(`${title}${"─".repeat(borderWidth)}`, safeWidth),
@@ -275,8 +309,9 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
       this.onHide();
       return;
     }
-    if (data === "r" && this.bitIssues !== undefined) {
-      void this.bitIssues.onRefresh();
+    if (data === "r") {
+      const refresh = this.bitIssues?.onRefresh ?? this.agentMemory?.onRefresh;
+      if (refresh !== undefined) void refresh();
       return;
     }
     if (data === "x") {
@@ -313,6 +348,8 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
       if (this.selection?.kind === "child") this.onInspect(this.selection.id);
       else if (this.selection?.kind === "issue") {
         this.bitIssues?.onInspect(this.selection.id);
+      } else if (this.selection?.kind === "memory") {
+        this.agentMemory?.onInspect(this.selection.id);
       }
     } else return;
 
@@ -329,6 +366,7 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
   dispose(): void {
     this.unsubscribeChild();
     this.unsubscribeIssues?.();
+    this.unsubscribeMemory?.();
   }
 
   getSelectedRunId(): string | undefined {
@@ -337,6 +375,10 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
 
   getSelectedIssueId(): string | undefined {
     return this.selection?.kind === "issue" ? this.selection.id : undefined;
+  }
+
+  getSelectedMemoryPath(): string | undefined {
+    return this.selection?.kind === "memory" ? this.selection.id : undefined;
   }
 
   prefer(kind: BrowserSelection["kind"]): void {
@@ -363,12 +405,19 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
         .issues.map(
           (issue): BrowserSelection => ({ kind: "issue", id: issue.id }),
         ) ?? [];
-    return [...children, ...issues];
+    const memories =
+      this.agentMemory?.registry
+        .getSnapshot()
+        .entries.map(
+          (entry): BrowserSelection => ({ kind: "memory", id: entry.path }),
+        ) ?? [];
+    return [...children, ...issues, ...memories];
   }
 
   private syncSelection(
     runs: FlatRun[],
     issues: readonly BitIssueSummary[],
+    memories: readonly AgentMemorySummary[],
   ): void {
     const selectable: BrowserSelection[] = [
       ...runs.map(
@@ -379,6 +428,9 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
       ),
       ...issues.map(
         (issue): BrowserSelection => ({ kind: "issue", id: issue.id }),
+      ),
+      ...memories.map(
+        (entry): BrowserSelection => ({ kind: "memory", id: entry.path }),
       ),
     ];
     if (this.pendingPreference !== undefined) {
@@ -413,32 +465,36 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
     snapshots: ChildInvocationSnapshot[],
     runs: FlatRun[],
     issues: readonly BitIssueSummary[],
+    memories: readonly AgentMemorySummary[],
     width: number,
     viewport: number,
   ): string[] {
     const issueSnapshot = this.bitIssues?.registry.getSnapshot();
-    if (runs.length === 0 && issues.length === 0) {
-      if (this.bitIssues === undefined) {
+    const memorySnapshot = this.agentMemory?.registry.getSnapshot();
+    if (runs.length === 0 && issues.length === 0 && memories.length === 0) {
+      if (this.bitIssues === undefined && this.agentMemory === undefined) {
         return [
           line("No child runs on this session branch.", width),
           line("Start subagent or workflow to populate this view.", width),
         ];
       }
-      let issueStatus = "Start subagent/workflow or create a local bit issue.";
-      if (issueSnapshot?.loading === true)
-        issueStatus = "Loading open bit issues…";
+      let status = "No coordination records are available.";
+      if (issueSnapshot?.loading === true || memorySnapshot?.loading === true)
+        status = "Loading coordination records…";
       else if (issueSnapshot?.error !== undefined) {
-        issueStatus = `Open bit issues unavailable: ${issueSnapshot.error}`;
+        status = `Open bit issues unavailable: ${issueSnapshot.error}`;
+      } else if (memorySnapshot?.error !== undefined) {
+        status = `Project memory unavailable: ${memorySnapshot.error}`;
       }
       return [
-        line("No child runs or open bit issues.", width),
-        line(issueStatus, width),
+        line("No child runs, open bit issues, or project memory.", width),
+        line(status, width),
       ];
     }
 
     const rendered: BrowserRow[] = [];
     if (runs.length > 0) {
-      if (this.bitIssues !== undefined)
+      if (this.bitIssues !== undefined || this.agentMemory !== undefined)
         rendered.push({ text: "Child sessions" });
       for (const invocation of snapshots) {
         rendered.push({
@@ -482,6 +538,32 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
         text: `${issueSnapshot.stale ? "stale" : "issue refresh failed"}: ${issueSnapshot.error}`,
       });
     }
+    if (memories.length > 0) {
+      rendered.push({ text: "Project memory" });
+      for (const entry of memories) {
+        const selection: BrowserSelection = {
+          kind: "memory",
+          id: entry.path,
+        };
+        rendered.push({
+          selection,
+          text: `${this.isCursorVisible(selection) ? ">" : " "} ▣ ${taskOneLine(entry.path)} — ${taskOneLine(entry.description)}`,
+        });
+      }
+      if (memorySnapshot?.truncated === true) {
+        rendered.push({ text: "… more project memory entries" });
+      }
+    }
+    if (memorySnapshot?.diagnosticCount) {
+      rendered.push({
+        text: `project memory ignored ${memorySnapshot.diagnosticCount} invalid note entries`,
+      });
+    }
+    if (memorySnapshot?.error !== undefined) {
+      rendered.push({
+        text: `${memorySnapshot.stale ? "stale" : "memory refresh failed"}: ${memorySnapshot.error}`,
+      });
+    }
 
     const selectedToken = this.selection && selectionToken(this.selection);
     const selectedLine = Math.max(
@@ -520,6 +602,7 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
     this.syncSelection(
       flattenRuns(this.registry.getSnapshots()),
       this.bitIssues?.registry.getSnapshot().issues ?? [],
+      this.agentMemory?.registry.getSnapshot().entries ?? [],
     );
     this.tui.requestRender();
   }
@@ -1042,6 +1125,217 @@ export class BitIssueDetailComponent implements ComponentLike {
   }
 }
 
+const memoryDetailContentLines = (
+  entry: SourcedMemoryRecord,
+  width: number,
+  theme: ChildRunTheme,
+): string[] => {
+  const root = new Container();
+  const metadata = new Box(1, 0, (text) => theme.bg("selectedBg", text));
+  metadata.addChild(
+    new Text(
+      theme.fg("toolTitle", theme.bold(taskOneLine(entry.record.path))),
+      0,
+      0,
+    ),
+  );
+  metadata.addChild(
+    new Text(
+      theme.fg("muted", `updated ${taskOneLine(entry.record.updatedAt)}`),
+      0,
+      0,
+    ),
+  );
+  metadata.addChild(
+    new Text(
+      theme.fg("muted", `source  ${taskOneLine(entry.sourceRef)}`),
+      0,
+      0,
+    ),
+  );
+  root.addChild(metadata);
+  root.addChild(new Text(theme.fg("accent", theme.bold("Description")), 0, 0));
+  const description = new Box(1, 0);
+  description.addChild(
+    new Text(
+      theme.fg(
+        "text",
+        wrapPlainText(
+          safeBlock(entry.record.description),
+          Math.max(1, width - 2),
+        ).join("\n"),
+      ),
+      0,
+      0,
+    ),
+  );
+  root.addChild(description);
+  root.addChild(new Text(theme.fg("accent", theme.bold("Content")), 0, 0));
+  const content = new Box(1, 0);
+  content.addChild(
+    new Text(
+      theme.fg(
+        "text",
+        wrapPlainText(
+          entry.record.content === ""
+            ? "(empty content)"
+            : safeBlock(entry.record.content),
+          Math.max(1, width - 2),
+        ).join("\n"),
+      ),
+      0,
+      0,
+    ),
+  );
+  root.addChild(content);
+  return root.render(Math.max(1, width));
+};
+
+/** Focused, near-full-screen read-only viewer for one project-memory entry. */
+export class AgentMemoryDetailComponent implements ComponentLike {
+  private offset = 0;
+  private lastMaxOffset = 0;
+  private lastViewport = 1;
+  private readonly unsubscribe: () => void;
+  private readonly theme: ChildRunTheme;
+
+  constructor(
+    private readonly registry: AgentMemoryRegistry,
+    private readonly path: string,
+    private readonly tui: TuiLike,
+    private readonly keybindings: KeybindingsLike,
+    private readonly onClose: () => void,
+    theme?: unknown,
+  ) {
+    this.theme = resolveTheme(theme);
+    this.unsubscribe = registry.subscribe(() => this.tui.requestRender());
+  }
+
+  render(width: number): string[] {
+    const safeWidth = Math.max(1, width);
+    const height = Math.max(1, this.tui.terminal.rows);
+    const showTitle = height >= 2;
+    const showHint = height >= 3;
+    const chrome = Number(showTitle) + Number(showHint);
+    const viewport = Math.max(1, height - chrome);
+    this.lastViewport = viewport;
+    const entry = this.registry.getEntry(this.path);
+    const allLines =
+      entry === undefined
+        ? new Text(
+            this.theme.fg(
+              "warning",
+              "Selected project memory is no longer available.",
+            ),
+            0,
+            0,
+          ).render(safeWidth)
+        : memoryDetailContentLines(entry, safeWidth, this.theme);
+    this.lastMaxOffset = Math.max(0, allLines.length - viewport);
+    this.offset = Math.min(this.offset, this.lastMaxOffset);
+
+    const visible = allLines.slice(this.offset, this.offset + viewport);
+    while (visible.length < viewport) visible.push("");
+
+    const title = this.theme.fg(
+      "toolTitle",
+      this.theme.bold(` Project memory · ${taskOneLine(this.path)} `),
+    );
+    const borderWidth = Math.max(1, safeWidth - visibleWidth(title));
+    const first = allLines.length === 0 ? 0 : this.offset + 1;
+    const last = Math.min(allLines.length, this.offset + viewport);
+    const position = `${first}-${last}/${allLines.length}`;
+    const output: string[] = [];
+    if (showTitle) {
+      output.push(
+        styledLine(
+          `${title}${this.theme.fg("borderMuted", "─".repeat(borderWidth))}`,
+          safeWidth,
+        ),
+      );
+    }
+    output.push(...visible.map((item) => styledLine(item, safeWidth)));
+    if (showHint) {
+      const hint = this.theme.fg(
+        "dim",
+        "↑↓ scroll  PgUp/PgDn page  Home/End  Esc/←/b/q close  ",
+      );
+      output.push(
+        styledLine(`${hint}${this.theme.fg("muted", position)}`, safeWidth),
+      );
+    }
+    return output.slice(0, height);
+  }
+
+  handleInput(data: string): void {
+    if (
+      data === "q" ||
+      data === "b" ||
+      this.matches(data, "tui.select.cancel") ||
+      this.matches(data, "tui.editor.cursorLeft") ||
+      defaultKeyMatches(data, "tui.select.cancel") ||
+      defaultKeyMatches(data, "tui.editor.cursorLeft")
+    ) {
+      this.onClose();
+      return;
+    }
+
+    const page = Math.max(1, this.lastViewport - 1);
+    if (
+      data === "k" ||
+      this.matches(data, "tui.select.up") ||
+      defaultKeyMatches(data, "tui.select.up")
+    ) {
+      this.offset = Math.max(0, this.offset - 1);
+    } else if (
+      this.matches(data, "tui.select.pageUp") ||
+      defaultKeyMatches(data, "tui.select.pageUp")
+    ) {
+      this.offset = Math.max(0, this.offset - page);
+    } else if (
+      data === "j" ||
+      this.matches(data, "tui.select.down") ||
+      defaultKeyMatches(data, "tui.select.down")
+    ) {
+      this.offset = Math.min(this.lastMaxOffset, this.offset + 1);
+    } else if (
+      this.matches(data, "tui.select.pageDown") ||
+      defaultKeyMatches(data, "tui.select.pageDown")
+    ) {
+      this.offset = Math.min(this.lastMaxOffset, this.offset + page);
+    } else if (
+      this.matches(data, "tui.editor.cursorLineStart") ||
+      defaultKeyMatches(data, "tui.editor.cursorLineStart")
+    ) {
+      this.offset = 0;
+    } else if (
+      this.matches(data, "tui.editor.cursorLineEnd") ||
+      defaultKeyMatches(data, "tui.editor.cursorLineEnd")
+    ) {
+      this.offset = this.lastMaxOffset;
+    } else return;
+    this.tui.requestRender();
+  }
+
+  invalidate(): void {}
+
+  dispose(): void {
+    this.unsubscribe();
+  }
+
+  getOffset(): number {
+    return this.offset;
+  }
+
+  private matches(data: string, keybinding: string): boolean {
+    try {
+      return this.keybindings.matches(data, keybinding);
+    } catch {
+      return false;
+    }
+  }
+}
+
 type MountState = "unmounted" | "mounted" | "disposed";
 
 export const CHILD_RUNS_WIDGET_KEY = "pi-harness-child-runs";
@@ -1117,7 +1411,9 @@ const sameCursor = (
  */
 export interface ChildRunsPanelOptions {
   readonly bitIssues?: BitIssueRegistry;
+  readonly agentMemory?: AgentMemoryRegistry;
   readonly refreshBitIssues?: () => void | Promise<unknown>;
+  readonly refreshCoordination?: () => void | Promise<unknown>;
   readonly killRun?: (runId: string) => ChildRunKillResult;
 }
 
@@ -1154,6 +1450,11 @@ export class ChildRunsPanelController {
   }
 
   ensureVisibleForIssues(ctx: BrowserContextLike): void {
+    if (this.hiddenByUser) return;
+    this.show(ctx, false);
+  }
+
+  ensureVisibleForMemory(ctx: BrowserContextLike): void {
     if (this.hiddenByUser) return;
     this.show(ctx, false);
   }
@@ -1230,6 +1531,7 @@ export class ChildRunsPanelController {
             this.bitIssueBindings(),
             theme,
             (runId) => this.killRun(runId),
+            this.agentMemoryBindings(),
           );
           if (preferred !== undefined) component.prefer(preferred);
           this.component = component;
@@ -1295,6 +1597,7 @@ export class ChildRunsPanelController {
             this.bitIssueBindings(),
             theme,
             (runId) => this.killRun(runId),
+            this.agentMemoryBindings(),
           );
           if (preferred !== undefined) component.prefer(preferred);
           if (refreshOnFocus) void this.options.refreshBitIssues?.();
@@ -1479,6 +1782,72 @@ export class ChildRunsPanelController {
       });
   }
 
+  private openMemoryDetail(path: string): void {
+    const { ui } = this;
+    const registry = this.options.agentMemory;
+    if (registry === undefined) return;
+    if (ui?.custom === undefined) {
+      ui?.notify(
+        "Project memory detail view requires custom TUI support.",
+        "warning",
+      );
+      return;
+    }
+    if (this.detailPromise !== undefined) return;
+
+    let detailPromise: Promise<void>;
+    try {
+      detailPromise = ui.custom<void>(
+        (tui, theme, keybindings, done) => {
+          let closed = false;
+          const close = () => {
+            if (closed) return;
+            closed = true;
+            done(undefined);
+          };
+          this.detailClose = close;
+          return new AgentMemoryDetailComponent(
+            registry,
+            path,
+            tui,
+            keybindings,
+            close,
+            theme,
+          );
+        },
+        {
+          overlay: true,
+          overlayOptions: {
+            width: "100%",
+            maxHeight: "100%",
+            anchor: "center",
+            margin: 0,
+          },
+        },
+      );
+    } catch (error) {
+      ui.notify(
+        `Project memory detail view could not open: ${String(error)}`,
+        "warning",
+      );
+      return;
+    }
+
+    this.detailPromise = detailPromise;
+    void detailPromise
+      .catch((error) => {
+        ui.notify(
+          `Project memory detail view could not open: ${String(error)}`,
+          "warning",
+        );
+      })
+      .finally(() => {
+        if (this.detailPromise !== detailPromise) return;
+        this.detailPromise = undefined;
+        this.detailClose = undefined;
+      });
+  }
+
   private killRun(runId: string): void {
     const result = this.options.killRun?.(runId);
     if (result === undefined) {
@@ -1514,7 +1883,19 @@ export class ChildRunsPanelController {
       registry,
       onInspect: (issueId) => this.openIssueDetail(issueId),
       onRefresh: async () => {
-        await this.options.refreshBitIssues?.();
+        await this.options.refreshCoordination?.();
+      },
+    };
+  }
+
+  private agentMemoryBindings(): AgentMemoryBrowserBindings | undefined {
+    const registry = this.options.agentMemory;
+    if (registry === undefined) return undefined;
+    return {
+      registry,
+      onInspect: (path) => this.openMemoryDetail(path),
+      onRefresh: async () => {
+        await this.options.refreshCoordination?.();
       },
     };
   }
@@ -1638,10 +2019,16 @@ export class ChildRunsPanelController {
     }
     if (this.focusWarningShown) return;
     this.focusWarningShown = true;
-    const fallbackKeys =
-      this.options.bitIssues === undefined
-        ? "/subagents or Ctrl+Alt+S"
-        : "/subagents, /bit-issues, Ctrl+Alt+S, or Ctrl+Alt+I";
+    const fallbackKeys = [
+      "/subagents",
+      this.options.bitIssues === undefined ? undefined : "/bit-issues",
+      this.options.agentMemory === undefined ? undefined : "/project-memory",
+      "Ctrl+Alt+S",
+      this.options.bitIssues === undefined ? undefined : "Ctrl+Alt+I",
+      this.options.agentMemory === undefined ? undefined : "Ctrl+Alt+M",
+    ]
+      .filter((item): item is string => item !== undefined)
+      .join(", ");
     this.ui?.notify(
       `Coordination browser focus degraded: ${reason}. Use ${fallbackKeys} for the public overlay fallback.`,
       "warning",

--- a/pi/extensions/pi-harness/features/child-runs/ui.ts
+++ b/pi/extensions/pi-harness/features/child-runs/ui.ts
@@ -267,41 +267,14 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
     const memories = memorySnapshot?.entries ?? [];
     this.syncSelection(runs, issues, memories);
 
-    const body = this.renderList(
+    return this.renderList(
       snapshots,
       runs,
       issues,
       memories,
       safeWidth,
-      height - 1,
+      height,
     );
-    let issueState = "";
-    if (issueSnapshot?.loading === true) issueState = " · refreshing";
-    else if (issueSnapshot?.stale === true) issueState = " · stale";
-    else if (issueSnapshot?.error !== undefined) issueState = " · unavailable";
-    let memoryState = "";
-    if (memorySnapshot?.loading === true) memoryState = " · refreshing";
-    else if (memorySnapshot?.stale === true) memoryState = " · stale";
-    else if (memorySnapshot?.error !== undefined)
-      memoryState = " · unavailable";
-    const counts = [
-      `Child sessions: ${runs.length}`,
-      this.bitIssues === undefined
-        ? undefined
-        : `Open bit issues: ${issues.length}${issueState}`,
-      this.agentMemory === undefined
-        ? undefined
-        : `Project memory: ${memories.length}${memoryState}`,
-    ].filter((item): item is string => item !== undefined);
-    const title =
-      this.bitIssues === undefined && this.agentMemory === undefined
-        ? " Child sessions "
-        : ` ${counts.join(" | ")} `;
-    const borderWidth = Math.max(1, safeWidth - visibleWidth(title));
-    return [
-      line(`${title}${"─".repeat(borderWidth)}`, safeWidth),
-      ...body,
-    ].slice(0, height);
   }
 
   handleInput(data: string): void {
@@ -494,12 +467,7 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
 
     const rendered: BrowserRow[] = [];
     if (runs.length > 0) {
-      if (this.bitIssues !== undefined || this.agentMemory !== undefined)
-        rendered.push({ text: "Child sessions" });
       for (const invocation of snapshots) {
-        rendered.push({
-          text: `${invocation.label} · ${invocation.source} · ${invocation.runs.length} run(s)`,
-        });
         for (const run of invocation.runs) {
           const stage =
             run.stageIndex === undefined
@@ -521,7 +489,6 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
       }
     }
     if (issues.length > 0) {
-      rendered.push({ text: "Open bit issues" });
       for (const issue of issues) {
         const selection: BrowserSelection = { kind: "issue", id: issue.id };
         rendered.push({
@@ -539,7 +506,6 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
       });
     }
     if (memories.length > 0) {
-      rendered.push({ text: "Project memory" });
       for (const entry of memories) {
         const selection: BrowserSelection = {
           kind: "memory",

--- a/pi/extensions/pi-harness/index.ts
+++ b/pi/extensions/pi-harness/index.ts
@@ -38,6 +38,7 @@ import setupSubagent from "./features/subagent/index";
 import setupWorkflow from "./features/workflow/index";
 import setupBitTask from "./features/bit-task/index";
 import setupAgentMemory from "./features/agent-memory/index";
+import { AgentMemoryRegistry } from "./features/agent-memory/registry";
 import setupStatusline from "./features/statusline/index";
 import setupProviderLog from "./features/provider-log/index";
 import setupAsukuNotify from "./features/asuku-notify/index";
@@ -127,12 +128,18 @@ const setupHarness = (
   // Reserve the parent turn before either hook-bridge partition registers its
   // async before_agent_start handler. This manager has no tool_call handler, so
   // the npm preflight still remains first in the command-permission chain.
+  const agentMemory =
+    config.features["agent-memory"] && !config.isChild
+      ? new AgentMemoryRegistry({ trust: config.trust })
+      : undefined;
   const childRuns =
     config.features.subagent ||
     config.features.workflow ||
-    config.features["bit-task"]
+    config.features["bit-task"] ||
+    agentMemory !== undefined
       ? setupChildRuns(pi, {
           bitIssues: config.features["bit-task"],
+          agentMemory,
           childExecution: config.features.subagent || config.features.workflow,
         })
       : undefined;
@@ -196,7 +203,12 @@ const setupHarness = (
       onWorktreeRemoved: (path) => bashSandbox.revokeWritableWorktree(path),
     });
   }
-  if (config.features["agent-memory"]) setupAgentMemory(pi, config);
+  if (config.features["agent-memory"])
+    setupAgentMemory(
+      pi,
+      config,
+      agentMemory === undefined ? {} : { registry: agentMemory },
+    );
   if (config.features.statusline) setupStatusline(pi, config);
   if (config.features["provider-log"]) setupProviderLog(pi, config);
   if (config.features["ask-user-question"]) setupAskUserQuestion(pi);

--- a/tests/pi-harness/agent-memory.test.ts
+++ b/tests/pi-harness/agent-memory.test.ts
@@ -12,6 +12,7 @@ import {
   type MemoryAggregate,
 } from "../../pi/extensions/pi-harness/features/agent-memory/cli";
 import type { SourcedMemoryRecord } from "../../pi/extensions/pi-harness/features/agent-memory/model";
+import { AgentMemoryRegistry } from "../../pi/extensions/pi-harness/features/agent-memory/registry";
 import { resolvePaths } from "../../pi/extensions/pi-harness/lib/paths";
 import { createFakePi } from "./fake-pi";
 
@@ -107,6 +108,22 @@ const resultText = (result: {
 const occurrences = (value: string, needle: string): number =>
   value.split(needle).length - 1;
 
+const onAbort = (
+  signal: AbortSignal | undefined,
+  callback: () => void,
+): void => {
+  const candidate = signal as unknown as
+    | {
+        addEventListener?(
+          event: "abort",
+          callback: () => void,
+          options: { once: true },
+        ): void;
+      }
+    | undefined;
+  candidate?.addEventListener?.("abort", callback, { once: true });
+};
+
 describe("agent-memory pi feature", () => {
   test("registers parent read/write tools but keeps child mutation unavailable", () => {
     const parent = createFakePi({ cwd: "/repo" });
@@ -122,6 +139,203 @@ describe("agent-memory pi feature", () => {
       cwd: "/repo",
     });
     expect(child.tools.map(({ name }) => name)).toEqual(["memory_recall"]);
+  });
+
+  test("shares one in-flight aggregate between the browser registry and startup recall", async () => {
+    let aggregateCalls = 0;
+    let release = (): void => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const source: AgentMemoryDataSource = {
+      aggregate: async () => {
+        aggregateCalls += 1;
+        await gate;
+        return aggregate();
+      },
+      update: async () => {
+        throw new Error("unused");
+      },
+    };
+    const registry = new AgentMemoryRegistry({
+      cli: source,
+      trust: { trustedRoots: ["/repo"] },
+    });
+    const pi = createFakePi({ cwd: "/repo", sessionId: "shared-refresh" });
+    setupAgentMemory(pi, config(), { registry, cwd: "/repo" });
+
+    const browserRefresh = registry.refresh("/repo");
+    const startupRecall = pi.emitBeforeAgentStart({
+      type: "before_agent_start",
+      prompt: "start",
+      systemPrompt: "base",
+    });
+    release();
+    const [outcome, startup] = await Promise.all([
+      browserRefresh,
+      startupRecall,
+    ]);
+
+    expect(outcome.ok).toBe(true);
+    expect(aggregateCalls).toBe(1);
+    expect(registry.getSnapshot().entries.map((entry) => entry.path)).toEqual([
+      "project/architecture.md",
+    ]);
+    expect(startup?.message?.customType).toBe(AGENT_MEMORY_RECALL_TYPE);
+  });
+
+  test("isolates shared refresh waiters and aborts the work only when none remain", async () => {
+    let finish = (): void => {};
+    let underlyingAborted = false;
+    const source: AgentMemoryDataSource = {
+      aggregate: async (_cwd, _trust, signal) =>
+        new Promise<MemoryAggregate>((resolve, reject) => {
+          finish = () => resolve(aggregate());
+          onAbort(signal, () => {
+            underlyingAborted = true;
+            reject(new AgentMemoryCliError("aborted", "aborted"));
+          });
+        }),
+      update: async () => {
+        throw new Error("unused");
+      },
+    };
+    const registry = new AgentMemoryRegistry({
+      cli: source,
+      trust: { trustedRoots: ["/repo"] },
+    });
+    const browserRefresh = registry.refresh("/repo");
+    const controller = new AbortController() as unknown as {
+      readonly signal: AbortSignal;
+      abort(): void;
+    };
+    const cancelledRecall = registry.refresh("/repo", controller.signal);
+    controller.abort();
+
+    const cancelledOutcome = await cancelledRecall;
+    expect(cancelledOutcome.ok).toBe(false);
+    expect(underlyingAborted).toBe(false);
+    finish();
+    const browserOutcome = await browserRefresh;
+    expect(browserOutcome.ok).toBe(true);
+
+    let singleAborted = false;
+    const singleSource: AgentMemoryDataSource = {
+      aggregate: async (_cwd, _trust, signal) =>
+        new Promise<MemoryAggregate>((_resolve, reject) => {
+          onAbort(signal, () => {
+            singleAborted = true;
+            reject(new AgentMemoryCliError("aborted", "aborted"));
+          });
+        }),
+      update: async () => {
+        throw new Error("unused");
+      },
+    };
+    const singleRegistry = new AgentMemoryRegistry({
+      cli: singleSource,
+      trust: { trustedRoots: ["/repo"] },
+    });
+    const singleController = new AbortController() as unknown as {
+      readonly signal: AbortSignal;
+      abort(): void;
+    };
+    const onlyWaiter = singleRegistry.refresh("/repo", singleController.signal);
+    singleController.abort();
+    const onlyOutcome = await onlyWaiter;
+    expect(onlyOutcome.ok).toBe(false);
+    expect(singleAborted).toBe(true);
+  });
+
+  test("contains subscriber failures without poisoning refresh", async () => {
+    const registry = new AgentMemoryRegistry({
+      cli: dataSource(),
+      trust: { trustedRoots: ["/repo"] },
+    });
+    let notifications = 0;
+    registry.subscribe(() => {
+      throw new Error("renderer failed");
+    });
+    registry.subscribe(() => {
+      notifications += 1;
+    });
+
+    const outcome = await registry.refresh("/repo");
+    expect(outcome.ok).toBe(true);
+    expect(notifications).toBe(3);
+  });
+
+  test("retains stale UI data without returning it as a successful recall", async () => {
+    let fail = false;
+    const source: AgentMemoryDataSource = {
+      aggregate: async () => {
+        if (fail) {
+          throw new AgentMemoryCliError("invalid-data", "corrupt notes");
+        }
+        return aggregate();
+      },
+      update: async () => {
+        throw new Error("unused");
+      },
+    };
+    const registry = new AgentMemoryRegistry({
+      cli: source,
+      trust: { trustedRoots: ["/repo"] },
+    });
+    const initial = await registry.refresh("/repo");
+    expect(initial.ok).toBe(true);
+    fail = true;
+
+    const failed = await registry.refresh("/repo");
+    expect(failed.ok).toBe(false);
+    expect(registry.getSnapshot()).toMatchObject({
+      stale: true,
+      error: "corrupt notes",
+      entries: [{ path: "project/architecture.md" }],
+    });
+    await expect(registry.aggregate("/repo")).rejects.toThrow("corrupt notes");
+  });
+
+  test("refreshes the browser snapshot after a successful memory update", async () => {
+    let current = aggregate();
+    const replacement = sourced("project/replacement.md");
+    const source: AgentMemoryDataSource = {
+      aggregate: async () => current,
+      update: async (_cwd, _trust, _sessionId, input) => {
+        current = aggregate([replacement]);
+        return {
+          status: "written",
+          path: input.path,
+          sourceRef: replacement.sourceRef,
+          deleted: false,
+          updatedAt: replacement.record.updatedAt,
+        };
+      },
+    };
+    const registry = new AgentMemoryRegistry({
+      cli: source,
+      trust: { trustedRoots: ["/repo"] },
+    });
+    const pi = createFakePi({ cwd: "/repo", sessionId: "update-refresh" });
+    setupAgentMemory(pi, config(), { registry, cwd: "/repo" });
+    await registry.refresh("/repo");
+
+    await tool(pi, "memory_update").execute(
+      "replace",
+      {
+        action: "put",
+        path: "project/replacement.md",
+        description: "Replacement",
+        content: "Updated",
+      } as never,
+      undefined,
+      undefined,
+      pi.ctx,
+    );
+
+    expect(registry.getSnapshot().entries.map((entry) => entry.path)).toEqual([
+      "project/replacement.md",
+    ]);
   });
 
   test("injects role-specific proactive stewardship guidance idempotently", async () => {

--- a/tests/pi-harness/child-run-layout.test.ts
+++ b/tests/pi-harness/child-run-layout.test.ts
@@ -61,7 +61,7 @@ const createLayout = async (
     toolCallId: "layout-parent",
     source: "workflow",
     label: "workflow",
-    runs: Array.from({ length: 30 }, (_, taskIndex) => ({
+    runs: Array.from({ length: includeIssues ? 2 : 30 }, (_, taskIndex) => ({
       agent: `agent-${taskIndex}`,
       task: `inspect task ${taskIndex}`,
       taskIndex,
@@ -174,7 +174,7 @@ describe("child-session browser normal-flow layout", () => {
     });
   }
 
-  test("keeps the same total budget when child and issue sections coexist", async () => {
+  test("keeps the same total budget when flat child and issue rows coexist", async () => {
     for (const [rows, columns, expectedPanelHeight] of [
       [24, 80, 6],
       [40, 120, 10],
@@ -185,7 +185,10 @@ describe("child-session browser normal-flow layout", () => {
         true,
       );
       expect(browserLines).toHaveLength(expectedPanelHeight);
-      expect(browserLines[0]).toContain("Open bit issues: 30");
+      expect(browserLines[0]).toContain("agent-0");
+      expect(browserLines[1]).toContain("agent-1");
+      expect(browserLines[2]).toContain("#issue-0");
+      expect(browserLines.join("\n")).not.toContain("Open bit issues");
       for (const editorLine of new Set(editorLines)) {
         expect(countLine(viewport, editorLine)).toBeGreaterThanOrEqual(
           countLine(editorLines, editorLine),

--- a/tests/pi-harness/child-run-ui.test.ts
+++ b/tests/pi-harness/child-run-ui.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
+import type { MemoryAggregate } from "../../pi/extensions/pi-harness/features/agent-memory/cli";
+import type { SourcedMemoryRecord } from "../../pi/extensions/pi-harness/features/agent-memory/model";
+import {
+  AgentMemoryRegistry,
+  type AgentMemoryDataSource,
+} from "../../pi/extensions/pi-harness/features/agent-memory/registry";
 import {
   readFocusedComponent,
   setFocusSafely,
@@ -14,6 +20,7 @@ import {
 } from "../../pi/extensions/pi-harness/features/bit-issues/registry";
 import { ChildRunRegistry } from "../../pi/extensions/pi-harness/features/child-runs/registry";
 import {
+  AgentMemoryDetailComponent,
   BitIssueDetailComponent,
   ChildRunDetailComponent,
   ChildRunsBrowserComponent,
@@ -699,7 +706,44 @@ const bitDetail = (
   comments: options.comments ?? { status: "none" },
 });
 
-const setupCombined = async (issueIds: string[], childCount = 0) => {
+const memoryEntry = (path: string, index: number): SourcedMemoryRecord => ({
+  record: {
+    version: 1,
+    path,
+    description: `Memory description ${index}`,
+    updatedAt: `2026-08-${String(index + 1).padStart(2, "0")}T08:00:00.000Z`,
+    deleted: false,
+    content: `Durable content ${index}`,
+  },
+  sourceRef: `refs/notes/pi-agent-memory/sessions/${"a".repeat(64)}/writers/${"b".repeat(64)}`,
+  targetOid: String(index).padStart(40, "c"),
+});
+
+const memoryAggregate = (paths: string[]): MemoryAggregate => {
+  const entries = paths.map(memoryEntry);
+  return {
+    repository: {
+      cwd: "/repo",
+      topLevel: "/repo",
+      commonDir: "/repo/.git",
+      objectFormat: "sha1",
+      trustSource: "direct",
+    },
+    merged: {
+      entries: new Map(entries.map((entry) => [entry.record.path, entry])),
+      deleted: new Map(),
+    },
+    refs: [],
+    diagnostics: [],
+    truncated: false,
+  };
+};
+
+const setupCombined = async (
+  issueIds: string[],
+  childCount = 0,
+  memoryPaths?: string[],
+) => {
   const base = setup(40);
   base.component.dispose();
   if (childCount > 0) addRuns(base.registry, childCount);
@@ -714,6 +758,27 @@ const setupCombined = async (issueIds: string[], childCount = 0) => {
   await issues.refresh("/repo");
   const inspectedIssues: string[] = [];
   let refreshes = 0;
+  let currentMemoryPaths = memoryPaths;
+  const memorySource: AgentMemoryDataSource = {
+    aggregate: async () => memoryAggregate(currentMemoryPaths ?? []),
+    update: async () => {
+      throw new Error("unused");
+    },
+  };
+  const memory =
+    memoryPaths === undefined
+      ? undefined
+      : new AgentMemoryRegistry({
+          cli: memorySource,
+          trust: { trustedRoots: ["/repo"] },
+          now: () => 200,
+        });
+  if (memory !== undefined) {
+    memory.beginSession("/repo");
+    await memory.refresh("/repo");
+  }
+  const inspectedMemory: string[] = [];
+  let memoryRefreshes = 0;
   const component = new ChildRunsBrowserComponent(
     base.registry,
     base.tui,
@@ -730,6 +795,15 @@ const setupCombined = async (issueIds: string[], childCount = 0) => {
     },
     undefined,
     (runId) => base.killed.push(runId),
+    memory === undefined
+      ? undefined
+      : {
+          registry: memory,
+          onInspect: (path) => inspectedMemory.push(path),
+          onRefresh: () => {
+            memoryRefreshes += 1;
+          },
+        },
   );
   return {
     ...base,
@@ -737,9 +811,15 @@ const setupCombined = async (issueIds: string[], childCount = 0) => {
     issues,
     details,
     inspectedIssues,
+    memory,
+    inspectedMemory,
     getRefreshes: () => refreshes,
+    getMemoryRefreshes: () => memoryRefreshes,
     setIssueIds(ids: string[]) {
       currentList = bitList(...ids);
+    },
+    setMemoryPaths(paths: string[]) {
+      currentMemoryPaths = paths;
     },
   };
 };
@@ -762,6 +842,34 @@ describe("combined coordination browser", () => {
       combinedLines.indexOf("Open bit issues"),
     );
     expect(combinedLines.every((item) => visibleWidth(item) <= 80)).toBe(true);
+  });
+
+  test("renders project memory below open issues and navigates into its detail", async () => {
+    const combined = await setupCombined(["issue-a"], 1, [
+      "reference/zeta.md",
+      "project/alpha.md",
+    ]);
+    const lines = combined.component.render(100);
+    expect(lines[0]).toContain("Project memory: 2");
+    expect(lines.indexOf("Open bit issues")).toBeLessThan(
+      lines.indexOf("Project memory"),
+    );
+    expect(lines.join("\n")).toContain("project/alpha.md");
+
+    combined.component.handleInput("down");
+    combined.component.handleInput("down");
+    expect(combined.component.getSelectedMemoryPath()).toBe("project/alpha.md");
+    combined.component.handleInput("enter");
+    expect(combined.inspectedMemory).toEqual(["project/alpha.md"]);
+
+    combined.setMemoryPaths([
+      "project/000-new.md",
+      "project/alpha.md",
+      "reference/zeta.md",
+    ]);
+    await combined.memory?.refresh("/repo");
+    combined.component.render(100);
+    expect(combined.component.getSelectedMemoryPath()).toBe("project/alpha.md");
   });
 
   test("moves selection across child and issue rows and dispatches typed detail", async () => {
@@ -810,6 +918,58 @@ describe("combined coordination browser", () => {
     pending.component.prefer("child");
     const [runId] = addRuns(pending.registry, 1);
     expect(pending.component.getSelectedRunId()).toBe(runId);
+  });
+});
+
+describe("project memory detail component", () => {
+  test("renders bounded untrusted content and scrolls to the final line", async () => {
+    const { tui, keybindings } = setup(12);
+    const base = memoryEntry("project/alpha.md", 0);
+    const entry: SourcedMemoryRecord = {
+      ...base,
+      record: {
+        ...base.record,
+        description: "Architecture decision 界😀",
+        content: `${"durable line 界😀 ".repeat(80)}\nCONTENT-END\u001b]2;spoof\u0007`,
+      },
+    };
+    const aggregate: MemoryAggregate = {
+      ...memoryAggregate([]),
+      merged: {
+        entries: new Map([[entry.record.path, entry]]),
+        deleted: new Map(),
+      },
+    };
+    const source: AgentMemoryDataSource = {
+      aggregate: async () => aggregate,
+      update: async () => {
+        throw new Error("unused");
+      },
+    };
+    const registry = new AgentMemoryRegistry({
+      cli: source,
+      trust: { trustedRoots: ["/repo"] },
+    });
+    registry.beginSession("/repo");
+    await registry.refresh("/repo");
+    let closes = 0;
+    const detail = new AgentMemoryDetailComponent(
+      registry,
+      "project/alpha.md",
+      tui,
+      keybindings,
+      () => closes++,
+    );
+
+    const initial = detail.render(24);
+    expect(initial.join("\n")).toContain("project/alpha.md");
+    expect(initial.every((line) => visibleWidth(line) <= 24)).toBe(true);
+    expect(stripTerminalControls(initial.join("\n"))).not.toContain("spoof");
+
+    detail.handleInput("end");
+    expect(detail.render(24).join("\n")).toContain("CONTENT-END");
+    detail.handleInput("b");
+    expect(closes).toBe(1);
   });
 });
 

--- a/tests/pi-harness/child-run-ui.test.ts
+++ b/tests/pi-harness/child-run-ui.test.ts
@@ -210,7 +210,7 @@ describe("child-session browser component", () => {
     expect(lines.every((item) => visibleWidth(item) <= 24)).toBe(true);
   });
 
-  test("caps populated height and uses every row after the title for content", () => {
+  test("caps populated height and uses every row for flat content", () => {
     for (const [rows, expectedHeight] of [
       [24, 6],
       [40, 10],
@@ -221,7 +221,7 @@ describe("child-session browser component", () => {
       const lines = component.render(80);
       expect(lines).toHaveLength(expectedHeight);
       expect(lines.join("\n")).not.toContain("↑↓ select");
-      expect(lines.at(-1)).toContain(`agent-${expectedHeight - 3}`);
+      expect(lines.at(-1)).toContain(`agent-${expectedHeight - 1}`);
     }
   });
 
@@ -825,22 +825,19 @@ const setupCombined = async (
 };
 
 describe("combined coordination browser", () => {
-  test("renders issue-only and combined sections in the old height budget", async () => {
+  test("renders child and issue rows in one flat height budget", async () => {
     const issueOnly = await setupCombined(["issue-a", "issue-b"]);
     const onlyLines = issueOnly.component.render(80);
-    expect(onlyLines[0]).toContain("Child sessions: 0 | Open bit issues: 2");
-    expect(onlyLines.join("\n")).toContain("Open bit issues");
-    expect(onlyLines.join("\n")).toContain("#issue-a");
+    expect(onlyLines[0]).toContain("#issue-a");
+    expect(onlyLines.join("\n")).not.toContain("Open bit issues");
     expect(issueOnly.component.getSelectedIssueId()).toBe("issue-a");
 
     const combined = await setupCombined(["issue-a"], 1);
     const combinedLines = combined.component.render(80);
     expect(combinedLines.length).toBeLessThanOrEqual(10);
-    expect(combinedLines.join("\n")).toContain("Child sessions");
-    expect(combinedLines.join("\n")).toContain("Open bit issues");
-    expect(combinedLines.indexOf("Child sessions")).toBeLessThan(
-      combinedLines.indexOf("Open bit issues"),
-    );
+    expect(combinedLines[0]).toContain("agent-0");
+    expect(combinedLines[1]).toContain("#issue-a");
+    expect(combinedLines.join("\n")).not.toContain("Child sessions");
     expect(combinedLines.every((item) => visibleWidth(item) <= 80)).toBe(true);
   });
 
@@ -850,11 +847,10 @@ describe("combined coordination browser", () => {
       "project/alpha.md",
     ]);
     const lines = combined.component.render(100);
-    expect(lines[0]).toContain("Project memory: 2");
-    expect(lines.indexOf("Open bit issues")).toBeLessThan(
-      lines.indexOf("Project memory"),
-    );
-    expect(lines.join("\n")).toContain("project/alpha.md");
+    expect(lines[0]).toContain("agent-0");
+    expect(lines[1]).toContain("#issue-a");
+    expect(lines[2]).toContain("project/alpha.md");
+    expect(lines.join("\n")).not.toContain("Project memory");
 
     combined.component.handleInput("down");
     combined.component.handleInput("down");

--- a/tests/pi-harness/harness-composition.test.ts
+++ b/tests/pi-harness/harness-composition.test.ts
@@ -3,6 +3,11 @@ import {
   loadConfig,
   type HarnessConfig,
 } from "../../pi/extensions/pi-harness/config";
+import type { MemoryAggregate } from "../../pi/extensions/pi-harness/features/agent-memory/cli";
+import {
+  AgentMemoryRegistry,
+  type AgentMemoryDataSource,
+} from "../../pi/extensions/pi-harness/features/agent-memory/registry";
 import {
   BitIssueCli,
   BoundedCommandError,
@@ -192,10 +197,15 @@ describe("pi-harness coordination browser composition", () => {
     const parent = registration(parentConfig);
     expect(parent.tools).toContain("memory_recall");
     expect(parent.tools).toContain("memory_update");
+    expect(parent.commands.has("subagents")).toBe(true);
+    expect(parent.commands.has("project-memory")).toBe(true);
+    expect(parent.shortcuts.has("ctrl+alt+m")).toBe(true);
 
     const child = registration({ ...parentConfig, isChild: true });
     expect(child.tools).toContain("memory_recall");
     expect(child.tools).not.toContain("memory_update");
+    expect(child.commands.has("subagents")).toBe(false);
+    expect(child.commands.has("project-memory")).toBe(false);
   });
 
   test("PI_HARNESS_CHILD=1 keeps read-only memory but disables resident sources", () => {
@@ -476,6 +486,104 @@ describe("open bit issue browser lifecycle", () => {
       throw new Error("bit-issues shortcut missing");
     await bitIssuesShortcut.handler(runtime.context);
     expect(runtime.getComponent()).toBeDefined();
+    await runtime.emit("session_shutdown");
+    expect(runtime.getComponent()).toBeUndefined();
+    expect(runtime.hasTerminalInput()).toBe(false);
+  });
+});
+
+describe("project memory browser lifecycle", () => {
+  test("background-mounts, focuses, refreshes, and disposes memory-only state", async () => {
+    const runtime = createIssueRuntime();
+    let aggregateCalls = 0;
+    const aggregate: MemoryAggregate = {
+      repository: {
+        cwd: "/repo",
+        topLevel: "/repo",
+        commonDir: "/repo/.git",
+        objectFormat: "sha1",
+        trustSource: "direct",
+      },
+      merged: {
+        entries: new Map([
+          [
+            "project/architecture.md",
+            {
+              record: {
+                version: 1,
+                path: "project/architecture.md",
+                description: "Architecture decision",
+                updatedAt: "2026-08-03T08:00:00.000Z",
+                deleted: false,
+                content: "Use the shared registry.",
+              },
+              sourceRef: `refs/notes/pi-agent-memory/sessions/${"a".repeat(64)}/writers/${"b".repeat(64)}`,
+              targetOid: "c".repeat(40),
+            },
+          ],
+        ]),
+        deleted: new Map(),
+      },
+      refs: [],
+      diagnostics: [],
+      truncated: false,
+    };
+    const source: AgentMemoryDataSource = {
+      aggregate: async () => {
+        aggregateCalls += 1;
+        return aggregate;
+      },
+      update: async () => {
+        throw new Error("unused");
+      },
+    };
+    const memory = new AgentMemoryRegistry({
+      cli: source,
+      trust: { trustedRoots: ["/repo"] },
+    });
+    setupChildRuns(runtime.pi, {
+      agentMemory: memory,
+      childExecution: false,
+    });
+
+    await runtime.emit("session_start");
+    await Bun.sleep(0);
+    expect(runtime.getComponent()?.render(100)[0]).toContain(
+      "Project memory: 1",
+    );
+    expect(runtime.getComponent()?.render(100).join("\n")).toContain(
+      "project/architecture.md",
+    );
+
+    const callsAfterSessionStart = aggregateCalls;
+    await runtime.emit("agent_settled");
+    await Bun.sleep(0);
+    expect(aggregateCalls).toBe(callsAfterSessionStart);
+    const subagents = runtime.commands.get("subagents");
+    if (subagents === undefined) throw new Error("subagents command missing");
+    await subagents.handler("", runtime.context);
+    expect(aggregateCalls).toBe(callsAfterSessionStart);
+
+    const command = runtime.commands.get("project-memory");
+    if (command === undefined)
+      throw new Error("project-memory command missing");
+    const callsBeforeCommand = aggregateCalls;
+    await command.handler("", runtime.context);
+    expect(aggregateCalls).toBe(callsBeforeCommand + 1);
+    expect(
+      (
+        runtime.getComponent() as RuntimeComponent & {
+          getSelectedMemoryPath(): string | undefined;
+        }
+      ).getSelectedMemoryPath(),
+    ).toBe("project/architecture.md");
+    expect(runtime.tui.focusedComponent).toBe(runtime.getComponent() ?? null);
+
+    const callsBeforeR = aggregateCalls;
+    runtime.getComponent()?.handleInput?.("r");
+    await Bun.sleep(0);
+    expect(aggregateCalls).toBeGreaterThan(callsBeforeR);
+
     await runtime.emit("session_shutdown");
     expect(runtime.getComponent()).toBeUndefined();
     expect(runtime.hasTerminalInput()).toBe(false);

--- a/tests/pi-harness/harness-composition.test.ts
+++ b/tests/pi-harness/harness-composition.test.ts
@@ -449,7 +449,8 @@ describe("open bit issue browser lifecycle", () => {
     await Bun.sleep(0);
     const mounted = runtime.getComponent();
     expect(mounted).toBeDefined();
-    expect(mounted?.render(80)[0]).toContain("Open bit issues: 1");
+    expect(mounted?.render(80)[0]).toContain("#issue-a");
+    expect(mounted?.render(80).join("\n")).not.toContain("Open bit issues");
     expect(runtime.tui.focusedComponent).not.toBe(mounted ?? null);
 
     const bitIssuesCommand = runtime.commands.get("bit-issues");
@@ -549,10 +550,10 @@ describe("project memory browser lifecycle", () => {
     await runtime.emit("session_start");
     await Bun.sleep(0);
     expect(runtime.getComponent()?.render(100)[0]).toContain(
-      "Project memory: 1",
-    );
-    expect(runtime.getComponent()?.render(100).join("\n")).toContain(
       "project/architecture.md",
+    );
+    expect(runtime.getComponent()?.render(100).join("\n")).not.toContain(
+      "Project memory",
     );
 
     const callsAfterSessionStart = aggregateCalls;


### PR DESCRIPTION
## Summary

- display bounded project memory below open bit issues in the coordination browser
- share one refreshable memory registry across startup recall, tools, updates, and the parent TUI
- add memory selection/detail UI, `/project-memory`, `Ctrl+Alt+M`, and explicit refresh behavior
- preserve parent/child ownership, stale/fresh boundaries, per-waiter cancellation, and source-specific issue refresh
- document the lifecycle and add focused registry, composition, UI, and safety coverage

## Verification

- `bun test tests/pi-harness/agent-memory.test.ts tests/pi-harness/child-run-ui.test.ts tests/pi-harness/harness-composition.test.ts` — 55 pass
- `bun test` — 1899 pass, 2 skip, 0 fail
- `bun run tsc`
- `bun run lint` — 0 errors; 9 pre-existing warnings in `pi/extensions/hearth-tools/adapters.ts`
- Prettier check for changed files
- `git diff --check`