### PR TITLE
feat(pi): integrate Hearth module graph

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.26",
         "@clack/prompts": "0.11.0",
-        "@hearthdev/napi": "0.1.0",
+        "@hearthdev/napi": "0.1.1",
         "c12": "3.2.0",
         "consola": "3.4.2",
         "defu": "6.1.4",
@@ -178,15 +178,15 @@
 
     "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
 
-    "@hearthdev/napi": ["@hearthdev/napi@0.1.0", "", { "optionalDependencies": { "@hearthdev/napi-darwin-arm64": "0.1.0", "@hearthdev/napi-darwin-x64": "0.1.0", "@hearthdev/napi-linux-arm64-gnu": "0.1.0", "@hearthdev/napi-linux-x64-gnu": "0.1.0" } }, "sha512-obrufSxvnEBrn7SM72qW3xdMg6pqT/sC586k0JpNpIkX/oPIVJWIuToYQnQinwE8ca/QHZM9K9WhXBz/M+G3nQ=="],
+    "@hearthdev/napi": ["@hearthdev/napi@0.1.1", "", { "optionalDependencies": { "@hearthdev/napi-darwin-arm64": "0.1.1", "@hearthdev/napi-darwin-x64": "0.1.1", "@hearthdev/napi-linux-arm64-gnu": "0.1.1", "@hearthdev/napi-linux-x64-gnu": "0.1.1" } }, "sha512-hTtKgFQHZHoLhqui1Bdr1RNLDwyy3hDZRPvUtycTY5ItlNLLcEWeBo2MRjUb2kuT4n9vEbFk0PUVWCQe3Y6d1w=="],
 
-    "@hearthdev/napi-darwin-arm64": ["@hearthdev/napi-darwin-arm64@0.1.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-3vg3ykiPVCNnL54+Pnnmy0j4X9qPsQQuJzZ5ba3K362KYXCyhD8u9knEQKlqJNNGL/BQT2C0y/MH4ODdJvCaow=="],
+    "@hearthdev/napi-darwin-arm64": ["@hearthdev/napi-darwin-arm64@0.1.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Fob3k4L8UB6UFC7hXk2TPG7wTRIj1OVI9ZOgOFJ4pDsarI21CEqAh3iLnzXUAufdp2I4vXDuN9VOAoylvTMHSg=="],
 
-    "@hearthdev/napi-darwin-x64": ["@hearthdev/napi-darwin-x64@0.1.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-rVSQ7rT//l8vhrFHnCc/jaN7bdqlsx6ZgW34p6tdPNNoAYoNt9MPzyvmP5Q+eezH99mccNpjyPjg1blWQQBQbQ=="],
+    "@hearthdev/napi-darwin-x64": ["@hearthdev/napi-darwin-x64@0.1.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-8nBlw1RubYZN/Gg+pH2JeLNUQXYnRqan/VMMyrrxUEbdIDJG9M7t/v2akX5KUi0p1t6IlVPMNRxa4DBRCPPftA=="],
 
-    "@hearthdev/napi-linux-arm64-gnu": ["@hearthdev/napi-linux-arm64-gnu@0.1.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-FUDNTOjubtnEaWL4FJfWdciGO0YWqrAnzzXMduIm8g7JFb0JRu92Rg67/RdPW+5rtovbne8KpUgqIreuxUkEiw=="],
+    "@hearthdev/napi-linux-arm64-gnu": ["@hearthdev/napi-linux-arm64-gnu@0.1.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-zWYN5MQclaSO8G1Rn2gRbUQD7U4+ERkOvwTO7TXLm34hQ1zUUaxQNi4j0YD9SZeqngbas/LU1oLCUHZLeYP7Kg=="],
 
-    "@hearthdev/napi-linux-x64-gnu": ["@hearthdev/napi-linux-x64-gnu@0.1.0", "", { "os": "linux", "cpu": "x64" }, "sha512-aS6smaXHMsSk+ZCi25YWNyXPPwjplqWBCLAGQVluR+7dLFdYUwGMkeMM9g707DURhXyD9gUE6eofOrbmBK2eTA=="],
+    "@hearthdev/napi-linux-x64-gnu": ["@hearthdev/napi-linux-x64-gnu@0.1.1", "", { "os": "linux", "cpu": "x64" }, "sha512-8/nZWMt/07gixBRlgyoln02EYRMX+kTc72PtAih2NWQSnlK1thcg6dyvfjSjfWBLt1qFP3xZlN7SctaR7p7QvQ=="],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@anthropic-ai/sandbox-runtime": "0.0.26",
     "@clack/prompts": "0.11.0",
-    "@hearthdev/napi": "0.1.0",
+    "@hearthdev/napi": "0.1.1",
     "c12": "3.2.0",
     "consola": "3.4.2",
     "defu": "6.1.4",

--- a/pi/README.md
+++ b/pi/README.md
@@ -334,11 +334,14 @@ uses the verified read-only route described above.
 
 ## Hearth-backed built-in tools
 
-`pi/extensions/hearth-tools` pins `@hearthdev/napi` exactly to `0.1.0` and
-constructs one in-process `HearthEngine` per pi process. Parent pi and every
-subagent/workflow child have separate resident caches and warm-shell pools;
-`/reload` reuses the process Engine when every Engine option is unchanged. A
-config, cwd, or inherited shell change during reload fails with a bounded
+`pi/extensions/hearth-tools` pins `@hearthdev/napi` exactly to `0.1.1` and
+constructs one in-process `HearthEngine` per pi process. The same resident
+Engine owns file/walk caches, the warm-shell pool, and the Hearth symbol/module
+graph. Parent pi and every subagent/workflow child have separate resident state;
+`/reload` reuses the process Engine when every Engine option is unchanged. The
+0.1.1 integration uses a new process slot, so a live reload cannot reuse a
+pre-graph 0.1.0 Engine. A config, cwd, or inherited shell change during reload
+fails with a bounded
 restart-required diagnostic instead of silently retaining old settings. BTW
 keeps extension/package discovery off but receives a custom Hearth-backed
 `read`; its active tools remain `read` and `ls`.
@@ -357,9 +360,10 @@ The checked-in maximum-speed defaults are:
 Override these fields, plus optional `maxCachedFiles`, in
 `~/.pi/agent/hearth-tools.local.json`; unknown keys are rejected. Invalid
 config, a missing/incompatible native addon, or an effective competing override
-for one of the five names terminates pi at startup with exit code 1; there is no
-built-in fallback. Registration restores the prior active names, so replacing
-`grep` does not enable it. Pi 0.80.7 exposes only the first effective tool per
+for one of the five built-in names or `hearth_graph` terminates pi at startup
+with exit code 1; there is no built-in fallback. Registration restores the prior
+active built-in names, so replacing `grep` does not enable it, then activates the
+new read-only `hearth_graph` tool. Pi 0.80.7 exposes only the first effective tool per
 name: a later inert losing registration cannot be enumerated, but it also cannot
 execute. Hearth checks effective ownership before registration, immediately
 after registration, before each agent turn, and again at the tool-call boundary.
@@ -386,24 +390,49 @@ drain timeout, the lease remains held until the late child actually settles,
 and branch navigation is cancelled until that old-branch record archives. This
 covers formatters and child writers independently of parent-message delivery.
 External editors and unmanaged processes still require `/hearth-clear-cache`,
-a restart, or `trustCache: false`. An `indeterminate` command is never retried
-automatically. In particular, a command that terminates its pooled warm shell
+a restart, or `trustCache: false`. Cache invalidation also marks retained graph
+state stale; the next graph sweep revalidates it rather than trusting old module
+edges. An `indeterminate` command is never retried automatically. In particular, a command that terminates its pooled warm shell
 may be indeterminate; set `warmShell: false` when exact signal-exit reporting is
 more important than shell reuse.
