### PR TITLE
fix(pi): cap child browser at three rows

### DIFF
--- a/pi/extensions/pi-harness/features/child-runs/ui.ts
+++ b/pi/extensions/pi-harness/features/child-runs/ui.ts
@@ -254,10 +254,10 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
   render(width: number): string[] {
     const safeWidth = Math.max(1, width);
     // The browser participates in normal layout flow with chat, editor, status
-    // rows, and footer. Combining sources must not increase this old budget.
+    // rows, and footer. Keep all combined sources within the three-row cap.
     const height = Math.max(
-      4,
-      Math.min(Math.floor(this.tui.terminal.rows / 4), 10),
+      1,
+      Math.min(Math.floor(this.tui.terminal.rows / 4), 3),
     );
     const snapshots = this.registry.getSnapshots();
     const runs = flattenRuns(snapshots);

--- a/tests/pi-harness/child-run-layout.test.ts
+++ b/tests/pi-harness/child-run-layout.test.ts
@@ -151,8 +151,8 @@ const countLine = (lines: string[], target: string): number =>
 
 describe("child-session browser normal-flow layout", () => {
   for (const [rows, columns, expectedPanelHeight] of [
-    [24, 80, 6],
-    [40, 120, 10],
+    [24, 80, 3],
+    [40, 120, 3],
   ] as const) {
     test(`keeps the editor visible in a ${rows}-row terminal`, async () => {
       const { editorLines, browserLines, viewport } = await createLayout(
@@ -167,7 +167,7 @@ describe("child-session browser normal-flow layout", () => {
         );
       }
       expect(viewport.filter((line) => line.startsWith("chat-"))).toHaveLength(
-        rows === 24 ? 7 : 19,
+        rows === 24 ? 10 : 26,
       );
       expect(viewport.at(-2)?.trimEnd()).toBe("footer-main");
       expect(viewport.at(-1)?.trimEnd()).toBe("footer-detail");
@@ -176,8 +176,8 @@ describe("child-session browser normal-flow layout", () => {
 
   test("keeps the same total budget when flat child and issue rows coexist", async () => {
     for (const [rows, columns, expectedPanelHeight] of [
-      [24, 80, 6],
-      [40, 120, 10],
+      [24, 80, 3],
+      [40, 120, 3],
     ] as const) {
       const { editorLines, browserLines, viewport } = await createLayout(
         rows,

--- a/tests/pi-harness/child-run-ui.test.ts
+++ b/tests/pi-harness/child-run-ui.test.ts
@@ -206,11 +206,12 @@ describe("child-session browser component", () => {
     expect(component.render(24)).toEqual([]);
   });
 
-  test("caps populated height and uses every row for flat content", () => {
+  test("caps populated height at three rows and uses every row for flat content", () => {
     for (const [rows, expectedHeight] of [
-      [24, 6],
-      [40, 10],
-      [12, 4],
+      [24, 3],
+      [40, 3],
+      [12, 3],
+      [8, 2],
     ] as const) {
       const { registry, component } = setup(rows);
       addRuns(registry, 30);


### PR DESCRIPTION
## Summary

- cap the resident child sessions, bit issues, and project memory browser at three rows
- let the browser shrink below three rows on small terminals
- update unit and real-TUI layout coverage for the smaller height budget

## Verification

- `bun test tests/pi-harness/child-run-ui.test.ts tests/pi-harness/child-run-layout.test.ts` (33 passed)
- `bun run tsc`
- `bun run lint` (0 errors; 9 unrelated existing warnings)
- `git diff --check`

A full `bun test` run was also attempted. Environment-dependent tests requiring the macOS sandbox runtime, local listening ports, or Ollama could not run in the current execution sandbox; the affected child-browser suites pass independently.