### PR TITLE
fix(pi): show newest child sessions first

### DIFF
--- a/pi/extensions/pi-harness/features/child-runs/ui.ts
+++ b/pi/extensions/pi-harness/features/child-runs/ui.ts
@@ -92,6 +92,11 @@ interface FlatRun {
   run: LiveChildRun;
 }
 
+const newestInvocationsFirst = (
+  snapshots: ChildInvocationSnapshot[],
+): ChildInvocationSnapshot[] =>
+  [...snapshots].sort((left, right) => right.createdAt - left.createdAt);
+
 const flattenRuns = (snapshots: ChildInvocationSnapshot[]): FlatRun[] =>
   snapshots.flatMap((invocation) =>
     invocation.runs.map((run) => ({ invocation, run })),
@@ -259,7 +264,7 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
       1,
       Math.min(Math.floor(this.tui.terminal.rows / 4), 3),
     );
-    const snapshots = this.registry.getSnapshots();
+    const snapshots = newestInvocationsFirst(this.registry.getSnapshots());
     const runs = flattenRuns(snapshots);
     const issueSnapshot = this.bitIssues?.registry.getSnapshot();
     const issues = issueSnapshot?.issues ?? [];
@@ -369,9 +374,9 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
   }
 
   private selectableRows(): BrowserSelection[] {
-    const children = flattenRuns(this.registry.getSnapshots()).map(
-      ({ run }): BrowserSelection => ({ kind: "child", id: run.runId }),
-    );
+    const children = flattenRuns(
+      newestInvocationsFirst(this.registry.getSnapshots()),
+    ).map(({ run }): BrowserSelection => ({ kind: "child", id: run.runId }));
     const issues =
       this.bitIssues?.registry
         .getSnapshot()
@@ -557,7 +562,7 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
 
   private requestRender(): void {
     this.syncSelection(
-      flattenRuns(this.registry.getSnapshots()),
+      flattenRuns(newestInvocationsFirst(this.registry.getSnapshots())),
       this.bitIssues?.registry.getSnapshot().issues ?? [],
       this.agentMemory?.registry.getSnapshot().entries ?? [],
     );

--- a/tests/pi-harness/child-run-ui.test.ts
+++ b/tests/pi-harness/child-run-ui.test.ts
@@ -110,11 +110,11 @@ const semanticTheme = {
   },
 };
 
-const setup = (rows = 20, theme?: unknown) => {
+const setup = (rows = 20, theme?: unknown, now: () => number = () => 100) => {
   let id = 0;
   const registry = new ChildRunRegistry({
     idFactory: () => `id-${++id}`,
-    now: () => 100,
+    now,
   });
   const renders: number[] = [];
   const tui = {
@@ -204,6 +204,37 @@ describe("child-session browser component", () => {
   test("renders nothing when empty", () => {
     const { component } = setup();
     expect(component.render(24)).toEqual([]);
+  });
+
+  test("orders child invocations newest first for rendering and navigation", () => {
+    let timestamp = 100;
+    const { registry, component } = setup(20, undefined, () => timestamp++);
+    const older = registry.beginInvocation({
+      toolCallId: "older-parent",
+      source: "subagent",
+      mode: "single",
+      label: "older",
+      runs: [{ agent: "older-agent", task: "older task", taskIndex: 0 }],
+    });
+    const newer = registry.beginInvocation({
+      toolCallId: "newer-parent",
+      source: "subagent",
+      mode: "single",
+      label: "newer",
+      runs: [{ agent: "newer-agent", task: "newer task", taskIndex: 0 }],
+    });
+
+    component.prefer("child");
+    const lines = component.render(80);
+
+    expect(lines[0]).toContain("newer-agent");
+    expect(lines[1]).toContain("older-agent");
+    expect(component.getSelectedRunId()).toBe(newer.runIds[0]);
+    component.handleInput("down");
+    expect(component.getSelectedRunId()).toBe(older.runIds[0]);
+    expect(
+      registry.getSnapshots().map(({ invocationId }) => invocationId),
+    ).toEqual([older.invocationId, newer.invocationId]);
   });
 
   test("caps populated height at three rows and uses every row for flat content", () => {


### PR DESCRIPTION
## Summary

- sort child-session invocations by `createdAt` descending in the browser
- use the same newest-first order for rendering, selection, and keyboard navigation
- preserve the registry internal order used for retention and pruning
- add regression coverage for ordering and navigation

## Verification

- `bun test tests/pi-harness/child-run-ui.test.ts tests/pi-harness/child-run-layout.test.ts tests/pi-harness/child-run-integration.test.ts` (62 pass)
- `bun run tsc`
- `bun run lint` (0 errors; 9 pre-existing warnings in `pi/extensions/hearth-tools/adapters.ts`)
- Prettier check for changed files
- `git diff --check`

## Full-suite note

`bun test` reached 1801 pass / 2 skip, but 105 environment-dependent tests failed because the local sandbox runtime could not initialize and ephemeral `Bun.serve({ port: 0 })` calls returned `EADDRINUSE`. The focused child-session UI, layout, and integration suites all pass.