+
+Successful `read` calls (including BTW reads) enqueue their in-project file for
+incremental graph analysis. Successful `grep` calls enqueue the matching files
+that remain after glob post-filtering. The session observer deduplicates paths,
+indexes batches of up to 128 files asynchronously through the shared Engine
+gate, skips paths outside the project root, and aborts pending native work on
+session shutdown. Graph indexing is advisory: failed paths and their bounded
+diagnostic remain visible until that path is observed and indexed successfully;
+a failure never changes an otherwise successful `read` or `grep` result.
+
+`hearth_graph` exposes `symbols`, `outline`, `search`, `definitions`, `deps`,
+`rdeps`, `neighborhood`, and `status`. A query first drains pending observed-file
+analysis; aborting that wait stops the tool call without discarding the
+session-scoped warmup. Graph operations are serialized independently of normal
+file reads so partial indexing cannot race a complete sweep. All semantic
+operations then sweep the complete gitignore-aware project universe, so the
+progressively warmed index becomes a complete project view on demand. `status`
+reports the current build without forcing a walk; an observed-files-only view is
+explicitly labeled `observed-partial` and `approximate` rather than presenting
+its last batch size as project coverage. Output is incrementally formatted and
+bounded, including its truncation notice, to 200 lines and 32 KiB. Every response
+keeps Hearth `exact`/`approximate` metadata, and the agent guidelines require
+consequential approximate results or unresolved imports to be confirmed with
+`read` or `grep`. Traversal depth is limited to four and symbol result limits to 200.
 
 Grep translates cwd-relative positive and negative ripgrep globs to Hearth,
 preserves root anchors, ignores valid globs for an explicit file operand like
 ripgrep, and still validates malformed classes, ranges, alternates, and escapes
 through Hearth's strict native glob parser. Negative globs, rooted positive
 globs, directory-only globs ending in `/`, and positive globs containing `/`
-use separator-aware post-filtering because Hearth 0.1.0 has no native exclusion
+use separator-aware post-filtering because Hearth 0.1.1 has no native exclusion
 glob and lets `*` cross separators in path globs. Negative matching also filters
 matching ancestor directories like ripgrep's walker. The adapter bounds native
 candidates and fails closed with a refinement error rather than returning an
 incomplete result if that bound is exhausted.
 
 Bash streams once into pi's existing accumulator, preserving progress updates,
-tail truncation, and full-output files. Hearth 0.1.0 streams valid UTF-8 text,
+tail truncation, and full-output files. Hearth 0.1.1 streams valid UTF-8 text,
 so invalid binary bytes are replacement-decoded and are not byte-identical in
 full-output files.
 

--- a/pi/SYSTEM.md
+++ b/pi/SYSTEM.md
@@ -13,6 +13,7 @@ Guidelines:
 
 - Use bash for file operations like ls, rg, find.
 - Use read to examine files instead of cat or sed.
+- When `hearth_graph` is available, successful `read` and `grep` calls warm its module index. Use `definitions`, `deps`, `rdeps`, and `neighborhood` to trace symbols, assess change impact, and explore project structure instead of repeating broad searches; verify exact source with `read` before editing.
 - Inspect `PI_*` environment variables when current model or session details are relevant.
 - Use edit for precise changes; every edits[].oldText must match exactly.
 - When changing multiple separate locations in one file, use one edit call with multiple entries in edits[] instead of multiple edit calls.

--- a/pi/extensions/hearth-tools/adapters.ts
+++ b/pi/extensions/hearth-tools/adapters.ts
@@ -30,6 +30,7 @@ import {
   type HearthAccessGate,
   type PiToolSettings,
 } from "./engine";
+import type { HearthGraphObserverLike } from "./graph";
 import { withStatusTitle } from "./status-title";
 
 const FILE_REFERENCE_PREFIX = "@";
