### PR TITLE
fix(pi): hide empty coordination browser

### DIFF
--- a/pi/extensions/pi-harness/features/child-runs/ui.ts
+++ b/pi/extensions/pi-harness/features/child-runs/ui.ts
@@ -445,13 +445,7 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
     const issueSnapshot = this.bitIssues?.registry.getSnapshot();
     const memorySnapshot = this.agentMemory?.registry.getSnapshot();
     if (runs.length === 0 && issues.length === 0 && memories.length === 0) {
-      if (this.bitIssues === undefined && this.agentMemory === undefined) {
-        return [
-          line("No child runs on this session branch.", width),
-          line("Start subagent or workflow to populate this view.", width),
-        ];
-      }
-      let status = "No coordination records are available.";
+      let status: string | undefined;
       if (issueSnapshot?.loading === true || memorySnapshot?.loading === true)
         status = "Loading coordination records…";
       else if (issueSnapshot?.error !== undefined) {
@@ -459,10 +453,7 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
       } else if (memorySnapshot?.error !== undefined) {
         status = `Project memory unavailable: ${memorySnapshot.error}`;
       }
-      return [
-        line("No child runs, open bit issues, or project memory.", width),
-        line(status, width),
-      ];
+      return status === undefined ? [] : [line(status, width)];
     }
 
     const rendered: BrowserRow[] = [];

--- a/tests/pi-harness/child-run-ui.test.ts
+++ b/tests/pi-harness/child-run-ui.test.ts
@@ -201,13 +201,9 @@ const addTranscript = (
 };
 
 describe("child-session browser component", () => {
-  test("renders an explanatory empty state within width", () => {
+  test("renders nothing when empty", () => {
     const { component } = setup();
-    const lines = component.render(24);
-    expect(lines.join("\n")).toContain("No child runs");
-    expect(lines.join("\n")).not.toContain("Open bit issues");
-    expect(lines.join("\n")).not.toContain("↑↓ select");
-    expect(lines.every((item) => visibleWidth(item) <= 24)).toBe(true);
+    expect(component.render(24)).toEqual([]);
   });
 
   test("caps populated height and uses every row for flat content", () => {
@@ -825,6 +821,11 @@ const setupCombined = async (
 };
 
 describe("combined coordination browser", () => {
+  test("renders nothing when every coordination source is empty", async () => {
+    const combined = await setupCombined([], 0, []);
+    expect(combined.component.render(80)).toEqual([]);
+  });
+
   test("renders child and issue rows in one flat height budget", async () => {
     const issueOnly = await setupCombined(["issue-a", "issue-b"]);
     const onlyLines = issueOnly.component.render(80);


### PR DESCRIPTION
## Summary

- render no rows when child runs, open bit issues, and project memory are all empty
- keep loading and retrieval-error diagnostics visible
- cover both child-only and combined empty states

## Testing

- `bun test tests/pi-harness/child-run-ui.test.ts tests/pi-harness/harness-composition.test.ts` — 41 passed
- `bun run tsc` — passed
- `bun run lint` — 0 errors, 9 pre-existing warnings
- `git diff --check` — passed
- `bun test` — 1799 passed, 2 skipped; 105 environment-related failures involving sandbox lifecycle and local server binding (`EADDRINUSE`)