### PR TITLE
fix(pi): gray remaining statusline metadata

### DIFF
--- a/pi/extensions/pi-harness/features/statusline/render.ts
+++ b/pi/extensions/pi-harness/features/statusline/render.ts
@@ -354,7 +354,9 @@ export const renderStatusline = (
   const directory = singleLine(snapshot.directory);
 
   if (snapshot.git.isRepository && snapshot.git.repository !== undefined) {
-    fields.push([{ text: singleLine(snapshot.git.repository) }]);
+    fields.push([
+      { text: singleLine(snapshot.git.repository), tone: "muted" },
+    ]);
   }
   // Claude always starts with the current directory, even when its basename
   // is empty (for example, the filesystem root).
@@ -385,7 +387,7 @@ export const renderStatusline = (
       : "";
   const projectLabel = cachedLabel || singleLine(snapshot.projectLabel ?? "");
   if (projectLabel !== "") {
-    const checks: Span[] = [{ text: projectLabel }];
+    const checks: Span[] = [{ text: projectLabel, tone: "muted" }];
     for (const [slot, display] of SLOTS) {
       const status = checkStatus(snapshot.cache, slot);
       const [glyph, tone] = STATUS_STYLES.get(status) ?? ["?", "dim"];

--- a/tests/pi-harness/statusline.test.ts
+++ b/tests/pi-harness/statusline.test.ts
@@ -294,10 +294,12 @@ describe("Claude-compatible statusline rendering", () => {
       ansiTheme,
     );
 
-    expect(line).toContain("\u001B[90m | dotfiles | main | \u001B[0m");
+    expect(line).toContain(
+      "\u001B[90mushironoko/dotfiles | dotfiles | main | \u001B[0m",
+    );
     expect(line).toContain("\u001B[32m+2\u001B[0m");
     expect(line).toContain("\u001B[31m-1\u001B[0m");
-    expect(line).toContain("\u001B[90m L\u001B[0m");
+    expect(line).toContain("\u001B[90m | TS L\u001B[0m");
     expect(line).toContain("L\u001B[0m\u001B[32m✓\u001B[0m");
     expect(line).toContain("\u001B[90m T\u001B[0m");
     expect(line).toContain("T\u001B[0m\u001B[33m…\u001B[0m");
@@ -399,7 +401,8 @@ describe("Claude-compatible statusline rendering", () => {
     );
 
     expect(line).toContain(
-      "\u001B[90m L\u001B[0m\u001B[90m?\u001B[0m" +
+      "\u001B[90mushironoko/dotfiles | dotfiles | TS L\u001B[0m" +
+        "\u001B[90m?\u001B[0m" +
         "\u001B[90m T\u001B[0m\u001B[90m?\u001B[0m" +
         "\u001B[90m X\u001B[0m\u001B[90m?\u001B[0m",
     );


### PR DESCRIPTION
## Summary

- render the repository identifier with the muted theme tone
- render the project label with the muted theme tone
- update ANSI color assertions for the statusline

## Testing

- `bun test tests/pi-harness/statusline.test.ts` (28 passed)
- `bun run tsc`
- `bun run lint` (0 errors; 9 existing warnings)
- `git diff --check`

## Full-suite note

`bun test` completed with 1799 passed and 2 skipped, while 105 unrelated permission/sandbox and local-server tests failed in the current environment, including `EADDRINUSE` when opening port 0.