### PR TITLE
fix(pi): keep parent tools responsive during subagents

### DIFF
--- a/pi/extensions/hearth-tools/engine.ts
+++ b/pi/extensions/hearth-tools/engine.ts
@@ -17,6 +17,11 @@ export interface HearthAccessGate {
   exclusive<T>(operation: () => Promise<T>): Promise<T>;
 }
 
+export interface HearthExternalWriterLease {
+  ready: Promise<void>;
+  complete: Promise<void>;
+}
+
 type AccessMode = "shared" | "exclusive";
 
 interface AccessWaiter {
@@ -37,13 +42,72 @@ export class HearthEngineGate implements HearthAccessGate {
   private readonly waiters: AccessWaiter[] = [];
   private activeReaders = 0;
   private activeWriter = false;
+  private activeExternalWriters = 0;
+  private externalWriterInvalidation?: () => unknown;
 
   shared<T>(operation: () => Promise<T>): Promise<T> {
-    return this.enqueue("shared", operation);
+    return this.enqueueExternalWriterSafe("shared", operation);
   }
 
   exclusive<T>(operation: () => Promise<T>): Promise<T> {
-    return this.enqueue("exclusive", operation);
+    return this.enqueueExternalWriterSafe("exclusive", operation);
+  }
+
+  /**
+   * Keeps Engine caches coherent while an out-of-process writer is active
+   * without holding the gate for that writer's full lifetime. Parent tools
+   * remain runnable; each one gets a fresh cache view and runs exclusively
+   * with respect to other Engine operations while external writes may race.
+   */
+  protectExternalWriter(
+    finished: Promise<void>,
+    invalidate: () => unknown,
+  ): HearthExternalWriterLease {
+    this.activeExternalWriters += 1;
+    this.externalWriterInvalidation = invalidate;
+
+    // The child does not start before this short barrier. Operations already
+    // admitted by the gate finish first, then their cached view is discarded.
+    const ready = this.enqueue("exclusive", async () => {
+      invalidate();
+    });
+    const readySettled = ready.then(
+      () => undefined,
+      () => undefined,
+    );
+    const writerSettled = finished.then(
+      () => undefined,
+      () => undefined,
+    );
+    const complete = Promise.all([readySettled, writerSettled]).then(() =>
+      this.enqueue("exclusive", async () => {
+        try {
+          invalidate();
+        } finally {
+          this.activeExternalWriters = Math.max(
+            0,
+            this.activeExternalWriters - 1,
+          );
+          if (this.activeExternalWriters === 0) {
+            this.externalWriterInvalidation = undefined;
+          }
+        }
+      }),
+    );
+    return { ready, complete };
+  }
+
+  private enqueueExternalWriterSafe<T>(
+    mode: AccessMode,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    if (this.activeExternalWriters === 0) {
+      return this.enqueue(mode, operation);
+    }
+    return this.enqueue("exclusive", async () => {
+      this.externalWriterInvalidation?.();
+      return operation();
+    });
   }
 
   private enqueue<T>(

--- a/pi/extensions/hearth-tools/index.ts
+++ b/pi/extensions/hearth-tools/index.ts
@@ -132,61 +132,11 @@ const definitions = (
     createHearthGrepDefinition(cwd, runtime.engine, runtime.gate),
   ] as const;
 
-interface ExternalWriterGroup {
-  accepting: boolean;
-  active: number;
-  ready: Promise<void>;
-  markReady(): void;
-  drained: Promise<void>;
-  markDrained(): void;
-  complete: Promise<void>;
-}
-
-const createExternalWriterProtector = (runtime: HearthEngineRuntime) => {
-  let group: ExternalWriterGroup | undefined;
-
-  return (finished: Promise<void>) => {
-    if (group === undefined || !group.accepting) {
-      let markReady = (): void => {};
-      let markDrained = (): void => {};
-      const next: ExternalWriterGroup = {
-        accepting: true,
-        active: 0,
-        ready: new Promise<void>((resolve) => {
-          markReady = resolve;
-        }),
-        markReady: () => markReady(),
-        drained: new Promise<void>((resolve) => {
-          markDrained = resolve;
-        }),
-        markDrained: () => markDrained(),
-        complete: Promise.resolve(),
-      };
-      next.complete = runtime.gate.exclusive(async () => {
-        next.markReady();
-        await next.drained;
-        runtime.engine.clearCaches();
-      });
-      const retire = (): void => {
-        if (group === next) group = undefined;
-      };
-      void next.complete.then(retire, retire);
-      group = next;
-    }
-
-    const current = group;
-    current.active += 1;
-    const release = (): void => {
-      current.active -= 1;
-      if (current.active === 0) {
-        current.accepting = false;
-        current.markDrained();
-      }
-    };
-    void finished.then(release, release);
-    return { ready: current.ready, complete: current.complete };
-  };
-};
+const createExternalWriterProtector =
+  (runtime: HearthEngineRuntime) => (finished: Promise<void>) =>
+    runtime.gate.protectExternalWriter(finished, () =>
+      runtime.engine.clearCaches(),
+    );
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object";

--- a/tests/pi-harness/hearth-tools-startup.test.ts
+++ b/tests/pi-harness/hearth-tools-startup.test.ts
@@ -264,6 +264,43 @@ describe("Hearth Engine access gate", () => {
       "reader:later",
     ]);
   });
+
+  test("keeps parent operations runnable during an external writer lease", async () => {
+    const gate = new HearthEngineGate();
+    let finishWriter: (() => void) | undefined;
+    const writerFinished = new Promise<void>((resolve) => {
+      finishWriter = resolve;
+    });
+    let invalidations = 0;
+    const lease = gate.protectExternalWriter(writerFinished, () => {
+      invalidations += 1;
+    });
+
+    await lease.ready;
+    expect(invalidations).toBe(1);
+
+    let parentRan = false;
+    await gate.shared(async () => {
+      parentRan = true;
+    });
+    expect(parentRan).toBe(true);
+    expect(invalidations).toBe(2);
+
+    let leaseCompleted = false;
+    void lease.complete.then(() => {
+      leaseCompleted = true;
+    });
+    await Promise.resolve();
+    expect(leaseCompleted).toBe(false);
+
+    finishWriter?.();
+    await lease.complete;
+    expect(leaseCompleted).toBe(true);
+    expect(invalidations).toBe(3);
+
+    await gate.shared(async () => {});
+    expect(invalidations).toBe(3);
+  });
 });
 
 describe("hearth-tools startup", () => {
@@ -522,6 +559,8 @@ describe("hearth-tools startup", () => {
     });
     expect(FakeEngine.clearCount).toBe(3);
 
+    const clearCommand = fake.commands.get("hearth-clear-cache");
+    expect(clearCommand).toBeDefined();
     await fake.emit("session_shutdown");
     // Register the next extension revision without starting its session. The
     // old initialized broker must remain active throughout this reload gap.
@@ -557,6 +596,16 @@ describe("hearth-tools startup", () => {
     expect(lease).toBeDefined();
     await lease?.ready;
 
+    const parentOperation = Promise.resolve(clearCommand?.handler("", context));
+    const parentOperationSettled = await Promise.race([
+      parentOperation.then(() => true),
+      new Promise<false>((resolveTimeout) => {
+        setTimeout(() => resolveTimeout(false), 25);
+      }),
+    ]);
+    expect(parentOperationSettled).toBe(true);
+    expect(FakeEngine.clearCount).toBe(7);
+
     const acceptance = fake.emit("message_end", {
       message: {
         role: "toolResult",
@@ -571,7 +620,7 @@ describe("hearth-tools startup", () => {
       }),
     ]);
     expect(acceptanceSettled).toBe(true);
-    expect(FakeEngine.clearCount).toBe(4);
+    expect(FakeEngine.clearCount).toBe(7);
 
     let finishSecondWriter = (): void => {};
     const secondWriterFinished = new Promise<void>((resolveWriter) => {
@@ -588,19 +637,20 @@ describe("hearth-tools startup", () => {
     });
     expect(secondLease).toBeDefined();
     await secondLease?.ready;
+    expect(FakeEngine.clearCount).toBe(8);
 
     let leaseCompleted = false;
     void lease?.complete.then(() => {
       leaseCompleted = true;
     });
     finishWriter();
-    await Promise.resolve();
-    expect(leaseCompleted).toBe(false);
+    await lease?.complete;
+    expect(leaseCompleted).toBe(true);
+    expect(FakeEngine.clearCount).toBe(9);
 
     finishSecondWriter();
-    await Promise.all([lease?.complete, secondLease?.complete]);
-    expect(leaseCompleted).toBe(true);
-    expect(FakeEngine.clearCount).toBe(5);
+    await secondLease?.complete;
+    expect(FakeEngine.clearCount).toBe(10);
 
     await fake.emit("message_end", {
       message: { role: "toolResult", toolName: "subagent" },
@@ -608,6 +658,6 @@ describe("hearth-tools startup", () => {
     await fake.emit("message_end", {
       message: { role: "toolResult", toolName: "worktree_remove" },
     });
-    expect(FakeEngine.clearCount).toBe(7);
+    expect(FakeEngine.clearCount).toBe(12);
   });
 });


### PR DESCRIPTION
## Summary

- replace the full-lifetime Hearth external-writer lock with short cache-invalidation barriers
- keep parent Hearth-backed tools runnable while background subagents and workflows are active
- complete overlapping child-writer leases independently and add regression coverage

## Root cause

Background child processes were protected by an exclusive Hearth gate lease held until every external writer in the group finished. Parent `read`, `bash`, `edit`, and related tools queued behind that lease, leaving the main agent in `Working...` and stacking new user prompts.

## Verification

- `bun test tests/pi-harness/background-child-runs.test.ts tests/pi-harness/hearth-tools-native.test.ts tests/pi-harness/hearth-tools-startup.test.ts` — 49 pass
- `bun test` outside the OS effect sandbox — 1905 pass, 2 skip, 0 fail
- `bun run tsc`
- `bun run lint` — 0 errors; 9 pre-existing warnings in `adapters.ts`
- Prettier check for changed files
- `bun run check:pi-imports`
- `bun run check:pi-baseline`

## Environment note

`bun run check:pi-compat` remains blocked by an unrelated global Pi declaration mismatch where `ActiveAbortSignal` does not satisfy the installed DOM `AbortSignal` type.