### PR TITLE
fix(pi): reset child session footer scroll

### DIFF
--- a/pi/extensions/pi-harness/features/child-runs/ui.ts
+++ b/pi/extensions/pi-harness/features/child-runs/ui.ts
@@ -230,6 +230,7 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
   private pendingPreference: BrowserSelection["kind"] | undefined;
   private selectedIndexHint = 0;
   private listOffset = 0;
+  private knownChildRunIds: Set<string>;
   private readonly unsubscribeChild: () => void;
   private readonly unsubscribeIssues: (() => void) | undefined;
   private readonly unsubscribeMemory: (() => void) | undefined;
@@ -247,7 +248,12 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
     private readonly agentMemory?: AgentMemoryBrowserBindings,
   ) {
     this.theme = resolveTheme(theme);
-    this.unsubscribeChild = registry.subscribe(() => this.requestRender());
+    this.knownChildRunIds = new Set(
+      flattenRuns(registry.getSnapshots()).map(({ run }) => run.runId),
+    );
+    this.unsubscribeChild = registry.subscribe(() =>
+      this.handleChildRegistryUpdate(),
+    );
     this.unsubscribeIssues = bitIssues?.registry.subscribe(() =>
       this.requestRender(),
     );
@@ -558,6 +564,25 @@ export class ChildRunsBrowserComponent implements ComponentLike, Focusable {
       this.selection !== undefined &&
       selectionToken(this.selection) === selectionToken(selection)
     );
+  }
+
+  private handleChildRegistryUpdate(): void {
+    const runs = flattenRuns(
+      newestInvocationsFirst(this.registry.getSnapshots()),
+    );
+    const hasNewRun = runs.some(
+      ({ run }) => !this.knownChildRunIds.has(run.runId),
+    );
+    this.knownChildRunIds = new Set(runs.map(({ run }) => run.runId));
+
+    const firstRun = runs[0]?.run;
+    if (hasNewRun && firstRun !== undefined) {
+      this.pendingPreference = undefined;
+      this.selection = { kind: "child", id: firstRun.runId };
+      this.selectedIndexHint = 0;
+      this.listOffset = 0;
+    }
+    this.requestRender();
   }
 
   private requestRender(): void {

--- a/tests/pi-harness/child-run-ui.test.ts
+++ b/tests/pi-harness/child-run-ui.test.ts
@@ -237,6 +237,31 @@ describe("child-session browser component", () => {
     ).toEqual([older.invocationId, newer.invocationId]);
   });
 
+  test("returns to the first row when a new child session is added", () => {
+    let timestamp = 100;
+    const { registry, component } = setup(12, undefined, () => timestamp++);
+    const olderRunIds = addRuns(registry, 6);
+    component.render(80);
+    for (let index = 0; index < 4; index++) component.handleInput("down");
+
+    const scrolled = component.render(80);
+    expect(scrolled[0]).toContain("agent-2");
+    expect(component.getSelectedRunId()).toBe(olderRunIds[4]);
+
+    const newer = registry.beginInvocation({
+      toolCallId: "newer-parent",
+      source: "subagent",
+      mode: "single",
+      label: "newer",
+      runs: [{ agent: "newer-agent", task: "newer task", taskIndex: 0 }],
+    });
+    const reset = component.render(80);
+
+    expect(reset[0]).toContain("newer-agent");
+    expect(reset[1]).toContain("agent-0");
+    expect(component.getSelectedRunId()).toBe(newer.runIds[0]);
+  });
+
   test("caps populated height at three rows and uses every row for flat content", () => {
     for (const [rows, expectedHeight] of [
       [24, 3],


### PR DESCRIPTION
## Summary
- detect newly added child runs in the child-session browser
- reset selection and viewport to the newest first row
- add regression coverage for a scrolled footer receiving a new session

## Verification
- bun test tests/pi-harness/child-run-ui.test.ts
- bun test tests/pi-harness/child-run-layout.test.ts tests/pi-harness/child-run-integration.test.ts
- bun run tsc
- bun run lint
- full suite: 1940 pass, 2 skip, 1 unrelated flaky fixture; isolated rerun passed