@@ -134,6 +135,17 @@ const absolutePath = (cwd: string, input: string): string => {
 
 const errorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
+
+const observeGraphFiles = (
+  observer: HearthGraphObserverLike | undefined,
+  paths: readonly string[],
+): void => {
+  try {
+    observer?.observe(paths);
+  } catch {
+    // Graph warming is advisory and must not change a successful file result.
+  }
+};
 
 const mapCancelled = (error: unknown, message: string): never => {
   if (errorMessage(error).startsWith("cancelled:")) throw new Error(message);
@@ -257,6 +269,7 @@ export const createHearthReadDefinition = (
   engine: HearthEngine,
   settings: PiToolSettings,
   gate: HearthAccessGate = IMMEDIATE_HEARTH_ACCESS_GATE,
+  observer?: HearthGraphObserverLike,
 ) => {
   const base = withStatusTitle(
     createReadToolDefinition(cwd, {
@@ -271,9 +284,17 @@ export const createHearthReadDefinition = (
         autoResizeImages: settings.imageAutoResize,
         operations: hearthReadOperations(engine, signal),
       });
-      return gate.shared(() =>
-        delegated.execute(id, params, signal, onUpdate, ctx),
-      );
+      return gate.shared(async () => {
+        const result = await delegated.execute(
+          id,
+          params,
+          signal,
+          onUpdate,
+          ctx,
+        );
+        observeGraphFiles(observer, [absolutePath(cwd, params.path)]);
+        return result;
+      });
     },
   };
   return definition;
@@ -284,6 +305,7 @@ export const createHearthReadTool = (
   engine: HearthEngine,
   settings: PiToolSettings,
   gate: HearthAccessGate = IMMEDIATE_HEARTH_ACCESS_GATE,
+  observer?: HearthGraphObserverLike,
 ) => {
   const base = createReadTool(cwd, {
     autoResizeImages: settings.imageAutoResize,
@@ -291,12 +313,14 @@ export const createHearthReadTool = (
   const tool: typeof base = {
     ...base,
     execute(id, params, signal, onUpdate) {
-      return gate.shared(() =>
-        createReadTool(cwd, {
+      return gate.shared(async () => {
+        const result = await createReadTool(cwd, {
           autoResizeImages: settings.imageAutoResize,
           operations: hearthReadOperations(engine, signal),
-        }).execute(id, params, signal, onUpdate),
-      );
+        }).execute(id, params, signal, onUpdate);
+        observeGraphFiles(observer, [absolutePath(cwd, params.path)]);
+        return result;
+      });
     },
   };
   return tool;
@@ -508,6 +532,7 @@ export const createHearthGrepDefinition = (
   cwd: string,
   engine: HearthEngine,
   gate: HearthAccessGate = IMMEDIATE_HEARTH_ACCESS_GATE,
+  observer?: HearthGraphObserverLike,
 ) => {
   const base = withStatusTitle(createGrepToolDefinition(cwd), "all-content");
   const definition: typeof base = {
@@ -553,6 +578,10 @@ export const createHearthGrepDefinition = (
           cwd,
           glob,
           result.rootIsDir,
+        );
+        observeGraphFiles(
+          observer,
+          filtered.map((file) => file.path),
         );
         const totalMatches = filtered.reduce(
           (total, file) => total + file.matchCount,

--- a/pi/extensions/hearth-tools/engine.ts
+++ b/pi/extensions/hearth-tools/engine.ts
@@ -182,12 +182,18 @@ export interface HearthEngineRuntime {
 
 // Bump the symbol whenever the slot shape changes so /reload cannot interpret
 // a runtime created by an older extension revision as the current contract.
-const ENGINE_SLOT = Symbol.for("ushironoko.pi-hearth-tools.engine.v2");
-const LEGACY_ENGINE_SLOT = Symbol.for("ushironoko.pi-hearth-tools.engine.v1");
+const ENGINE_SLOT = Symbol.for("ushironoko.pi-hearth-tools.engine.v3");
+const LEGACY_ENGINE_SLOT_V2 = Symbol.for(
+  "ushironoko.pi-hearth-tools.engine.v2",
+);
+const LEGACY_ENGINE_SLOT_V1 = Symbol.for(
+  "ushironoko.pi-hearth-tools.engine.v1",
+);
 
 interface GlobalWithEngine {
   [ENGINE_SLOT]?: HearthEngineRuntime;
-  [LEGACY_ENGINE_SLOT]?: unknown;
+  [LEGACY_ENGINE_SLOT_V2]?: unknown;
+  [LEGACY_ENGINE_SLOT_V1]?: unknown;
 }
 
 export class HearthEngineRestartRequiredError extends Error {
@@ -237,11 +243,11 @@ export const getOrCreateEngineRuntime = (
   shell: ShellSpec,
 ): HearthEngineRuntime => {
   const host = globalThis as GlobalWithEngine;
-  // A live /reload from the pre-gate slot must release its global root before
-  // constructing v2. The stale extension runtime may keep a short-lived local
-  // reference until reload teardown completes, but the old optimizer/warm shell
-  // can then drop instead of remaining process-rooted forever.
-  delete host[LEGACY_ENGINE_SLOT];
+  // A live /reload must release pre-graph and pre-gate global roots before
+  // constructing v3. A 0.1.0 Engine in the v2 slot has no graph methods and
+  // cannot satisfy the current runtime even when its ordinary options match.
+  delete host[LEGACY_ENGINE_SLOT_V2];
+  delete host[LEGACY_ENGINE_SLOT_V1];
   const options = createOptions(cwd, config, shell);
   const existing = host[ENGINE_SLOT];
   if (existing !== undefined) {
@@ -263,5 +269,6 @@ export const getOrCreateEngineRuntime = (
 export const clearProcessEngineForTests = (): void => {
   const host = globalThis as GlobalWithEngine;
   delete host[ENGINE_SLOT];
-  delete host[LEGACY_ENGINE_SLOT];
+  delete host[LEGACY_ENGINE_SLOT_V2];
+  delete host[LEGACY_ENGINE_SLOT_V1];
 };

--- a/pi/extensions/hearth-tools/graph.ts
+++ b/pi/extensions/hearth-tools/graph.ts
@@ -1,0 +1,732 @@
+import {
+  defineTool,
+  type ToolDefinition,
+} from "@earendil-works/pi-coding-agent";
+import type {
+  GraphDepEdge,
+  GraphMeta,
+  GraphResult,
+  GraphSymbol,
+  HearthEngine,
+} from "@hearthdev/napi";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+import type { HearthAccessGate } from "./engine";
+
+export const HEARTH_GRAPH_TOOL_NAME = "hearth_graph";
+
+const AUTO_INDEX_BATCH_SIZE = 128;
+const AUTO_INDEX_SENTINEL = "__pi_hearth_graph_auto_index__";
+const DEFAULT_RESULT_LIMIT = 50;
+const MAX_RESULT_LIMIT = 200;
+const DEFAULT_GRAPH_DEPTH = 1;
+const MAX_GRAPH_DEPTH = 4;
+const MAX_OUTPUT_LINES = 200;
+const MAX_OUTPUT_BYTES = 32 * 1024;
+const OUTPUT_NOTICE_RESERVE_BYTES = 256;
+const MAX_CONTENT_LINES = MAX_OUTPUT_LINES - 1;
+const MAX_CONTENT_BYTES = MAX_OUTPUT_BYTES - OUTPUT_NOTICE_RESERVE_BYTES;
+const MAX_FIELD_LENGTH = 500;
+const MAX_PATH_LENGTH = 4_096;
+const MAX_SYMBOL_TEXT_LENGTH = 512;
+
+const GRAPH_OPERATIONS = [
+  "symbols",
+  "outline",
+  "search",
+  "definitions",
+  "deps",
+  "rdeps",
+  "neighborhood",
+  "status",
+] as const;
+
+type GraphOperation = (typeof GRAPH_OPERATIONS)[number];
+
+const GraphParameters = {
+  type: "object",
+  properties: {
+    operation: {
+      type: "string",
+      enum: GRAPH_OPERATIONS,
+      description: "Graph query to run",
+    },
+    path: {
+      type: "string",
+      minLength: 1,
+      maxLength: MAX_PATH_LENGTH,
+      description:
+        "Project-relative or absolute file path for symbols, outline, deps, rdeps, or neighborhood",
+    },
+    query: {
+      type: "string",
+      minLength: 1,
+      maxLength: MAX_SYMBOL_TEXT_LENGTH,
+      description: "Symbol-name query for search",
+    },
+    name: {
+      type: "string",
+      minLength: 1,
+      maxLength: MAX_SYMBOL_TEXT_LENGTH,
+      description: "Exact symbol name for definitions",
+    },
+    depth: {
+      type: "integer",
+      minimum: 1,
+      maximum: MAX_GRAPH_DEPTH,
+      description:
+        "Traversal depth for deps, rdeps, or neighborhood (default: 1)",
+    },
+    limit: {
+      type: "integer",
+      minimum: 1,
+      maximum: MAX_RESULT_LIMIT,
+      description:
+        "Maximum symbol results for search or definitions (default: 50)",
+    },
+    verify: {
+      type: "boolean",
+      description:
+        "Use the source-text verification backstop for reverse dependencies (default: true)",
+    },
+  },
+  required: ["operation"],
+  additionalProperties: false,
+} as const;
+
+export interface HearthGraphObserverStatus {
+  observedFiles: number;
+  pendingFiles: number;
+  failedFiles: number;
+  indexing: boolean;
+  projectComplete: boolean;
+  lastError?: string;
+}
+
+export interface HearthGraphObserverLike {
+  observe(paths: readonly string[]): void;
+}
+
+export interface HearthGraphRuntime extends HearthGraphObserverLike {
+  flush(signal?: AbortSignal): Promise<void>;
+  runQuery<T>(operation: () => Promise<T>, signal?: AbortSignal): Promise<T>;
+  markProjectComplete(clearAutoFailures?: boolean): void;
+  dispose(): void;
+  status(): HearthGraphObserverStatus;
+}
+
+interface NativeAbortController {
+  readonly signal: AbortSignal;
+  abort(): void;
+}
+
+interface ObservableAbortSignal {
+  readonly aborted: boolean;
+  addEventListener(
+    type: "abort",
+    listener: () => void,
+    options?: { once?: boolean },
+  ): void;
+  removeEventListener(type: "abort", listener: () => void): void;
+}
+
+const nativeAbortController = (): NativeAbortController => {
+  const Constructor =
+    globalThis.AbortController as unknown as new () => NativeAbortController;
+  return new Constructor();
+};
+
+const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+const abortedError = (): Error => new Error("Operation aborted");
+
+const waitAbortable = async <T>(
+  operation: Promise<T>,
+  signal: AbortSignal | undefined,
+): Promise<T> => {
+  if (signal === undefined) return operation;
+  const observable = signal as unknown as ObservableAbortSignal;
+  if (observable.aborted) throw abortedError();
+
+  let onAbort: (() => void) | undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    onAbort = () => reject(abortedError());
+    observable.addEventListener("abort", onAbort, { once: true });
+  });
+  try {
+    return await Promise.race([operation, aborted]);
+  } finally {
+    if (onAbort !== undefined) {
+      observable.removeEventListener("abort", onAbort);
+    }
+  }
+};
+
+const boundedField = (value: string): string => {
+  const escaped = value
+    .replaceAll("\\", "\\\\")
+    .replaceAll("\r", String.raw`\r`)
+    .replaceAll("\n", String.raw`\n`)
+    .replaceAll("\t", String.raw`\t`);
+  return escaped.length <= MAX_FIELD_LENGTH
+    ? escaped
+    : `${escaped.slice(0, MAX_FIELD_LENGTH)}…`;
+};
+
+const withinRoot = (root: string, input: string): string | undefined => {
+  const absolute = resolve(root, input);
+  const rel = relative(root, absolute);
+  if (
+    rel === "" ||
+    rel === ".." ||
+    rel.startsWith(`..${sep}`) ||
+    isAbsolute(rel)
+  ) {
+    return undefined;
+  }
+  return absolute;
+};
+
+/**
+ * Incrementally warms Hearth graph state from files the agent has observed.
+ * Failures are retained for diagnostics but never reject the originating file
+ * tool. Explicit graph queries call flush() before reading graph state.
+ */
+export class HearthGraphObserver implements HearthGraphRuntime {
+  private readonly pending = new Set<string>();
+  private readonly observed = new Set<string>();
+  private readonly failures = new Map<string, string>();
+  private readonly controller = nativeAbortController();
+  private graphTail: Promise<void> = Promise.resolve();
+  private running?: Promise<void>;
+  private disposed = false;
+  private projectComplete = false;
+  private unexpectedError?: string;
+
+  constructor(
+    private readonly root: string,
+    private readonly engine: HearthEngine,
+    private readonly gate: HearthAccessGate,
+  ) {}
+
+  observe(paths: readonly string[]): void {
+    if (this.disposed) return;
+    let accepted = false;
+    for (const path of paths) {
+      const absolute = withinRoot(this.root, path);
+      if (absolute === undefined) continue;
+      accepted = true;
+      this.observed.add(absolute);
+      this.pending.add(absolute);
+    }
+    if (accepted) this.projectComplete = false;
+    this.ensureRunning();
+  }
+
+  async flush(signal?: AbortSignal): Promise<void> {
+    while (!this.disposed) {
+      this.ensureRunning();
+      const { running } = this;
+      if (running === undefined) return;
+      await waitAbortable(running, signal);
+    }
+  }
+
+  runQuery<T>(operation: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+    const scheduled = this.graphTail.then(async () => {
+      if (
+        signal !== undefined &&
+        (signal as unknown as ObservableAbortSignal).aborted
+      ) {
+        throw abortedError();
+      }
+      return operation();
+    });
+    this.graphTail = scheduled.then(
+      () => undefined,
+      () => undefined,
+    );
+    return waitAbortable(scheduled, signal);
+  }
+
+  markProjectComplete(clearAutoFailures = false): void {
+    this.projectComplete = true;
+    if (clearAutoFailures) this.failures.clear();
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.pending.clear();
+    this.controller.abort();
+  }
+
+  status(): HearthGraphObserverStatus {
+    let lastFailure: string | undefined;
+    for (const failure of this.failures.values()) lastFailure = failure;
+    const lastError = this.unexpectedError ?? lastFailure;
+    return {
+      observedFiles: this.observed.size,
+      pendingFiles: this.pending.size,
+      failedFiles: this.failures.size,
+      indexing: this.running !== undefined,
+      projectComplete: this.projectComplete,
+      ...(lastError === undefined ? {} : { lastError }),
+    };
+  }
+
+  private ensureRunning(): void {
+    if (
+      this.disposed ||
+      this.pending.size === 0 ||
+      this.running !== undefined
+    ) {
+      return;
+    }
+    const running = this.run();
+    this.running = running;
+    void running.then(
+      () => this.finishRun(running),
+      (error) => {
+        this.unexpectedError = boundedField(errorMessage(error));
+        this.finishRun(running);
+      },
+    );
+  }
+
+  private finishRun(running: Promise<void>): void {
+    if (this.running === running) this.running = undefined;
+    this.ensureRunning();
+  }
+
+  private async run(): Promise<void> {
+    while (!this.disposed && this.pending.size > 0) {
+      const files = [...this.pending].slice(0, AUTO_INDEX_BATCH_SIZE);
+      for (const file of files) this.pending.delete(file);
+      try {
+        await this.runQuery(
+          () =>
+            this.gate.shared(async () => {
+              await this.engine.graphDefinitionsAsync(
+                {
+                  root: this.root,
+                  name: AUTO_INDEX_SENTINEL,
+                  files,
+                  hidden: true,
+                  respectGitignore: true,
+                  followSymlinks: false,
+                },
+                this.controller.signal,
+              );
+            }),
+          this.controller.signal,
+        );
+        for (const file of files) this.failures.delete(file);
+        // A caller-supplied file view is intentionally partial even when all
+        // observed files were indexed successfully.
+        this.projectComplete = false;
+      } catch (error) {
+        if (!this.disposed) {
+          const message = boundedField(errorMessage(error));
+          for (const file of files) this.failures.set(file, message);
+        }
+      }
+    }
+  }
+}
+
+const requiredText = (
+  value: string | undefined,
+  field: "path" | "query" | "name",
+  operation: GraphOperation,
+): string => {
+  if (value === undefined || value.trim().length === 0) {
+    throw new Error(`${field} is required for ${operation}`);
+  }
+  return value;
+};
+
+const baseParams = (root: string) => ({
+  root,
+  hidden: true,
+  respectGitignore: true,
+  followSymlinks: false,
+});
+
+const runGraphQuery = async (
+  engine: HearthEngine,
+  root: string,
+  operation: GraphOperation,
+  params: {
+    path?: string;
+    query?: string;
+    name?: string;
+    depth?: number;
+    limit?: number;
+    verify?: boolean;
+  },
+  signal: AbortSignal | undefined,
+): Promise<GraphResult> => {
+  const common = baseParams(root);
+  switch (operation) {
+    case "symbols": {
+      return engine.graphSymbolsAsync(
+        {
+          ...common,
+          path: requiredText(params.path, "path", operation),
+        },
+        signal,
+      );
+    }
+    case "outline": {
+      return engine.graphOutlineAsync(
+        {
+          ...common,
+          path: requiredText(params.path, "path", operation),
+        },
+        signal,
+      );
+    }
+    case "search": {
+      return engine.graphSearchAsync(
+        {
+          ...common,
+          query: requiredText(params.query, "query", operation),
+          limit: params.limit ?? DEFAULT_RESULT_LIMIT,
+        },
+        signal,
+      );
+    }
+    case "definitions": {
+      return engine.graphDefinitionsAsync(
+        {
+          ...common,
+          name: requiredText(params.name, "name", operation),
+          limit: params.limit ?? DEFAULT_RESULT_LIMIT,
+        },
+        signal,
+      );
+    }
+    case "deps": {
+      return engine.graphDepsAsync(
+        {
+          ...common,
+          path: requiredText(params.path, "path", operation),
+          depth: params.depth ?? DEFAULT_GRAPH_DEPTH,
+        },
+        signal,
+      );
+    }
+    case "rdeps": {
+      return engine.graphRdepsAsync(
+        {
+          ...common,
+          path: requiredText(params.path, "path", operation),
+          depth: params.depth ?? DEFAULT_GRAPH_DEPTH,
+          verify: params.verify ?? true,
+        },
+        signal,
+      );
+    }
+    case "neighborhood": {
+      return engine.graphNeighborhoodAsync(
+        {
+          ...common,
+          path: requiredText(params.path, "path", operation),
+          depth: params.depth ?? DEFAULT_GRAPH_DEPTH,
+        },
+        signal,
+      );
+    }
+    case "status": {
+      return engine.graphStatusAsync(common, signal);
+    }
+  }
+};
+
+const displayPath = (root: string, path: string): string => {
+  const rel = relative(root, path);
+  const display =
+    rel !== "" &&
+    rel !== ".." &&
+    !rel.startsWith(`..${sep}`) &&
+    !isAbsolute(rel)
+      ? rel.replaceAll("\\", "/")
+      : path;
+  return boundedField(display);
+};
+
+const symbolLine = (root: string, symbol: GraphSymbol): string =>
+  `${displayPath(root, symbol.path)}:${symbol.line}:${symbol.column} ${boundedField(symbol.kind)} ${boundedField(symbol.name)}`;
+
+const edgeLine = (root: string, edge: GraphDepEdge): string =>
+  `${displayPath(root, edge.from)}:${edge.line} --${boundedField(edge.kind)} ${boundedField(edge.specifier)}--> ${displayPath(root, edge.to)} [${edge.guarantee}]`;
+
+const metaLine = (
+  meta: GraphMeta,
+  observer: HearthGraphObserverStatus,
+): string => {
+  const guarantee = observer.projectComplete ? meta.guarantee : "approximate";
+  const scope = observer.projectComplete ? "project" : "observed-partial";
+  const indexed = observer.projectComplete
+    ? `${meta.indexedFiles}/${meta.universeFiles}`
+    : `${meta.indexedFiles} lastSweepFiles=${meta.universeFiles}`;
+  return `graph guarantee=${guarantee} scope=${scope} indexed=${indexed} unsupported=${meta.unsupportedFiles} oversize=${meta.oversizeFiles} swept=${meta.swept} sweepAgeMs=${meta.sweepAgeMs}`;
+};
+
+export interface HearthGraphFormatResult {
+  text: string;
+  truncated: boolean;
+  outputLines: number;
+  outputBytes: number;
+  omittedRows: number;
+}
+
+class GraphOutputBuilder {
+  private readonly lines: string[] = [];
+  private bytes = 0;
+  private omittedRows = 0;
+  private truncated = false;
+
+  add(line: string): boolean {
+    const lineBytes =
+      Buffer.byteLength(line, "utf8") + (this.lines.length === 0 ? 0 : 1);
+    if (
+      this.truncated ||
+      this.lines.length >= MAX_CONTENT_LINES ||
+      this.bytes + lineBytes > MAX_CONTENT_BYTES
+    ) {
+      this.truncated = true;
+      this.omittedRows += 1;
+      return false;
+    }
+    this.lines.push(line);
+    this.bytes += lineBytes;
+    return true;
+  }
+
+  addRows<T>(rows: readonly T[], format: (row: T) => string): void {
+    if (this.truncated) {
+      this.omittedRows += rows.length;
+      return;
+    }
+    for (const [index, row] of rows.entries()) {
+      if (this.add(format(row))) continue;
+      this.omittedRows += rows.length - index - 1;
+      return;
+    }
+  }
+
+  finish(): HearthGraphFormatResult {
+    const output = [...this.lines];
+    if (this.truncated) {
+      output.push(`[Graph output truncated: ${this.omittedRows} rows omitted]`);
+    }
+    const text = output.join("\n");
+    return {
+      text,
+      truncated: this.truncated,
+      outputLines: output.length,
+      outputBytes: Buffer.byteLength(text, "utf8"),
+      omittedRows: this.omittedRows,
+    };
+  }
+}
+
+export const formatGraphResult = (
+  root: string,
+  operation: GraphOperation,
+  result: GraphResult,
+  observer: HearthGraphObserverStatus,
+): HearthGraphFormatResult => {
+  const formatted = new GraphOutputBuilder();
+  formatted.add(metaLine(result.meta, observer));
+  formatted.add(
+    `observed files=${observer.observedFiles} pending=${observer.pendingFiles} failed=${observer.failedFiles} indexing=${observer.indexing}`,
+  );
+  if (observer.lastError !== undefined) {
+    formatted.add(`auto-index lastError=${boundedField(observer.lastError)}`);
+  }
+
+  switch (operation) {
+    case "symbols": {
+      const output = result.symbols;
+      if (output === undefined)
+        throw new Error("Hearth graph symbols result missing");
+      formatted.add(
+        `symbols ${displayPath(root, output.path)} (${output.symbols.length})`,
+      );
+      formatted.addRows(output.symbols, (symbol) => symbolLine(root, symbol));
+      break;
+    }
+    case "outline": {
+      const output = result.outline;
+      if (output === undefined)
+        throw new Error("Hearth graph outline result missing");
+      formatted.add(
+        `outline ${displayPath(root, output.path)} (${output.symbols.length})`,
+      );
+      formatted.addRows(
+        output.symbols,
+        (symbol) =>
+          `${"  ".repeat(Math.min(symbol.depth, 12))}${symbolLine(root, symbol)}`,
+      );
+      break;
+    }
+    case "search": {
+      const output = result.search;
+      if (output === undefined)
+        throw new Error("Hearth graph search result missing");
+      formatted.add(
+        `search results (${output.symbols.length}) limitReached=${output.limitReached}`,
+      );
+      formatted.addRows(output.symbols, (symbol) => symbolLine(root, symbol));
+      break;
+    }
+    case "definitions": {
+      const output = result.definitions;
+      if (output === undefined) {
+        throw new Error("Hearth graph definitions result missing");
+      }
+      formatted.add(
+        `definitions (${output.symbols.length}) limitReached=${output.limitReached}`,
+      );
+      formatted.addRows(output.symbols, (symbol) => symbolLine(root, symbol));
+      break;
+    }
+    case "deps": {
+      const output = result.deps;
+      if (output === undefined)
+        throw new Error("Hearth graph deps result missing");
+      formatted.add(
+        `dependencies ${displayPath(root, output.node.path)} (${output.edges.length})`,
+      );
+      formatted.addRows(output.edges, (edge) => edgeLine(root, edge));
+      formatted.addRows(
+        output.unresolved,
+        (unresolved) =>
+          `unresolved:${unresolved.line} ${boundedField(unresolved.specifier)} (${boundedField(unresolved.reason)})`,
+      );
+      formatted.add(
+        `coverage analyzed=${output.coverage.analyzed} stubs=${output.coverage.stubs}`,
+      );
+      break;
+    }
+    case "rdeps": {
+      const output = result.rdeps;
+      if (output === undefined)
+        throw new Error("Hearth graph rdeps result missing");
+      formatted.add(
+        `reverse dependencies ${displayPath(root, output.node.path)} (${output.importers.length}) verified=${output.verified}`,
+      );
+      formatted.addRows(
+        output.importers,
+        (importer) =>
+          `${displayPath(root, importer.node.path)}:${importer.line}${importer.specifier === undefined ? "" : ` ${boundedField(importer.specifier)}`} [${importer.guarantee}]`,
+      );
+      formatted.add(
+        `coverage analyzed=${output.coverage.analyzed} stubs=${output.coverage.stubs}`,
+      );
+      break;
+    }
+    case "neighborhood": {
+      const output = result.neighborhood;
+      if (output === undefined) {
+        throw new Error("Hearth graph neighborhood result missing");
+      }
+      formatted.add(
+        `neighborhood ${displayPath(root, output.center.path)} nodes=${output.nodes.length} edges=${output.edges.length}`,
+      );
+      formatted.addRows(
+        output.nodes,
+        (node) =>
+          `node ${displayPath(root, node.path)} language=${node.language ?? "unknown"} indexed=${node.indexed}`,
+      );
+      formatted.addRows(output.edges, (edge) => edgeLine(root, edge));
+      formatted.add(
+        `coverage analyzed=${output.coverage.analyzed} stubs=${output.coverage.stubs}`,
+      );
+      break;
+    }
+    case "status": {
+      const output = result.status;
+      if (output === undefined)
+        throw new Error("Hearth graph status result missing");
+      formatted.add(
+        `status built=${output.built} building=${output.building} pending=${output.pendingFiles} stale=${output.staleFiles} failed=${output.failedFiles}`,
+      );
+      formatted.add(
+        `topology symbols=${output.symbols} edges=${output.edges} components=${output.components}`,
+      );
+      formatted.addRows(
+        output.languages,
+        (language) =>
+          `language ${boundedField(language.language)} files=${language.files} symbols=${language.symbols}`,
+      );
+      break;
+    }
+  }
+
+  return formatted.finish();
+};
+
+export const createHearthGraphDefinition = (
+  root: string,
+  engine: HearthEngine,
+  gate: HearthAccessGate,
+  observer: HearthGraphRuntime,
+): ToolDefinition<typeof GraphParameters, Record<string, unknown>> =>
+  defineTool({
+    name: HEARTH_GRAPH_TOOL_NAME,
+    label: "Hearth Graph",
+    description:
+      "Query the current project module graph and symbol index. Supports symbols, outlines, symbol search, definitions, dependencies, reverse dependencies, neighborhoods, and build status.",
+    promptSnippet:
+      "Query the Hearth project symbol index and module dependency graph",
+    promptGuidelines: [
+      "Use hearth_graph after locating relevant files when symbol definitions or module dependency direction would reduce further text searching.",
+      "Treat approximate graph guarantees and unresolved imports as incomplete evidence; confirm consequential conclusions with read or grep.",
+      "Graph paths are restricted to the current project and traversal depth is bounded.",
+    ],
+    executionMode: "sequential",
+    parameters: GraphParameters,
+    async execute(_id, params, signal) {
+      await observer.flush(signal);
+      const result = await observer.runQuery(
+        () =>
+          gate.shared(() =>
+            runGraphQuery(engine, root, params.operation, params, signal),
+          ),
+        signal,
+      );
+      if (params.operation !== "status") {
+        observer.markProjectComplete(result.meta.guarantee === "exact");
+      }
+      const observerStatus = observer.status();
+      const effectiveGuarantee = observerStatus.projectComplete
+        ? result.meta.guarantee
+        : "approximate";
+      const formatted = formatGraphResult(
+        root,
+        params.operation,
+        result,
+        observerStatus,
+      );
+      return {
+        content: [{ type: "text", text: formatted.text }],
+        details: {
+          operation: params.operation,
+          nativeMeta: result.meta,
+          effectiveGuarantee,
+          scope: observerStatus.projectComplete
+            ? "project"
+            : "observed-partial",
+          observer: observerStatus,
+          truncated: formatted.truncated,
+          outputLines: formatted.outputLines,
+          outputBytes: formatted.outputBytes,
+          omittedRows: formatted.omittedRows,
+        },
+      };
+    },
+  });

--- a/pi/extensions/hearth-tools/index.ts
+++ b/pi/extensions/hearth-tools/index.ts
@@ -27,16 +27,26 @@ import {
   type PiToolSettings,
 } from "./engine";
 import {
+  createHearthGraphDefinition,
+  HearthGraphObserver,
+  HEARTH_GRAPH_TOOL_NAME,
+  type HearthGraphRuntime,
+} from "./graph";
+import {
   registerHearthInvalidationService,
   registerHearthReadService,
 } from "./service";
 
-export const HEARTH_TOOL_NAMES = [
+export const HEARTH_OVERRIDE_TOOL_NAMES = [
   "read",
   "write",
   "edit",
   "bash",
   "grep",
+] as const;
+export const HEARTH_TOOL_NAMES = [
+  ...HEARTH_OVERRIDE_TOOL_NAMES,
+  HEARTH_GRAPH_TOOL_NAME,
 ] as const;
 
 const STARTUP_ERROR = "pi-hearth-tools: Hearth native backend is unavailable";
@@ -77,6 +87,7 @@ export interface RuntimeState {
   runtime: HearthEngineRuntime;
   settings: PiToolSettings;
   config: HearthToolsConfig;
+  graph: HearthGraphRuntime;
 }
 
 const defaultFatal: Fatal = (message) => {
@@ -113,10 +124,17 @@ const definitions = (
   runtime: HearthEngineRuntime,
   settings: PiToolSettings,
   config: HearthToolsConfig,
+  graph: HearthGraphRuntime,
   bashOperations?: BashOperations,
 ) =>
   [
-    createHearthReadDefinition(cwd, runtime.engine, settings, runtime.gate),
+    createHearthReadDefinition(
+      cwd,
+      runtime.engine,
+      settings,
+      runtime.gate,
+      graph,
+    ),
     createHearthWriteDefinition(cwd, runtime.engine, runtime.gate),
     createHearthEditDefinition(cwd, runtime.engine, runtime.gate),
     createHearthBashDefinition(cwd, runtime.engine, settings, {
@@ -129,7 +147,8 @@ const definitions = (
             commandPrefixHandled: true,
           }),
     }),
-    createHearthGrepDefinition(cwd, runtime.engine, runtime.gate),
+    createHearthGrepDefinition(cwd, runtime.engine, runtime.gate, graph),
+    createHearthGraphDefinition(cwd, runtime.engine, runtime.gate, graph),
   ] as const;
 
 const createExternalWriterProtector =
@@ -268,7 +287,12 @@ export const setupHearthTools = async (
         config,
         settings.shell,
       );
-      state = { runtime, settings, config };
+      const graph = new HearthGraphObserver(
+        ctx.cwd,
+        runtime.engine,
+        runtime.gate,
+      );
+      state = { runtime, settings, config, graph };
       invalidation.activate({
         clearCaches,
         protectExternalWriter: createExternalWriterProtector(runtime),
@@ -276,11 +300,12 @@ export const setupHearthTools = async (
 
       assertNoExistingOverride(pi);
       const activeBefore = pi.getActiveTools();
-      const [read, write, edit, bash, grep] = definitions(
+      const [read, write, edit, bash, grep, hearthGraph] = definitions(
         ctx.cwd,
         runtime,
         settings,
         config,
+        graph,
         bashSandboxProvider?.sandboxedOperations,
       );
       pi.registerTool(read);
@@ -288,7 +313,10 @@ export const setupHearthTools = async (
       pi.registerTool(edit);
       pi.registerTool(bash);
       pi.registerTool(grep);
-      pi.setActiveTools(activeBefore);
+      pi.registerTool(hearthGraph);
+      pi.setActiveTools([
+        ...new Set([...activeBefore, HEARTH_GRAPH_TOOL_NAME]),
+      ]);
       assertHearthOwnership(pi);
       bashSandboxProvider?.attach({
         commandPrefix: settings.shellCommandPrefix,
@@ -337,7 +365,10 @@ export const setupHearthTools = async (
     await clearCaches();
   });
 
-  pi.on("session_shutdown", () => service.dispose());
+  pi.on("session_shutdown", () => {
+    state?.graph.dispose();
+    service.dispose();
+  });
 
   pi.on("user_bash", () => {
     if (state === undefined) return;

--- a/pi/extensions/hearth-tools/service.ts
+++ b/pi/extensions/hearth-tools/service.ts
@@ -133,6 +133,7 @@ export const registerHearthReadService = (
         current.runtime.engine,
         current.settings,
         current.runtime.gate,
+        current.graph,
       );
     },
   };

--- a/tests/config/pi-system-prompt.test.ts
+++ b/tests/config/pi-system-prompt.test.ts
@@ -34,6 +34,20 @@ describe("global pi system prompt", () => {
     expect(prompt).not.toContain("@earendil-works/pi-coding-agent");
   });
 
+  test("teaches agents to use the warmed Hearth graph efficiently", async () => {
+    const prompt = await readFile(PROMPT_PATH, "utf8");
+
+    expect(prompt).toContain("When `hearth_graph` is available");
+    expect(prompt).toContain(
+      "successful `read` and `grep` calls warm its module index",
+    );
+    expect(prompt).toContain(
+      "`definitions`, `deps`, `rdeps`, and `neighborhood`",
+    );
+    expect(prompt).toContain("assess change impact");
+    expect(prompt).toContain("verify exact source with `read` before editing");
+  });
+
   test("requires autonomous execution, retry, and complete reporting", async () => {
     const prompt = await readFile(PROMPT_PATH, "utf8");
 

--- a/tests/pi-harness/hearth-tools-graph.test.ts
+++ b/tests/pi-harness/hearth-tools-graph.test.ts
@@ -1,0 +1,276 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  HearthEngine,
+  type GraphMeta,
+  type GraphResult,
+  type GraphSymbol,
+  type ShellSpec,
+} from "@hearthdev/napi";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { HearthEngineGate } from "../../pi/extensions/hearth-tools/engine";
+import {
+  createHearthGraphDefinition,
+  formatGraphResult,
+  HearthGraphObserver,
+} from "../../pi/extensions/hearth-tools/graph";
+
+const roots: string[] = [];
+const root = async (): Promise<string> => {
+  const value = await mkdtemp(join(tmpdir(), "pi-hearth-graph-"));
+  roots.push(value);
+  return value;
+};
+
+const shell: ShellSpec = {
+  program: "/bin/bash",
+  args: ["-c"],
+  transport: "arg" as ShellSpec["transport"],
+};
+
+const engine = (cwd: string): HearthEngine =>
+  new HearthEngine({
+    cwd,
+    trustCache: true,
+    warmShell: false,
+    enableOptimizer: false,
+    shell,
+  });
+
+const context = { model: undefined } as never;
+
+interface NativeAbortController {
+  readonly signal: AbortSignal;
+  abort(): void;
+}
+
+const abortController = (): NativeAbortController => {
+  const Constructor =
+    globalThis.AbortController as unknown as new () => NativeAbortController;
+  return new Constructor();
+};
+
+const resultText = (
+  result: Awaited<
+    ReturnType<ReturnType<typeof createHearthGraphDefinition>["execute"]>
+  >,
+): string => {
+  const [content] = result.content;
+  return content?.type === "text" ? content.text : "";
+};
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+describe("Hearth graph integration", () => {
+  test("incrementally indexes observed files and exposes project graph queries", async () => {
+    const cwd = await root();
+    await mkdir(join(cwd, "src"), { recursive: true });
+    const dependency = join(cwd, "src", "value.ts");
+    const importer = join(cwd, "src", "run.ts");
+    await writeFile(dependency, "export const value = 1;\n");
+    await writeFile(
+      importer,
+      'import { value } from "./value";\nexport function run() { return value; }\n',
+    );
+
+    const hearth = engine(cwd);
+    const gate = new HearthEngineGate();
+    const observer = new HearthGraphObserver(cwd, hearth, gate);
+    observer.observe([dependency, join(cwd, "..", "outside.ts")]);
+    await observer.flush();
+
+    const partial = await hearth.graphStatusAsync({ root: cwd });
+    expect(partial.status?.built).toBe(true);
+    expect(partial.status?.indexedFiles).toBe(1);
+    expect(observer.status().observedFiles).toBe(1);
+
+    observer.observe([importer]);
+    await observer.flush();
+    const observedStatus = await hearth.graphStatusAsync({ root: cwd });
+    expect(observedStatus.status?.indexedFiles).toBe(2);
+    const partialText = formatGraphResult(
+      cwd,
+      "status",
+      observedStatus,
+      observer.status(),
+    ).text;
+    expect(partialText).toContain(
+      "guarantee=approximate scope=observed-partial indexed=2 lastSweepFiles=1",
+    );
+    expect(partialText).not.toContain("indexed=2/1");
+
+    const tool = createHearthGraphDefinition(cwd, hearth, gate, observer);
+    const definitions = await tool.execute(
+      "graph-definitions",
+      { operation: "definitions", name: "run" },
+      undefined,
+      undefined,
+      context,
+    );
+    const definitionsText = resultText(definitions);
+    expect(definitionsText).toContain("definitions (1)");
+    expect(definitionsText).toContain("src/run.ts");
+    expect(definitionsText).toContain("function run");
+
+    const dependencies = await tool.execute(
+      "graph-deps",
+      { operation: "deps", path: "src/run.ts" },
+      undefined,
+      undefined,
+      context,
+    );
+    const dependenciesText = resultText(dependencies);
+    expect(dependenciesText).toContain("dependencies src/run.ts");
+    expect(dependenciesText).toContain("src/value.ts");
+    expect(dependenciesText).toContain("guarantee=exact");
+
+    observer.dispose();
+  });
+
+  test("retains failed batches until their files are successfully retried", async () => {
+    const cwd = await root();
+    const broken = join(cwd, "broken.ts");
+    const healthy = join(cwd, "healthy.ts");
+    await writeFile(broken, "export const broken = true;\n");
+    await writeFile(healthy, "export const healthy = true;\n");
+    let brokenFails = true;
+    const fakeEngine = {
+      async graphDefinitionsAsync(params: { files?: string[] }) {
+        if (brokenFails && params.files?.includes(broken)) {
+          throw new Error("synthetic graph failure");
+        }
+        return {};
+      },
+    } as unknown as HearthEngine;
+    const observer = new HearthGraphObserver(
+      cwd,
+      fakeEngine,
+      new HearthEngineGate(),
+    );
+
+    observer.observe([broken]);
+    await expect(observer.flush()).resolves.toBeUndefined();
+    observer.observe([healthy]);
+    await observer.flush();
+    expect(observer.status()).toMatchObject({
+      observedFiles: 2,
+      pendingFiles: 0,
+      failedFiles: 1,
+      indexing: false,
+      projectComplete: false,
+      lastError: "synthetic graph failure",
+    });
+
+    brokenFails = false;
+    observer.observe([broken]);
+    await observer.flush();
+    expect(observer.status().failedFiles).toBe(0);
+    expect(observer.status().lastError).toBeUndefined();
+  });
+
+  test("lets a graph call stop waiting for session-scoped warmup", async () => {
+    const cwd = await root();
+    const path = join(cwd, "slow.ts");
+    await writeFile(path, "export const slow = true;\n");
+    let markStarted = (): void => {};
+    const started = new Promise<void>((resolveStarted) => {
+      markStarted = resolveStarted;
+    });
+    let markFinished = (): void => {};
+    const finished = new Promise<void>((resolveFinished) => {
+      markFinished = resolveFinished;
+    });
+    const fakeEngine = {
+      graphDefinitionsAsync(_params: unknown, signal: AbortSignal | undefined) {
+        markStarted();
+        return new Promise((_resolve, reject) => {
+          if (signal === undefined) return;
+          const observable = signal as unknown as {
+            addEventListener(
+              type: "abort",
+              listener: () => void,
+              options?: { once?: boolean },
+            ): void;
+          };
+          observable.addEventListener(
+            "abort",
+            () => {
+              reject(new Error("session warmup cancelled"));
+              markFinished();
+            },
+            { once: true },
+          );
+        });
+      },
+    } as unknown as HearthEngine;
+    const observer = new HearthGraphObserver(
+      cwd,
+      fakeEngine,
+      new HearthEngineGate(),
+    );
+    observer.observe([path]);
+    await started;
+
+    const caller = abortController();
+    const draining = observer.flush(caller.signal);
+    caller.abort();
+    await expect(draining).rejects.toThrow("Operation aborted");
+
+    observer.dispose();
+    await finished;
+  });
+
+  test("formats huge graph results incrementally within strict output bounds", () => {
+    const cwd = "/workspace";
+    const symbol: GraphSymbol = {
+      name: "repeated_symbol",
+      kind: "function",
+      path: join(cwd, "src", "module.ts"),
+      nodeId: "node",
+      line: 1,
+      column: 1,
+      depth: 0,
+    };
+    const symbols: GraphSymbol[] = Array.from(
+      { length: 150_000 },
+      () => symbol,
+    );
+    const meta: GraphMeta = {
+      guarantee: "exact" as GraphMeta["guarantee"],
+      root: cwd,
+      universeFiles: 150_000,
+      indexedFiles: 150_000,
+      unsupportedFiles: 0,
+      oversizeFiles: 0,
+      revalidatedFiles: 150_000,
+      reindexedFiles: 150_000,
+      swept: true,
+      sweepAgeMs: 0,
+      walkCacheHit: false,
+      repairTruncated: false,
+    };
+    const result = {
+      meta,
+      search: { symbols, limitReached: false },
+    } satisfies GraphResult;
+
+    const formatted = formatGraphResult(cwd, "search", result, {
+      observedFiles: 150_000,
+      pendingFiles: 0,
+      failedFiles: 0,
+      indexing: false,
+      projectComplete: true,
+    });
+    expect(formatted.truncated).toBe(true);
+    expect(formatted.omittedRows).toBeGreaterThan(100_000);
+    expect(formatted.outputLines).toBeLessThanOrEqual(200);
+    expect(formatted.outputBytes).toBeLessThanOrEqual(32 * 1024);
+    expect(formatted.text.split("\n")).toHaveLength(formatted.outputLines);
+    expect(formatted.text).toContain("Graph output truncated");
+  });
+});

--- a/tests/pi-harness/hearth-tools-native.test.ts
+++ b/tests/pi-harness/hearth-tools-native.test.ts
@@ -94,6 +94,73 @@ describe("Hearth-backed pi tool contracts", () => {
     });
   });
 
+  test("read and grep report observed files without changing successful results", async () => {
+    const cwd = await root();
+    const path = join(cwd, "observed.ts");
+    await writeFile(path, "export const observed = true;\n");
+    const hearth = engine(cwd);
+    const observed: string[][] = [];
+    const observer = {
+      observe(paths: readonly string[]) {
+        observed.push([...paths]);
+      },
+    };
+
+    const read = createHearthReadDefinition(
+      cwd,
+      hearth,
+      settings,
+      undefined,
+      observer,
+    );
+    const readResult = await read.execute(
+      "read-observed",
+      { path: "observed.ts" },
+      undefined,
+      undefined,
+      context,
+    );
+    expect(readResult.content[0]).toEqual({
+      type: "text",
+      text: "export const observed = true;\n",
+    });
+
+    const grep = createHearthGrepDefinition(cwd, hearth, undefined, observer);
+    const grepResult = await grep.execute(
+      "grep-observed",
+      { pattern: "observed", path: "." },
+      undefined,
+      undefined,
+      context,
+    );
+    expect(grepResult.content[0]).toEqual({
+      type: "text",
+      text: "observed.ts:1: export const observed = true;",
+    });
+    expect(observed).toEqual([[path], [path]]);
+
+    const advisoryRead = createHearthReadDefinition(
+      cwd,
+      hearth,
+      settings,
+      undefined,
+      {
+        observe() {
+          throw new Error("graph observer failure");
+        },
+      },
+    );
+    await expect(
+      advisoryRead.execute(
+        "read-advisory",
+        { path: "observed.ts" },
+        undefined,
+        undefined,
+        context,
+      ),
+    ).resolves.toBeDefined();
+  });
+
   test("edit applies multiple original-relative replacements and returns pi details", async () => {
     const cwd = await root();
     const path = join(cwd, "edit.txt");

--- a/tests/pi-harness/hearth-tools-startup.test.ts
+++ b/tests/pi-harness/hearth-tools-startup.test.ts
@@ -319,7 +319,7 @@ describe("hearth-tools startup", () => {
     );
   });
 
-  test("registers five overrides on session start without activating grep", async () => {
+  test("registers five overrides plus an active graph tool without activating grep", async () => {
     const fake = fakePi();
     await setupHearthTools(fake.pi, {
       loadModule: async () => ({ HearthEngine: FakeEngine as never }),
@@ -338,7 +338,13 @@ describe("hearth-tools startup", () => {
     );
 
     expect(fake.tools.map((tool) => tool.name)).toEqual([...HEARTH_TOOL_NAMES]);
-    expect(fake.active()).toEqual(["read", "bash", "write", "edit"]);
+    expect(fake.active()).toEqual([
+      "read",
+      "bash",
+      "write",
+      "edit",
+      "hearth_graph",
+    ]);
     expect(FakeEngine.constructed).toHaveLength(1);
     expect(FakeEngine.constructed[0]).toMatchObject({
       cwd: "/workspace",
@@ -509,9 +515,14 @@ describe("hearth-tools startup", () => {
     ).rejects.toThrow(COLLISION_ERROR);
   });
 
-  test("releases the legacy process slot before creating the gated runtime", async () => {
-    const legacySlot = Symbol.for("ushironoko.pi-hearth-tools.engine.v1");
-    Reflect.set(globalThis, legacySlot, { engine: {}, options: {} });
+  test("releases pre-graph process slots before creating the current runtime", async () => {
+    const legacySlots = [
+      Symbol.for("ushironoko.pi-hearth-tools.engine.v1"),
+      Symbol.for("ushironoko.pi-hearth-tools.engine.v2"),
+    ];
+    for (const legacySlot of legacySlots) {
+      Reflect.set(globalThis, legacySlot, { engine: {}, options: {} });
+    }
     const fake = fakePi();
     await setupHearthTools(fake.pi, {
       loadModule: async () => ({ HearthEngine: FakeEngine as never }),
@@ -524,7 +535,9 @@ describe("hearth-tools startup", () => {
     });
     await fake.emit("session_start", { reason: "reload" });
 
-    expect(Reflect.has(globalThis, legacySlot)).toBe(false);
+    for (const legacySlot of legacySlots) {
+      expect(Reflect.has(globalThis, legacySlot)).toBe(false);
+    }
     expect(FakeEngine.constructed).toHaveLength(1);
   });
 


### PR DESCRIPTION
## Summary

- upgrade `@hearthdev/napi` to 0.1.1 and keep the resident Engine reload-safe with a v3 process slot
- incrementally warm the module graph from successful `read`, `grep`, and BTW reads without changing their result contracts
- add the active `hearth_graph` tool with `symbols`, `outline`, `search`, `definitions`, `deps`, `rdeps`, `neighborhood`, and `status` operations
- report partial versus project-wide coverage and retain per-path indexing failures until a successful retry
- serialize graph operations, make warmup waiting caller-abortable, and bound output to 200 lines and 32 KiB
- teach agents through `pi/SYSTEM.md` to use the warmed graph for definitions, dependency impact, and structural exploration while verifying exact source with `read`
- document the graph lifecycle, guarantees, cache coherency, and failure behavior

## Implementation notes

Explicit semantic graph queries flush pending observations and perform a gitignore-aware project sweep. Automatic indexing remains advisory: graph failures are diagnosed but never turn a successful file-tool call into an error.

Large native result sets are formatted incrementally rather than expanded in memory. Native metadata is preserved while Pi also reports its effective scope and guarantee.

The global Pi prompt conditionally recommends `hearth_graph` only when the tool is available. Keeping this guidance in `SYSTEM.md` avoids repeated per-tool reminder messages and preserves it across resume and compaction.

## Testing

- `bun test tests/config/pi-system-prompt.test.ts tests/pi-harness/hearth-tools-graph.test.ts` — 9 passed
- `bun test tests/pi-harness/hearth-tools-graph.test.ts tests/pi-harness/hearth-tools-native.test.ts tests/pi-harness/hearth-tools-startup.test.ts` — 33 passed
- `bun test` — 1939 passed, 2 gated skips, 0 failed
- `bun run tsc`
- `bun run lint` — 0 errors; 9 pre-existing hexadecimal-style warnings
- `bun run check:pi-imports`
- `bun run check:pi-compat` — global Pi 0.83.0 against local baseline 0.80.7