### PR TITLE
style(pi): render statusline metadata in gray

### DIFF
--- a/pi/extensions/pi-harness/features/statusline/render.ts
+++ b/pi/extensions/pi-harness/features/statusline/render.ts
@@ -358,14 +358,14 @@ export const renderStatusline = (
   }
   // Claude always starts with the current directory, even when its basename
   // is empty (for example, the filesystem root).
-  fields.push([{ text: directory }]);
+  fields.push([{ text: directory, tone: "muted" }]);
 
   const branch =
     runtime.branch === undefined || runtime.branch === null
       ? ""
       : singleLine(runtime.branch);
   if (branch !== "" && branch !== "detached") {
-    fields.push([{ text: branch }]);
+    fields.push([{ text: branch, tone: "muted" }]);
   }
 
   if (
@@ -389,7 +389,10 @@ export const renderStatusline = (
     for (const [slot, display] of SLOTS) {
       const status = checkStatus(snapshot.cache, slot);
       const [glyph, tone] = STATUS_STYLES.get(status) ?? ["?", "dim"];
-      checks.push({ text: ` ${display}` }, { text: glyph, tone });
+      checks.push(
+        { text: ` ${display}`, tone: "muted" },
+        { text: glyph, tone },
+      );
     }
     fields.push(checks);
   }

--- a/tests/pi-harness/statusline.test.ts
+++ b/tests/pi-harness/statusline.test.ts
@@ -282,23 +282,27 @@ describe("Claude-compatible statusline rendering", () => {
     ).toEqual(["dotfiles | TS L? T? X?"]);
   });
 
-  test("uses Claude-equivalent colors for diffs, checks, model, and context", () => {
+  test("uses theme colors for metadata, diffs, checks, model, and context", () => {
     const [line = ""] = renderStatusline(
       snapshot({
         git: gitStatus({ additions: 2, deletions: 1 }),
         projectLabel: "TS",
         cache: sampleCache(),
       }),
-      { modelName: "Sonnet", remainingContext: 9 },
+      { branch: "main", modelName: "Sonnet", remainingContext: 9 },
       200,
       ansiTheme,
     );
 
+    expect(line).toContain("\u001B[90m | dotfiles | main | \u001B[0m");
     expect(line).toContain("\u001B[32m+2\u001B[0m");
     expect(line).toContain("\u001B[31m-1\u001B[0m");
-    expect(line).toContain("L\u001B[32m✓\u001B[0m");
-    expect(line).toContain("T\u001B[33m…\u001B[0m");
-    expect(line).toContain("X\u001B[31m✗\u001B[0m");
+    expect(line).toContain("\u001B[90m L\u001B[0m");
+    expect(line).toContain("L\u001B[0m\u001B[32m✓\u001B[0m");
+    expect(line).toContain("\u001B[90m T\u001B[0m");
+    expect(line).toContain("T\u001B[0m\u001B[33m…\u001B[0m");
+    expect(line).toContain("\u001B[90m X\u001B[0m");
+    expect(line).toContain("X\u001B[0m\u001B[31m✗\u001B[0m");
     expect(line).toContain("\u001B[36mSonnet\u001B[0m");
     expect(line).toContain("\u001B[31m9%\u001B[0m");
   });
@@ -395,7 +399,9 @@ describe("Claude-compatible statusline rendering", () => {
     );
 
     expect(line).toContain(
-      "L\u001B[90m?\u001B[0m T\u001B[90m?\u001B[0m X\u001B[90m?\u001B[0m",
+      "\u001B[90m L\u001B[0m\u001B[90m?\u001B[0m" +
+        "\u001B[90m T\u001B[0m\u001B[90m?\u001B[0m" +
+        "\u001B[90m X\u001B[0m\u001B[90m?\u001B[0m",
     );
   });
 


### PR DESCRIPTION
## Summary

- render the footer directory and branch with the theme `muted` color (`gray` in `transparent-dark`)
- render the L/T/X check labels in the same gray while preserving status glyph colors
- extend statusline rendering coverage for the new theme styling

## Verification

- `bun test tests/pi-harness/statusline.test.ts` (28 passed)
- `bun run tsc`
- `bun run lint` (0 errors; 9 pre-existing warnings outside this change)
- `prettier --check pi/extensions/pi-harness/features/statusline/render.ts tests/pi-harness/statusline.test.ts`

## Environment note

The full `bun test` suite was attempted, but nested sandbox initialization and local port binding are unavailable in the harness environment; the focused statusline suite passes.