### PR TITLE
refactor(pi): consolidate similarity findings

### DIFF
--- a/pi/extensions/pi-harness/features/agent-memory/registry.ts
+++ b/pi/extensions/pi-harness/features/agent-memory/registry.ts
@@ -1,3 +1,8 @@
+import {
+  type AbortControllerLike,
+  createAbortController,
+  isAbortSignal,
+} from "../../lib/abort";
 import { stripTerminalControls } from "../../lib/terminal-text";
 import type { TrustConfig } from "../../lib/trust";
 import {
@@ -67,52 +72,6 @@ interface AgentMemoryRegistryOptions {
   readonly trust: TrustConfig;
   readonly now?: () => number;
 }
-
-interface AbortSignalLike {
-  readonly aborted: boolean;
-  addEventListener(
-    event: "abort",
-    listener: () => void,
-    options?: { once?: boolean },
-  ): void;
-  removeEventListener(event: "abort", listener: () => void): void;
-}
-
-interface AbortControllerLike {
-  readonly signal: AbortSignal & AbortSignalLike;
-  abort(): void;
-}
-
-const isAbortSignal = (
-  value: unknown,
-): value is AbortSignal & AbortSignalLike =>
-  typeof value === "object" &&
-  value !== null &&
-  "aborted" in value &&
-  typeof value.aborted === "boolean" &&
-  "addEventListener" in value &&
-  typeof value.addEventListener === "function" &&
-  "removeEventListener" in value &&
-  typeof value.removeEventListener === "function";
-
-const createAbortController = (): AbortControllerLike => {
-  const controller: unknown = new AbortController();
-  if (
-    typeof controller !== "object" ||
-    controller === null ||
-    !("abort" in controller) ||
-    typeof controller.abort !== "function" ||
-    !("signal" in controller) ||
-    !isAbortSignal(controller.signal)
-  ) {
-    throw new Error("AbortController is unavailable");
-  }
-  const { abort, signal } = controller;
-  return {
-    signal,
-    abort: () => Reflect.apply(abort, controller, []),
-  };
-};
 
 const abortedOutcome = (message: string): AgentMemoryRefreshOutcome => {
   const error = new AgentMemoryCliError("aborted", message);

--- a/pi/extensions/pi-harness/features/asuku-notify/index.ts
+++ b/pi/extensions/pi-harness/features/asuku-notify/index.ts
@@ -8,6 +8,10 @@ import { spawn } from "node:child_process";
 import { constants } from "node:fs";
 import { access } from "node:fs/promises";
 import type { HarnessConfig } from "../../config";
+import {
+  isAbortSignal as isActiveAbortSignal,
+  tryCreateAbortController as createAbortController,
+} from "../../lib/abort";
 import { launchDetached, type DetachedSpawnFunction } from "../../lib/detached";
 import { sanitizeChildEnv } from "../../lib/child-env";
 import type {
@@ -76,55 +80,6 @@ interface ConfirmBridgeRegistration {
   bridgedConfirm: ConfirmFunction;
   ctx: CtxLike;
 }
-
-interface ActiveAbortSignal {
-  readonly aborted: boolean;
-  addEventListener(
-    type: "abort",
-    listener: () => void,
-    options?: { once?: boolean },
-  ): void;
-  removeEventListener(type: "abort", listener: () => void): void;
-}
-
-interface AbortControllerLike {
-  readonly signal: ActiveAbortSignal;
-  abort(): void;
-}
-
-const isActiveAbortSignal = (value: unknown): value is ActiveAbortSignal =>
-  typeof value === "object" &&
-  value !== null &&
-  "aborted" in value &&
-  typeof value.aborted === "boolean" &&
-  "addEventListener" in value &&
-  typeof value.addEventListener === "function" &&
-  "removeEventListener" in value &&
-  typeof value.removeEventListener === "function";
-
-const createAbortController = (): AbortControllerLike | undefined => {
-  let value: unknown;
-  try {
-    value = new AbortController();
-  } catch {
-    return undefined;
-  }
-  if (
-    typeof value !== "object" ||
-    value === null ||
-    !("abort" in value) ||
-    typeof value.abort !== "function" ||
-    !("signal" in value) ||
-    !isActiveAbortSignal(value.signal)
-  ) {
-    return undefined;
-  }
-  const { abort, signal } = value;
-  return {
-    signal,
-    abort: () => Reflect.apply(abort, value, []),
-  };
-};
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);

--- a/pi/extensions/pi-harness/features/bash-sandbox/runtime.ts
+++ b/pi/extensions/pi-harness/features/bash-sandbox/runtime.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { BashOperations } from "@earendil-works/pi-coding-agent";
+import { type ActiveAbortSignal, isAbortSignal } from "../../lib/abort";
 import { sanitizeChildEnv } from "../../lib/child-env";
 
 export const CONTROLLED_BASH_PATH = "/bin/bash";
@@ -83,31 +84,8 @@ type SpawnFunction = (
   options: SpawnOptions,
 ) => SpawnedProcess;
 
-interface ActiveAbortSignal {
-  readonly aborted: boolean;
-  addEventListener(
-    type: "abort",
-    listener: () => void,
-    options?: { once?: boolean },
-  ): void;
-  removeEventListener(type: "abort", listener: () => void): void;
-}
-
-const activeAbortSignal = (value: unknown): ActiveAbortSignal | undefined => {
-  if (
-    value === null ||
-    typeof value !== "object" ||
-    !("aborted" in value) ||
-    typeof value.aborted !== "boolean" ||
-    !("addEventListener" in value) ||
-    typeof value.addEventListener !== "function" ||
-    !("removeEventListener" in value) ||
-    typeof value.removeEventListener !== "function"
-  ) {
-    return undefined;
-  }
-  return value as ActiveAbortSignal;
-};
+const activeAbortSignal = (value: unknown): ActiveAbortSignal | undefined =>
+  isAbortSignal(value) ? value : undefined;
 
 interface ControlledBashOptions {
   readonly getScratchDirectory: () => string | undefined;

--- a/pi/extensions/pi-harness/features/bit-issues/registry.ts
+++ b/pi/extensions/pi-harness/features/bit-issues/registry.ts
@@ -1,3 +1,8 @@
+import {
+  type AbortControllerLike,
+  createAbortController,
+  isAbortSignal,
+} from "../../lib/abort";
 import { stripTerminalControls } from "../../lib/terminal-text";
 import { BitIssueCli } from "./cli";
 import {
@@ -26,56 +31,10 @@ interface BitIssueRegistryOptions {
   readonly now?: () => number;
 }
 
-interface AbortSignalLike {
-  readonly aborted: boolean;
-  addEventListener(
-    event: "abort",
-    listener: () => void,
-    options?: { once?: boolean },
-  ): void;
-  removeEventListener(event: "abort", listener: () => void): void;
-}
-
-interface AbortControllerLike {
-  readonly signal: AbortSignal & AbortSignalLike;
-  abort(): void;
-}
-
 interface LinkedController {
   readonly controller: AbortControllerLike;
   dispose(): void;
 }
-
-const isAbortSignal = (
-  value: unknown,
-): value is AbortSignal & AbortSignalLike =>
-  typeof value === "object" &&
-  value !== null &&
-  "aborted" in value &&
-  typeof value.aborted === "boolean" &&
-  "addEventListener" in value &&
-  typeof value.addEventListener === "function" &&
-  "removeEventListener" in value &&
-  typeof value.removeEventListener === "function";
-
-const createAbortController = (): AbortControllerLike => {
-  const controller: unknown = new AbortController();
-  if (
-    typeof controller !== "object" ||
-    controller === null ||
-    !("abort" in controller) ||
-    typeof controller.abort !== "function" ||
-    !("signal" in controller) ||
-    !isAbortSignal(controller.signal)
-  ) {
-    throw new Error("AbortController is unavailable");
-  }
-  const { abort, signal } = controller;
-  return {
-    signal,
-    abort: () => Reflect.apply(abort, controller, []),
-  };
-};
 
 const linkedController = (signal?: AbortSignal): LinkedController => {
   const controller = createAbortController();

--- a/pi/extensions/pi-harness/features/child-runs/index.ts
+++ b/pi/extensions/pi-harness/features/child-runs/index.ts
@@ -123,6 +123,41 @@ export interface SetupChildRunsOptions {
   readonly backgroundDrainTimeoutMs?: number;
 }
 
+type CoordinationRefreshOutcome =
+  | { readonly ok: true; readonly count: number }
+  | {
+      readonly ok: false;
+      readonly kind: string;
+      readonly message: string;
+    };
+
+interface CoordinationRefreshSource {
+  refresh(cwd: string): Promise<CoordinationRefreshOutcome>;
+}
+
+const createCoordinationRefresher = (
+  source: CoordinationRefreshSource | undefined,
+  ensureVisible: (ctx: RuntimeContextLike) => void,
+  unavailableLabel: string,
+): ((ctx: RuntimeContextLike, explicit?: boolean) => Promise<void>) => {
+  let lastExplicitWarning: string | undefined;
+  return async (ctx, explicit = false) => {
+    if (source === undefined) return;
+    const cwd = ctx.cwd ?? process.cwd();
+    const outcome = await source.refresh(cwd);
+    if (outcome.ok) {
+      lastExplicitWarning = undefined;
+      if (outcome.count > 0) ensureVisible(ctx);
+      return;
+    }
+    if (!explicit) return;
+    const warning = `${outcome.kind}:${outcome.message}`;
+    if (warning === lastExplicitWarning) return;
+    lastExplicitWarning = warning;
+    ctx.ui.notify(`${unavailableLabel}: ${outcome.message}`, "warning");
+  };
+};
+
 const replayBranch = (
   registry: ChildRunRegistry,
   ctx: RuntimeContextLike,
@@ -149,55 +184,17 @@ const setupChildRuns = (
     : undefined;
   const { agentMemory } = options;
   let activeContext: RuntimeContextLike | undefined;
-  let lastExplicitIssueWarning: string | undefined;
-  let lastExplicitMemoryWarning: string | undefined;
   let panel: ChildRunsPanelController;
-  const refreshBitIssues = async (
-    ctx: RuntimeContextLike,
-    explicit = false,
-  ): Promise<void> => {
-    if (bitIssues === undefined) return;
-    const cwd = ctx.cwd ?? process.cwd();
-    const outcome = await bitIssues.refresh(cwd);
-    if (outcome.ok) {
-      lastExplicitIssueWarning = undefined;
-      if (outcome.count > 0) panel.ensureVisibleForIssues(ctx);
-      return;
-    }
-    if (explicit) {
-      const warning = `${outcome.kind}:${outcome.message}`;
-      if (warning !== lastExplicitIssueWarning) {
-        lastExplicitIssueWarning = warning;
-        ctx.ui.notify(
-          `Open bit issues unavailable: ${outcome.message}`,
-          "warning",
-        );
-      }
-    }
-  };
-  const refreshAgentMemory = async (
-    ctx: RuntimeContextLike,
-    explicit = false,
-  ): Promise<void> => {
-    if (agentMemory === undefined) return;
-    const cwd = ctx.cwd ?? process.cwd();
-    const outcome = await agentMemory.refresh(cwd);
-    if (outcome.ok) {
-      lastExplicitMemoryWarning = undefined;
-      if (outcome.count > 0) panel.ensureVisibleForMemory(ctx);
-      return;
-    }
-    if (explicit) {
-      const warning = `${outcome.kind}:${outcome.message}`;
-      if (warning !== lastExplicitMemoryWarning) {
-        lastExplicitMemoryWarning = warning;
-        ctx.ui.notify(
-          `Project memory unavailable: ${outcome.message}`,
-          "warning",
-        );
-      }
-    }
-  };
+  const refreshBitIssues = createCoordinationRefresher(
+    bitIssues,
+    (ctx) => panel.ensureVisibleForIssues(ctx),
+    "Open bit issues unavailable",
+  );
+  const refreshAgentMemory = createCoordinationRefresher(
+    agentMemory,
+    (ctx) => panel.ensureVisibleForMemory(ctx),
+    "Project memory unavailable",
+  );
   const refreshCoordination = async (
     ctx: RuntimeContextLike,
     explicit = false,

--- a/pi/extensions/pi-harness/features/permission-audit/index.ts
+++ b/pi/extensions/pi-harness/features/permission-audit/index.ts
@@ -21,6 +21,10 @@ import {
   type PermissionTaskAuditContext,
 } from "./model";
 import {
+  projectPermissionNavigation,
+  projectPermissionRunEvidence,
+} from "./projection";
+import {
   createPermissionAuditWriter,
   type PermissionAuditWriter,
 } from "./writer";
@@ -297,6 +301,13 @@ export const setupPermissionAudit = (
     const finalization = (async (): Promise<PermissionAuditFinalizeResult> => {
       try {
         const project = projectContext(transaction.project);
+        const runEvidence = projectPermissionRunEvidence(
+          transaction.runEvidence,
+        );
+        const leadingNavigation = projectPermissionNavigation(
+          transaction.leadingNavigation,
+        );
+        const gitCwd = projectPermissionNavigation(transaction.gitCwd);
         const record = await writer.append((identity) =>
           fitPermissionDecisionRecord({
             ...identity,
@@ -308,16 +319,10 @@ export const setupPermissionAudit = (
             command: transaction.command,
             ...(transaction.cwd === undefined ? {} : { cwd: transaction.cwd }),
             task: transaction.task,
-            ...(transaction.runEvidence === undefined
-              ? {}
-              : { runEvidence: transaction.runEvidence }),
+            ...(runEvidence === undefined ? {} : { runEvidence }),
             ...(project === undefined ? {} : { project }),
-            ...(transaction.leadingNavigation === undefined
-              ? {}
-              : { leadingNavigation: transaction.leadingNavigation }),
-            ...(transaction.gitCwd === undefined
-              ? {}
-              : { gitCwd: transaction.gitCwd }),
+            ...(leadingNavigation === undefined ? {} : { leadingNavigation }),
+            ...(gitCwd === undefined ? {} : { gitCwd }),
             executionBoundary: transaction.executionBoundary,
             stages: transaction.stages,
             boundaryDisposition,

--- a/pi/extensions/pi-harness/features/permission-audit/projection.ts
+++ b/pi/extensions/pi-harness/features/permission-audit/projection.ts
@@ -1,0 +1,42 @@
+import type {
+  PermissionLeadingNavigation,
+  PermissionRunEvidence,
+} from "../permission-policy/context";
+import type {
+  PermissionNavigationAuditContext,
+  PermissionRunAuditContext,
+} from "./model";
+
+/**
+ * Copies only fields owned by the persisted audit schema. Runtime evidence may
+ * evolve independently without implicitly expanding private JSONL records.
+ */
+export const projectPermissionRunEvidence = (
+  evidence: PermissionRunEvidence | undefined,
+): PermissionRunAuditContext | undefined => {
+  if (evidence === undefined) return undefined;
+  return {
+    ...(evidence.assistantText === undefined
+      ? {}
+      : { assistantText: evidence.assistantText }),
+    ...(evidence.askUserQuestionResultText === undefined
+      ? {}
+      : { askUserQuestionResultText: evidence.askUserQuestionResultText }),
+    priorToolResults: evidence.priorToolResults.map((result) => ({
+      toolName: result.toolName,
+      status: result.status,
+    })),
+    fingerprint: evidence.fingerprint,
+  };
+};
+
+/** Projects precomputed navigation scope without persisting future metadata. */
+export const projectPermissionNavigation = (
+  navigation: PermissionLeadingNavigation | undefined,
+): PermissionNavigationAuditContext | undefined =>
+  navigation === undefined
+    ? undefined
+    : {
+        scope: navigation.scope,
+        sameRepository: navigation.sameRepository,
+      };

--- a/pi/extensions/pi-harness/features/permission-policy/context.ts
+++ b/pi/extensions/pi-harness/features/permission-policy/context.ts
@@ -2,14 +2,21 @@ import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
 import { realpath, stat } from "node:fs/promises";
 import { basename, isAbsolute, resolve as resolvePath } from "node:path";
+import {
+  type ActiveAbortSignal,
+  createAbortController,
+  isAbortSignal,
+} from "../../lib/abort";
 import { sanitizeChildEnvAsync } from "../../lib/child-env";
+import {
+  MAX_GIT_WORKTREE_PORCELAIN_BYTES,
+  parseGitWorktreePorcelain,
+} from "../../lib/git-worktree-porcelain";
 import { isPathWithin } from "../../lib/trust";
 
 const MAX_TASK_TEXT_BYTES = 1_024;
 const MAX_PENDING_TASKS = 8;
-const MAX_GIT_OUTPUT_BYTES = 64 * 1_024;
-const MAX_DISCOVERED_WORKTREES = 128;
-const MAX_DISCOVERED_PATH_BYTES = 1_024;
+const MAX_GIT_OUTPUT_BYTES = MAX_GIT_WORKTREE_PORCELAIN_BYTES;
 const MAX_VISIBLE_WORKTREES = 16;
 const MAX_VISIBLE_PATH_BYTES = 512;
 const MAX_VISIBLE_PROJECT_BYTES = 2_048;
@@ -21,14 +28,15 @@ const fingerprint = (...parts: readonly string[]): string => {
   return hash.digest("hex");
 };
 
+const isUtf8ContinuationByte = (byte: number | undefined): boolean =>
+  byte !== undefined && byte >= 128 && byte < 192;
+
 const truncateUtf8 = (value: string, maxBytes: number): string => {
   const encoded = Buffer.from(value, "utf8");
   if (encoded.byteLength <= maxBytes) return value;
   const marker = Buffer.from("…", "utf8");
   let end = Math.max(0, maxBytes - marker.byteLength);
-  while (end > 0 && (encoded[end] ?? 0) >= 128 && (encoded[end] ?? 0) < 192) {
-    end -= 1;
-  }
+  while (end > 0 && isUtf8ContinuationByte(encoded[end])) end -= 1;
   return `${encoded.subarray(0, end).toString("utf8")}${marker.toString("utf8")}`;
 };
 
@@ -480,11 +488,7 @@ const truncateUtf8Tail = (value: string, maxBytes: number): string => {
   let start = Math.min(encoded.byteLength, marker.byteLength);
   const targetStart = encoded.byteLength - (maxBytes - marker.byteLength);
   start = Math.max(start, targetStart);
-  while (
-    start < encoded.byteLength &&
-    (encoded[start] ?? 0) >= 0x80 &&
-    (encoded[start] ?? 0) < 192
-  ) {
+  while (start < encoded.byteLength && isUtf8ContinuationByte(encoded[start])) {
     start += 1;
   }
   return `${marker.toString("utf8")}${encoded.subarray(start).toString("utf8")}`;
@@ -673,52 +677,6 @@ const decoder = new TextDecoder(undefined, {
   fatal: true,
   ignoreBOM: true,
 });
-
-interface ActiveAbortSignal {
-  readonly aborted: boolean;
-  addEventListener(
-    type: "abort",
-    listener: () => void,
-    options?: { once?: boolean },
-  ): void;
-  removeEventListener(type: "abort", listener: () => void): void;
-}
-
-const isAbortSignal = (
-  value: AbortSignal | undefined,
-): value is AbortSignal & ActiveAbortSignal =>
-  value !== undefined &&
-  typeof value === "object" &&
-  "aborted" in value &&
-  typeof value.aborted === "boolean" &&
-  "addEventListener" in value &&
-  typeof value.addEventListener === "function" &&
-  "removeEventListener" in value &&
-  typeof value.removeEventListener === "function";
-
-interface AbortControllerLike {
-  readonly signal: AbortSignal & ActiveAbortSignal;
-  abort(): void;
-}
-
-const createAbortController = (): AbortControllerLike => {
-  const value: unknown = new AbortController();
-  if (
-    typeof value !== "object" ||
-    value === null ||
-    !("abort" in value) ||
-    typeof value.abort !== "function" ||
-    !("signal" in value) ||
-    !isAbortSignal(value.signal as AbortSignal | undefined)
-  ) {
-    throw new Error("AbortController is unavailable");
-  }
-  const { abort, signal } = value;
-  return {
-    signal: signal as AbortSignal & ActiveAbortSignal,
-    abort: () => Reflect.apply(abort, value, []),
-  };
-};
 
 export const runGitWorktreeList = (
   cwd: string,
@@ -971,89 +929,6 @@ interface ProjectContextOptions {
   readonly timeoutMs?: number;
 }
 
-interface ParsedWorktreeRecord {
-  readonly path: string;
-  readonly prunable: boolean;
-  readonly bare: boolean;
-}
-
-const parseWorktreeRecords = (
-  stdout: Uint8Array,
-): readonly ParsedWorktreeRecord[] | undefined => {
-  if (stdout.byteLength === 0 || stdout.byteLength > MAX_GIT_OUTPUT_BYTES) {
-    return undefined;
-  }
-  let text: string;
-  try {
-    text = decoder.decode(stdout);
-  } catch {
-    return undefined;
-  }
-  if (!text.endsWith("\0\0")) return undefined;
-
-  const records: ParsedWorktreeRecord[] = [];
-  const seenPaths = new Set<string>();
-  let fields: string[] = [];
-  const consume = (): boolean => {
-    if (fields.length === 0) return true;
-    const worktreeFields = fields.filter((field) =>
-      field.startsWith("worktree "),
-    );
-    const [worktreeField] = worktreeFields;
-    const [firstField] = fields;
-    if (
-      worktreeFields.length !== 1 ||
-      worktreeField === undefined ||
-      worktreeField !== firstField
-    ) {
-      return false;
-    }
-    const path = worktreeField.slice("worktree ".length);
-    if (
-      path === "" ||
-      !isAbsolute(path) ||
-      Buffer.byteLength(path, "utf8") > MAX_DISCOVERED_PATH_BYTES ||
-      hasControlCharacter(path)
-    ) {
-      return false;
-    }
-    if (seenPaths.has(path)) return false;
-    seenPaths.add(path);
-    const seenKinds = new Set<string>();
-    for (const field of fields.slice(1)) {
-      const [kind] = field.split(" ", 1);
-      if (
-        kind === undefined ||
-        !["HEAD", "branch", "detached", "bare", "locked", "prunable"].includes(
-          kind,
-        ) ||
-        seenKinds.has(kind)
-      ) {
-        return false;
-      }
-      seenKinds.add(kind);
-    }
-    if (seenKinds.has("branch") && seenKinds.has("detached")) return false;
-    records.push({
-      path,
-      prunable: seenKinds.has("prunable"),
-      bare: seenKinds.has("bare"),
-    });
-    return records.length <= MAX_DISCOVERED_WORKTREES;
-  };
-
-  for (const field of text.split("\0")) {
-    if (field !== "") {
-      fields.push(field);
-      continue;
-    }
-    if (!consume()) return undefined;
-    fields = [];
-  }
-  if (fields.length !== 0 || records.length === 0) return undefined;
-  return records;
-};
-
 const unavailableProject = (
   cwd: string | undefined,
   reason: string,
@@ -1155,7 +1030,7 @@ const discoverProjectContextUnbounded = async (
     return unavailable(canonicalCwd, result.reason);
   }
 
-  const records = parseWorktreeRecords(result.stdout);
+  const records = parseGitWorktreePorcelain(result.stdout);
   if (records === undefined) {
     return unavailable(canonicalCwd, "git returned malformed worktree data");
   }

--- a/pi/extensions/pi-harness/features/permission-policy/index.ts
+++ b/pi/extensions/pi-harness/features/permission-policy/index.ts
@@ -1,6 +1,11 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  type ActiveAbortSignal,
+  createAbortController,
+  isAbortSignal as isActiveAbortSignal,
+} from "../../lib/abort";
 import type { CtxLike, InputEvent, PiLike } from "../../lib/pi-like";
 import {
   DEFAULT_PERMISSION_JUDGE_CONFIG,
@@ -79,52 +84,8 @@ type PermissionConfirmationOutcome =
   | "not-shown"
   | "aborted";
 
-interface ActiveAbortSignal {
-  readonly aborted: boolean;
-  addEventListener(
-    type: "abort",
-    listener: () => void,
-    options?: { once?: boolean },
-  ): void;
-  removeEventListener(type: "abort", listener: () => void): void;
-}
-
-interface AbortControllerLike {
-  readonly signal: ActiveAbortSignal;
-  abort(): void;
-}
-
-const isActiveAbortSignal = (value: unknown): value is ActiveAbortSignal =>
-  typeof value === "object" &&
-  value !== null &&
-  "aborted" in value &&
-  typeof value.aborted === "boolean" &&
-  "addEventListener" in value &&
-  typeof value.addEventListener === "function" &&
-  "removeEventListener" in value &&
-  typeof value.removeEventListener === "function";
-
 const signalIsAborted = (signal: ActiveAbortSignal | undefined): boolean =>
   signal?.aborted === true;
-
-const createAbortController = (): AbortControllerLike => {
-  const value: unknown = new AbortController();
-  if (
-    typeof value !== "object" ||
-    value === null ||
-    !("abort" in value) ||
-    typeof value.abort !== "function" ||
-    !("signal" in value) ||
-    !isActiveAbortSignal(value.signal)
-  ) {
-    throw new Error("AbortController is unavailable");
-  }
-  const { abort, signal } = value;
-  return {
-    signal,
-    abort: () => Reflect.apply(abort, value, []),
-  };
-};
 
 const requestPermissionConfirmation = async (
   ctx: CtxLike,

--- a/pi/extensions/pi-harness/features/permission-policy/judge.ts
+++ b/pi/extensions/pi-harness/features/permission-policy/judge.ts
@@ -2,6 +2,11 @@ import { createHash } from "node:crypto";
 import { connect, type Socket } from "node:net";
 import { resolve } from "node:path";
 import type { PermissionJudgeConfig } from "../../config";
+import {
+  type ActiveAbortSignal,
+  createAbortController,
+  isAbortSignal as isActiveAbortSignal,
+} from "../../lib/abort";
 import type {
   BoundedTaskContext,
   PermissionLeadingNavigation,
@@ -119,50 +124,6 @@ interface JudgeOptions {
 interface CacheEntry {
   expiresAt: number;
 }
-
-interface ActiveAbortSignal {
-  readonly aborted: boolean;
-  addEventListener(
-    type: "abort",
-    listener: () => void,
-    options?: { once?: boolean },
-  ): void;
-  removeEventListener(type: "abort", listener: () => void): void;
-}
-
-interface AbortControllerLike {
-  readonly signal: ActiveAbortSignal;
-  abort(): void;
-}
-
-const isActiveAbortSignal = (value: unknown): value is ActiveAbortSignal =>
-  typeof value === "object" &&
-  value !== null &&
-  "aborted" in value &&
-  typeof value.aborted === "boolean" &&
-  "addEventListener" in value &&
-  typeof value.addEventListener === "function" &&
-  "removeEventListener" in value &&
-  typeof value.removeEventListener === "function";
-
-const createAbortController = (): AbortControllerLike => {
-  const value: unknown = new AbortController();
-  if (
-    typeof value !== "object" ||
-    value === null ||
-    !("abort" in value) ||
-    typeof value.abort !== "function" ||
-    !("signal" in value) ||
-    !isActiveAbortSignal(value.signal)
-  ) {
-    throw new Error("AbortController is unavailable");
-  }
-  const { abort, signal } = value;
-  return {
-    signal,
-    abort: () => Reflect.apply(abort, value, []),
-  };
-};
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);

--- a/pi/extensions/pi-harness/features/permission-policy/rules.ts
+++ b/pi/extensions/pi-harness/features/permission-policy/rules.ts
@@ -14,17 +14,20 @@ import { isPackageRunnerInvocation } from "./package-runner";
 import { literalTrustedCdTarget } from "./trusted-cd";
 import { isPathWithin } from "../../lib/trust";
 
-interface DenyRule {
+interface RequiredReasonRule<TPattern> {
   readonly source?: string;
-  readonly pattern: RegExp;
+  readonly pattern: TPattern;
   readonly reason: string;
 }
 
-interface AllowRule {
+interface OptionalReasonRule<TPattern> {
   readonly source?: string;
-  readonly pattern: RegExp;
+  readonly pattern: TPattern;
   readonly reason?: string;
 }
+
+type DenyRule = RequiredReasonRule<RegExp>;
+type AllowRule = OptionalReasonRule<RegExp>;
 
 interface AskRule {
   readonly pattern: RegExp;
@@ -109,17 +112,8 @@ interface EvaluationOptions {
   readonly trustedReadContext?: TrustedReadContext;
 }
 
-interface DenyDefinition {
-  readonly source?: string;
-  readonly pattern: string;
-  readonly reason: string;
-}
-
-interface AllowDefinition {
-  readonly source?: string;
-  readonly pattern: string;
-  readonly reason?: string;
-}
+type DenyDefinition = RequiredReasonRule<string>;
+type AllowDefinition = OptionalReasonRule<string>;
 
 interface AskDefinition {
   readonly pattern: string;

--- a/pi/extensions/pi-harness/features/subagent/index.ts
+++ b/pi/extensions/pi-harness/features/subagent/index.ts
@@ -1,3 +1,4 @@
+import { createAbortController } from "../../lib/abort";
 import type { CtxLike, PiLike } from "../../lib/pi-like";
 import type { HarnessConfig } from "../../config";
 import { replacePrevious } from "../../lib/placeholder";
@@ -57,42 +58,8 @@ interface Semaphore {
   acquire(signal?: AbortSignal): Promise<() => void>;
 }
 
-interface AbortControllerLike {
-  signal: AbortSignal;
-  abort(): void;
-}
-
 const isAborted = (signal: AbortSignal | undefined): boolean =>
   signal !== undefined && "aborted" in signal && signal.aborted === true;
-
-const isAbortSignal = (value: unknown): value is AbortSignal =>
-  typeof value === "object" &&
-  value !== null &&
-  "aborted" in value &&
-  typeof value.aborted === "boolean" &&
-  "addEventListener" in value &&
-  typeof value.addEventListener === "function" &&
-  "removeEventListener" in value &&
-  typeof value.removeEventListener === "function";
-
-const createAbortController = (): AbortControllerLike => {
-  const controller: unknown = new AbortController();
-  if (
-    typeof controller !== "object" ||
-    controller === null ||
-    !("abort" in controller) ||
-    typeof controller.abort !== "function" ||
-    !("signal" in controller) ||
-    !isAbortSignal(controller.signal)
-  ) {
-    throw new Error("AbortController is unavailable");
-  }
-  const { abort, signal } = controller;
-  return {
-    signal,
-    abort: () => Reflect.apply(abort, controller, []),
-  };
-};
 
 const getResultOutput = (result: SpawnResult): string =>
   result.output || result.stderr || "(no output)";

--- a/pi/extensions/pi-harness/lib/abort.ts
+++ b/pi/extensions/pi-harness/lib/abort.ts
@@ -1,0 +1,63 @@
+export interface ActiveAbortSignal {
+  readonly aborted: boolean;
+  addEventListener(
+    type: "abort",
+    listener: () => void,
+    options?: { once?: boolean },
+  ): void;
+  removeEventListener(type: "abort", listener: () => void): void;
+}
+
+export interface AbortControllerLike {
+  readonly signal: AbortSignal & ActiveAbortSignal;
+  abort(): void;
+}
+
+type AbortControllerFactory = () => unknown;
+
+export const isAbortSignal = (
+  value: unknown,
+): value is AbortSignal & ActiveAbortSignal =>
+  typeof value === "object" &&
+  value !== null &&
+  "aborted" in value &&
+  typeof value.aborted === "boolean" &&
+  "addEventListener" in value &&
+  typeof value.addEventListener === "function" &&
+  "removeEventListener" in value &&
+  typeof value.removeEventListener === "function";
+
+/** Creates a validated controller whose abort method keeps its native receiver. */
+export const createAbortController = (
+  factory: AbortControllerFactory = () => new AbortController(),
+): AbortControllerLike => {
+  const controller = factory();
+  if (
+    typeof controller !== "object" ||
+    controller === null ||
+    !("abort" in controller) ||
+    typeof controller.abort !== "function" ||
+    !("signal" in controller) ||
+    !isAbortSignal(controller.signal)
+  ) {
+    throw new Error("AbortController is unavailable");
+  }
+  const { abort, signal } = controller;
+  return {
+    signal,
+    abort: () => Reflect.apply(abort, controller, []),
+  };
+};
+
+/** Graceful variant for optional UI bridges that can operate without abort. */
+export const tryCreateAbortController = (
+  factory?: AbortControllerFactory,
+): AbortControllerLike | undefined => {
+  try {
+    return factory === undefined
+      ? createAbortController()
+      : createAbortController(factory);
+  } catch {
+    return undefined;
+  }
+};

--- a/pi/extensions/pi-harness/lib/git-worktree-porcelain.ts
+++ b/pi/extensions/pi-harness/lib/git-worktree-porcelain.ts
@@ -1,0 +1,121 @@
+import { isAbsolute } from "node:path";
+
+export const MAX_GIT_WORKTREE_PORCELAIN_BYTES = 64 * 1_024;
+export const MAX_GIT_WORKTREE_RECORDS = 128;
+export const MAX_GIT_WORKTREE_PATH_BYTES = 1_024;
+
+const decoder = new TextDecoder(undefined, {
+  fatal: true,
+  ignoreBOM: true,
+});
+const allowedFieldKinds = new Set([
+  "HEAD",
+  "branch",
+  "detached",
+  "bare",
+  "locked",
+  "prunable",
+]);
+
+export interface GitWorktreePorcelainRecord {
+  readonly path: string;
+  readonly bare: boolean;
+  readonly prunable: boolean;
+}
+
+const hasControlCharacter = (value: string): boolean =>
+  [...value].some((character) => {
+    const codePoint = character.codePointAt(0);
+    return codePoint !== undefined && (codePoint <= 31 || codePoint === 127);
+  });
+
+/**
+ * Parses the NUL-delimited output of `git worktree list --porcelain -z`.
+ *
+ * This parser is intentionally bounded and fail-closed because its output is
+ * used for repository boundary decisions. Filesystem canonicalization and
+ * caller-specific bare/prunable filtering happen after this structural pass.
+ */
+export const parseGitWorktreePorcelain = (
+  stdout: Uint8Array,
+): readonly GitWorktreePorcelainRecord[] | undefined => {
+  if (
+    stdout.byteLength === 0 ||
+    stdout.byteLength > MAX_GIT_WORKTREE_PORCELAIN_BYTES
+  ) {
+    return undefined;
+  }
+
+  let text: string;
+  try {
+    text = decoder.decode(stdout);
+  } catch {
+    return undefined;
+  }
+  if (!text.endsWith("\0\0")) return undefined;
+
+  const records: GitWorktreePorcelainRecord[] = [];
+  const seenPaths = new Set<string>();
+  let fields: string[] = [];
+  const consume = (): boolean => {
+    if (fields.length === 0) return true;
+
+    const [firstField] = fields;
+    const worktreeFields = fields.filter((field) =>
+      field.startsWith("worktree "),
+    );
+    const [worktreeField] = worktreeFields;
+    if (
+      firstField === undefined ||
+      worktreeField === undefined ||
+      worktreeFields.length !== 1 ||
+      worktreeField !== firstField
+    ) {
+      return false;
+    }
+
+    const path = worktreeField.slice("worktree ".length);
+    if (
+      path === "" ||
+      !isAbsolute(path) ||
+      Buffer.byteLength(path, "utf8") > MAX_GIT_WORKTREE_PATH_BYTES ||
+      hasControlCharacter(path) ||
+      seenPaths.has(path)
+    ) {
+      return false;
+    }
+    seenPaths.add(path);
+
+    const seenKinds = new Set<string>();
+    for (const field of fields.slice(1)) {
+      const [kind] = field.split(" ", 1);
+      if (
+        kind === undefined ||
+        !allowedFieldKinds.has(kind) ||
+        seenKinds.has(kind)
+      ) {
+        return false;
+      }
+      seenKinds.add(kind);
+    }
+    if (seenKinds.has("branch") && seenKinds.has("detached")) return false;
+
+    records.push({
+      path,
+      bare: seenKinds.has("bare"),
+      prunable: seenKinds.has("prunable"),
+    });
+    return records.length <= MAX_GIT_WORKTREE_RECORDS;
+  };
+
+  for (const field of text.split("\0")) {
+    if (field !== "") {
+      fields.push(field);
+      continue;
+    }
+    if (!consume()) return undefined;
+    fields = [];
+  }
+  if (fields.length !== 0 || records.length === 0) return undefined;
+  return records;
+};

--- a/pi/extensions/pi-harness/lib/repo-boundary.ts
+++ b/pi/extensions/pi-harness/lib/repo-boundary.ts
@@ -20,6 +20,10 @@ import { execFile } from "node:child_process";
 import { realpath, stat } from "node:fs/promises";
 import { isAbsolute } from "node:path";
 import { sanitizeChildEnv } from "./child-env";
+import {
+  MAX_GIT_WORKTREE_PORCELAIN_BYTES,
+  parseGitWorktreePorcelain,
+} from "./git-worktree-porcelain";
 import { isPathWithin } from "./trust";
 
 export type CwdBoundaryResult =
@@ -63,86 +67,14 @@ export const gitCommonDir = (cwd: string): Promise<string | undefined> =>
 
 export type GitCommonDirFn = (cwd: string) => Promise<string | undefined>;
 
-const MAX_WORKTREE_LIST_BYTES = 64 * 1_024;
-const MAX_WORKTREE_COUNT = 128;
-const MAX_WORKTREE_PATH_BYTES = 1_024;
-const fatalUtf8 = new TextDecoder(undefined, { fatal: true, ignoreBOM: true });
-
-interface WorktreeRecord {
-  readonly path: string;
-  readonly bare: boolean;
-  readonly prunable: boolean;
-}
-
 const parseWorktreeRoots = async (
   stdout: Uint8Array,
 ): Promise<readonly string[] | undefined> => {
-  if (stdout.byteLength === 0 || stdout.byteLength > MAX_WORKTREE_LIST_BYTES) {
-    return undefined;
-  }
-  let text: string;
-  try {
-    text = fatalUtf8.decode(stdout);
-  } catch {
-    return undefined;
-  }
-  if (!text.endsWith("\0\0")) return undefined;
+  const records = parseGitWorktreePorcelain(stdout);
+  if (records === undefined) return undefined;
 
-  const records: WorktreeRecord[] = [];
-  let fields: string[] = [];
-  const consume = (): boolean => {
-    if (fields.length === 0) return true;
-    const [first] = fields;
-    if (first === undefined || !first.startsWith("worktree ")) return false;
-    if (fields.filter((field) => field.startsWith("worktree ")).length !== 1) {
-      return false;
-    }
-    const path = first.slice("worktree ".length);
-    if (
-      !isAbsolute(path) ||
-      Buffer.byteLength(path, "utf8") > MAX_WORKTREE_PATH_BYTES ||
-      hasControlCharacter(path)
-    ) {
-      return false;
-    }
-    const seenKinds = new Set<string>();
-    for (const field of fields.slice(1)) {
-      const [kind] = field.split(" ", 1);
-      if (
-        kind === undefined ||
-        !["HEAD", "branch", "detached", "bare", "locked", "prunable"].includes(
-          kind,
-        ) ||
-        seenKinds.has(kind)
-      ) {
-        return false;
-      }
-      seenKinds.add(kind);
-    }
-    if (seenKinds.has("branch") && seenKinds.has("detached")) return false;
-    records.push({
-      path,
-      bare: seenKinds.has("bare"),
-      prunable: seenKinds.has("prunable"),
-    });
-    return records.length <= MAX_WORKTREE_COUNT;
-  };
-
-  for (const field of text.split("\0")) {
-    if (field !== "") {
-      fields.push(field);
-      continue;
-    }
-    if (!consume()) return undefined;
-    fields = [];
-  }
-  if (fields.length !== 0 || records.length === 0) return undefined;
-
-  const lexical = new Set<string>();
   const canonical = new Set<string>();
   for (const record of records) {
-    if (lexical.has(record.path)) return undefined;
-    lexical.add(record.path);
     // A prunable administrative record is not a currently registered,
     // navigable worktree even when an attacker recreates its old path.
     if (record.bare || record.prunable) continue;
@@ -172,7 +104,7 @@ export const gitWorktreeRoots: GitWorktreeRootsFn = (cwd) =>
       {
         cwd,
         encoding: "buffer",
-        maxBuffer: MAX_WORKTREE_LIST_BYTES,
+        maxBuffer: MAX_GIT_WORKTREE_PORCELAIN_BYTES,
         timeout: 5_000,
         env: sanitizeChildEnv(
           process.env,

--- a/tests/pi-harness/abort.test.ts
+++ b/tests/pi-harness/abort.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createAbortController,
+  isAbortSignal,
+  tryCreateAbortController,
+} from "../../pi/extensions/pi-harness/lib/abort";
+
+const structuralSignal = () => ({
+  aborted: false,
+  addEventListener: (_type: "abort", _listener: () => void): void => {},
+  removeEventListener: (_type: "abort", _listener: () => void): void => {},
+});
+
+describe("shared Abort primitives", () => {
+  test("accepts native and complete structural signals", () => {
+    expect(isAbortSignal(createAbortController().signal)).toBe(true);
+    expect(isAbortSignal(structuralSignal())).toBe(true);
+  });
+
+  test.each([
+    ["undefined", undefined],
+    ["null", null],
+    ["primitive", false],
+    ["missing aborted", { ...structuralSignal(), aborted: undefined }],
+    [
+      "missing addEventListener",
+      { ...structuralSignal(), addEventListener: undefined },
+    ],
+    [
+      "missing removeEventListener",
+      { ...structuralSignal(), removeEventListener: undefined },
+    ],
+  ])("rejects malformed signals: %s", (_label, value) => {
+    expect(isAbortSignal(value)).toBe(false);
+  });
+
+  test("creates a native controller and emits abort once", () => {
+    const controller = createAbortController();
+    let aborts = 0;
+    controller.signal.addEventListener("abort", () => {
+      aborts += 1;
+    });
+
+    controller.abort();
+    controller.abort();
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(aborts).toBe(1);
+  });
+
+  test("keeps the raw controller receiver when delegating abort", () => {
+    const signal = structuralSignal();
+    let rawController: {
+      signal: ReturnType<typeof structuralSignal>;
+      abort(): void;
+    };
+    rawController = {
+      signal,
+      abort() {
+        if (this !== rawController) throw new Error("lost abort receiver");
+        signal.aborted = true;
+      },
+    };
+
+    const controller = createAbortController(() => rawController);
+    controller.abort();
+
+    expect(signal.aborted).toBe(true);
+  });
+
+  test("throws for malformed controllers but offers a graceful variant", () => {
+    const malformed = () => ({ abort() {}, signal: {} });
+    expect(() => createAbortController(malformed)).toThrow(
+      "AbortController is unavailable",
+    );
+    expect(tryCreateAbortController(malformed)).toBeUndefined();
+    expect(
+      tryCreateAbortController(() => {
+        throw new Error("constructor failed");
+      }),
+    ).toBeUndefined();
+    expect(tryCreateAbortController()).toBeDefined();
+  });
+});

--- a/tests/pi-harness/git-worktree-porcelain.test.ts
+++ b/tests/pi-harness/git-worktree-porcelain.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import {
+  MAX_GIT_WORKTREE_PORCELAIN_BYTES,
+  MAX_GIT_WORKTREE_RECORDS,
+  MAX_GIT_WORKTREE_PATH_BYTES,
+  parseGitWorktreePorcelain,
+} from "../../pi/extensions/pi-harness/lib/git-worktree-porcelain";
+
+const output = (...records: readonly (readonly string[])[]): Buffer =>
+  Buffer.from(
+    `${records.flatMap((fields) => [...fields, ""]).join("\0")}\0`,
+    "utf8",
+  );
+
+describe("parseGitWorktreePorcelain", () => {
+  test("parses branch, detached, locked, bare, and prunable records", () => {
+    expect(
+      parseGitWorktreePorcelain(
+        output(
+          [
+            "worktree /repo",
+            "HEAD a",
+            "branch refs/heads/main",
+            "locked maintenance",
+          ],
+          ["worktree /linked", "HEAD b", "detached"],
+          ["worktree /repo.git", "bare"],
+          ["worktree /stale", "HEAD c", "prunable missing gitdir"],
+        ),
+      ),
+    ).toEqual([
+      { path: "/repo", bare: false, prunable: false },
+      { path: "/linked", bare: false, prunable: false },
+      { path: "/repo.git", bare: true, prunable: false },
+      { path: "/stale", bare: false, prunable: true },
+    ]);
+  });
+
+  test.each([
+    ["empty output", Buffer.alloc(0)],
+    ["missing final NUL", Buffer.from("worktree /repo")],
+    ["missing record separator", Buffer.from("worktree /repo\0")],
+    [
+      "invalid UTF-8",
+      Buffer.concat([
+        Buffer.from("worktree /repo/"),
+        Buffer.from([255]),
+        Buffer.from("\0\0"),
+      ]),
+    ],
+    ["relative path", output(["worktree relative", "HEAD a"])],
+    ["control character", output(["worktree /bad\npath", "HEAD a"])],
+    [
+      "worktree field after another field",
+      output(["HEAD a", "worktree /repo"]),
+    ],
+    [
+      "multiple worktree fields",
+      output(["worktree /repo", "worktree /other", "HEAD a"]),
+    ],
+    ["unknown field", output(["worktree /repo", "future value"])],
+    ["duplicate field kind", output(["worktree /repo", "HEAD a", "HEAD b"])],
+    [
+      "branch and detached",
+      output(["worktree /repo", "branch refs/heads/main", "detached"]),
+    ],
+    [
+      "duplicate path",
+      output(["worktree /repo", "HEAD a"], ["worktree /repo", "HEAD b"]),
+    ],
+  ])("rejects malformed input: %s", (_label, stdout) => {
+    expect(parseGitWorktreePorcelain(stdout)).toBeUndefined();
+  });
+
+  test("rejects inputs above each security bound", () => {
+    expect(
+      parseGitWorktreePorcelain(
+        Buffer.alloc(MAX_GIT_WORKTREE_PORCELAIN_BYTES + 1, 0x61),
+      ),
+    ).toBeUndefined();
+    expect(
+      parseGitWorktreePorcelain(
+        output([`worktree /${"a".repeat(MAX_GIT_WORKTREE_PATH_BYTES)}`]),
+      ),
+    ).toBeUndefined();
+    expect(
+      parseGitWorktreePorcelain(
+        output(
+          ...Array.from(
+            { length: MAX_GIT_WORKTREE_RECORDS + 1 },
+            (_, index) => [`worktree /repo-${index}`, `HEAD ${index}`],
+          ),
+        ),
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/tests/pi-harness/harness-composition.test.ts
+++ b/tests/pi-harness/harness-composition.test.ts
@@ -494,6 +494,38 @@ describe("open bit issue browser lifecycle", () => {
 });
 
 describe("project memory browser lifecycle", () => {
+  test("keeps automatic failures silent and deduplicates explicit warnings", async () => {
+    const runtime = createIssueRuntime();
+    const source: AgentMemoryDataSource = {
+      aggregate: async () => {
+        throw new Error("memory is unavailable");
+      },
+      update: async () => {
+        throw new Error("unused");
+      },
+    };
+    const memory = new AgentMemoryRegistry({
+      cli: source,
+      trust: { trustedRoots: ["/repo"] },
+    });
+    setupChildRuns(runtime.pi, {
+      agentMemory: memory,
+      childExecution: false,
+    });
+
+    await runtime.emit("session_start");
+    await Bun.sleep(0);
+    expect(runtime.notifications).toEqual([]);
+    const command = runtime.commands.get("project-memory");
+    if (command === undefined)
+      throw new Error("project-memory command missing");
+    await command.handler("", runtime.context);
+    await command.handler("", runtime.context);
+    expect(runtime.notifications).toEqual([
+      "Project memory unavailable: memory is unavailable",
+    ]);
+  });
+
   test("background-mounts, focuses, refreshes, and disposes memory-only state", async () => {
     const runtime = createIssueRuntime();
     let aggregateCalls = 0;

--- a/tests/pi-harness/permission-audit.test.ts
+++ b/tests/pi-harness/permission-audit.test.ts
@@ -15,6 +15,10 @@ import {
   type PermissionDecisionRecordInput,
 } from "../../pi/extensions/pi-harness/features/permission-audit/model";
 import {
+  projectPermissionNavigation,
+  projectPermissionRunEvidence,
+} from "../../pi/extensions/pi-harness/features/permission-audit/projection";
+import {
   createPermissionAuditWriter,
   permissionAuditLogFileName,
   type PermissionAuditFileHandle,
@@ -32,7 +36,12 @@ import {
   setupPermissionAudit,
 } from "../../pi/extensions/pi-harness/features/permission-audit/index";
 import setupPermissionPolicy from "../../pi/extensions/pi-harness/features/permission-policy/index";
-import { createPermissionTaskTracker } from "../../pi/extensions/pi-harness/features/permission-policy/context";
+import {
+  createPermissionTaskTracker,
+  type PermissionLeadingNavigation,
+  type PermissionRunEvidence,
+  type PermissionToolResultEvidence,
+} from "../../pi/extensions/pi-harness/features/permission-policy/context";
 import { CHILD_PERMISSION_SIGNAL_ENV } from "../../pi/extensions/pi-harness/features/permission-policy/block";
 import { sanitizeChildEnv } from "../../pi/extensions/pi-harness/lib/child-env";
 import { resolvePaths } from "../../pi/extensions/pi-harness/lib/paths";
@@ -98,6 +107,49 @@ const allowedStage: PermissionAuditStage = {
 };
 
 describe("permission audit record model", () => {
+  test("projects only persisted fields from runtime permission contexts", () => {
+    const priorToolResults: readonly (PermissionToolResultEvidence & {
+      readonly runtimeOnly: string;
+    })[] = [
+      { toolName: "AskUserQuestion", status: "ok", runtimeOnly: "nested" },
+    ];
+    const runEvidence: PermissionRunEvidence & {
+      readonly runtimeOnly: string;
+    } = {
+      assistantText: "Inspecting the repository.",
+      askUserQuestionResultText: "Approved.",
+      priorToolResults,
+      fingerprint: "runtime-fingerprint",
+      runtimeOnly: "top-level",
+    };
+    const navigation: PermissionLeadingNavigation & {
+      readonly canonicalPath: string;
+    } = {
+      scope: "listed-worktree",
+      sameRepository: true,
+      canonicalPath: "/private/runtime-only",
+    };
+
+    const projectedEvidence = projectPermissionRunEvidence(runEvidence);
+    expect(projectedEvidence).toEqual({
+      assistantText: "Inspecting the repository.",
+      askUserQuestionResultText: "Approved.",
+      priorToolResults: [{ toolName: "AskUserQuestion", status: "ok" }],
+      fingerprint: "runtime-fingerprint",
+    });
+    expect(projectedEvidence?.priorToolResults).not.toBe(
+      runEvidence.priorToolResults,
+    );
+    expect(JSON.stringify(projectedEvidence)).not.toContain("runtimeOnly");
+    expect(projectPermissionNavigation(navigation)).toEqual({
+      scope: "listed-worktree",
+      sameRepository: true,
+    });
+    expect(
+      JSON.stringify(projectPermissionNavigation(navigation)),
+    ).not.toContain("canonicalPath");
+  });
+
   test("derives terminal decisions from challenges rather than intermediate ASK", () => {
     const intermediateAsk: PermissionAuditStage = {
       type: "deterministic",

--- a/tests/pi-harness/permission-judge-context.test.ts
+++ b/tests/pi-harness/permission-judge-context.test.ts
@@ -90,6 +90,16 @@ describe("current permission task context", () => {
     expect(first?.fingerprint).not.toBe(second?.fingerprint);
   });
 
+  test("truncates a multibyte task prefix only at a UTF-8 boundary", () => {
+    const task = boundTaskContext(`${"a".repeat(1_020)}🙂tail`, "interactive");
+
+    expect(task?.text).toBe(`${"a".repeat(1_020)}…`);
+    expect(task?.text).not.toContain("�");
+    expect(Buffer.byteLength(task?.text ?? "", "utf8")).toBeLessThanOrEqual(
+      1_024,
+    );
+  });
+
   test("promotes matching raw input only when its agent run starts", () => {
     const tracker = createPermissionTaskTracker();
     tracker.capture({
@@ -288,6 +298,35 @@ describe("current permission task context", () => {
 });
 
 describe("current permission run evidence", () => {
+  test("truncates a multibyte evidence tail only at a UTF-8 boundary", () => {
+    const evidence = derivePermissionRunEvidence(
+      [
+        { type: "message", message: { role: "user", content: "task" } },
+        {
+          type: "message",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: `head🙂${"z".repeat(2_042)}` }],
+          },
+        },
+        {
+          type: "message",
+          message: {
+            role: "assistant",
+            content: [{ type: "toolCall", id: "current", name: "bash" }],
+          },
+        },
+      ],
+      "current",
+    );
+
+    expect(evidence?.assistantText).toBe(`…${"z".repeat(2_042)}`);
+    expect(evidence?.assistantText).not.toContain("�");
+    expect(
+      Buffer.byteLength(evidence?.assistantText ?? "", "utf8"),
+    ).toBeLessThanOrEqual(2 * 1_024);
+  });
+
   test("binds assistant text, AskUserQuestion results, and prior metadata to the exact tool call", () => {
     const evidence = derivePermissionRunEvidence(
       [


### PR DESCRIPTION
## Summary

- consolidate fail-closed Git worktree porcelain parsing and shared Abort primitives
- deduplicate child-run coordination refreshes and make permission type relationships explicit
- project runtime permission data through audit allowlists and share UTF-8 continuation-byte detection
- add focused regression coverage for parser, abort, audit privacy, refresh warnings, and multibyte boundaries

## Similarity

Using `similarity-ts --types pi/extensions/pi-harness` with default thresholds:

- function pairs: 7 → 5
- similar type pairs: 61 → 13

Remaining matches are intentional directional algorithms, boundary DTOs, or unrelated structural similarities.

## Verification

- `bun run tsc`
- `bun run lint` (0 errors; existing unrelated warnings only)
- focused pi-harness tests
- `bun test`: 1932 passed, 2 skipped, 0 failed
- two independent final reviews: no findings