### PR TITLE
feat(pi): add persistent ultracode context setting

### DIFF
--- a/claude/.claude/hooks/user_prompt_submit/ultracode_codex_context.sh
+++ b/claude/.claude/hooks/user_prompt_submit/ultracode_codex_context.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# UserPromptSubmit hook: when the prompt opts into ultracode, deterministically
-# inject the cross-model (codex) mandate so workflow authoring cannot miss it.
-# Silent (exit 0, no output) on every other prompt and on machines where codex
-# is absent or unauthenticated.
+# UserPromptSubmit hook: when the prompt opts into ultracode, or the Pi bridge's
+# persistent auto-injection is enabled, deterministically inject the cross-model
+# mandate so workflow authoring cannot miss it. Silent (exit 0, no output) when
+# inactive or on machines where codex is absent or unauthenticated.
 set -euo pipefail
 
 INPUT=$(cat)
@@ -12,7 +12,13 @@ PROMPT=$(printf '%s' "$INPUT" | jq -r '.prompt // .user_prompt // empty' 2>/dev/
 
 case $PROMPT in
   *ultracode*|*"ultra code"*) ;;
-  *) exit 0 ;;
+  *)
+    # Only pi-harness supplies this trusted path. Direct Claude hook execution
+    # therefore keeps the original keyword-only activation behavior.
+    ULTRACODE_CONFIG="${PI_HARNESS_LOCAL_CONFIG_FILE:-}"
+    [ -n "$ULTRACODE_CONFIG" ] && [ -r "$ULTRACODE_CONFIG" ] || exit 0
+    jq -se 'length == 1 and (.[0] | type == "object") and (.[0].ultracode.autoInjectContext == true)' "$ULTRACODE_CONFIG" >/dev/null 2>&1 || exit 0
+    ;;
 esac
 
 # codex is installed via bun; the hook shell may lack that PATH entry.

--- a/pi/extensions/pi-harness/features/hook-bridge/index.ts
+++ b/pi/extensions/pi-harness/features/hook-bridge/index.ts
@@ -246,7 +246,10 @@ export default function setupHookBridge(
         JSON.stringify(makeUserPromptSubmitStdin(event.prompt, cwd)),
         {
           cwd,
-          env: options?.env,
+          env: {
+            ...options?.env,
+            PI_HARNESS_LOCAL_CONFIG_FILE: config.paths.localConfigFile,
+          },
           timeoutMs: spec.timeoutMs,
           maxOutputBytes: spec.maxOutputBytes,
         },

--- a/pi/extensions/pi-harness/features/ultracode-settings/index.ts
+++ b/pi/extensions/pi-harness/features/ultracode-settings/index.ts
@@ -1,0 +1,208 @@
+import { randomUUID } from "node:crypto";
+import {
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
+import type { PiLike } from "../../lib/pi-like";
+
+export interface UltracodeSettingState {
+  autoInjectContext: boolean;
+  error?: string;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const isMissingFile = (error: unknown): boolean =>
+  isRecord(error) && error.code === "ENOENT";
+
+const readConfig = (
+  configFile: string,
+): { root: Record<string, unknown>; raw: string | undefined } => {
+  let raw: string;
+  try {
+    raw = readFileSync(configFile, "utf8");
+  } catch (error) {
+    if (isMissingFile(error)) return { root: {}, raw: undefined };
+    throw error;
+  }
+
+  const parsed: unknown = JSON.parse(raw);
+  if (!isRecord(parsed)) {
+    throw new Error("pi-harness.local.json must contain an object");
+  }
+  return { root: parsed, raw };
+};
+
+const configErrorMessage = (error: unknown): string => {
+  if (error instanceof SyntaxError) {
+    return "pi-harness.local.json could not be parsed";
+  }
+  return error instanceof Error ? error.message : String(error);
+};
+
+export const readUltracodeSetting = (
+  configFile: string,
+): UltracodeSettingState => {
+  try {
+    const { root } = readConfig(configFile);
+    const { ultracode } = root;
+    if (ultracode === undefined) return { autoInjectContext: false };
+    if (!isRecord(ultracode)) {
+      return {
+        autoInjectContext: false,
+        error: "ultracode must contain an object",
+      };
+    }
+    const { autoInjectContext } = ultracode;
+    if (autoInjectContext === undefined) return { autoInjectContext: false };
+    if (typeof autoInjectContext !== "boolean") {
+      return {
+        autoInjectContext: false,
+        error: "ultracode.autoInjectContext must be a boolean",
+      };
+    }
+    return { autoInjectContext };
+  } catch (error) {
+    return {
+      autoInjectContext: false,
+      error: configErrorMessage(error),
+    };
+  }
+};
+
+const writableConfigPath = (configFile: string): string => {
+  let symbolicLink: boolean;
+  try {
+    symbolicLink = lstatSync(configFile).isSymbolicLink();
+  } catch (error) {
+    if (isMissingFile(error)) return configFile;
+    throw error;
+  }
+  // Resolve an existing link outside the ENOENT fallback so a dangling link
+  // fails instead of being silently replaced by a regular config file.
+  return symbolicLink ? realpathSync(configFile) : configFile;
+};
+
+const currentRaw = (configFile: string): string | undefined => {
+  try {
+    return readFileSync(configFile, "utf8");
+  } catch (error) {
+    if (isMissingFile(error)) return undefined;
+    throw error;
+  }
+};
+
+export const writeUltracodeSetting = (
+  configFile: string,
+  autoInjectContext: boolean,
+): void => {
+  const target = writableConfigPath(configFile);
+  const { root, raw } = readConfig(target);
+  const existing = root.ultracode;
+  if (existing !== undefined && !isRecord(existing)) {
+    throw new Error("ultracode must contain an object");
+  }
+  root.ultracode = {
+    ...existing,
+    autoInjectContext,
+  };
+
+  const directory = dirname(target);
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const temporary = join(
+    directory,
+    `.${basename(target)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  let mode = 0o600;
+  try {
+    mode = statSync(target).mode & 0o777;
+  } catch (error) {
+    if (!isMissingFile(error)) throw error;
+  }
+
+  const removeTemporary = (): void => {
+    try {
+      unlinkSync(temporary);
+    } catch {
+      // Best-effort cleanup: never mask the original write failure.
+    }
+  };
+  try {
+    writeFileSync(temporary, `${JSON.stringify(root, null, 2)}\n`, {
+      encoding: "utf8",
+      flag: "wx",
+      mode,
+    });
+    if (currentRaw(target) !== raw) {
+      throw new Error(
+        "pi-harness.local.json changed concurrently; retry the command",
+      );
+    }
+    renameSync(temporary, target);
+  } catch (error) {
+    removeTemporary();
+    throw error;
+  }
+  removeTemporary();
+};
+
+const usage = "Usage: /settings ultracode on|off|status";
+
+export default function setupUltracodeSettings(
+  pi: PiLike,
+  configFile: string,
+): void {
+  // Pi does not expose an API for extending the built-in /settings selector.
+  // Intercept only our namespaced form instead of registering a conflicting
+  // extension command named "settings"; bare /settings remains built-in.
+  pi.on("input", (event, ctx) => {
+    const parts = event.text.trim().split(/\s+/).filter(Boolean);
+    if (
+      parts[0]?.toLowerCase() !== "/settings" ||
+      parts[1]?.toLowerCase() !== "ultracode"
+    ) {
+      return undefined;
+    }
+
+    const action = parts[2]?.toLowerCase() ?? "status";
+    if (parts.length > 3 || !["on", "off", "status"].includes(action)) {
+      ctx.ui.notify(usage, "warning");
+      return { action: "handled" };
+    }
+    if (action === "status") {
+      const state = readUltracodeSetting(configFile);
+      if (state.error !== undefined) {
+        ctx.ui.notify(`Ultracode setting error: ${state.error}`, "error");
+      } else {
+        ctx.ui.notify(
+          `Ultracode context auto-injection: ${state.autoInjectContext ? "on" : "off"}`,
+          "info",
+        );
+      }
+      return { action: "handled" };
+    }
+
+    const enabled = action === "on";
+    try {
+      writeUltracodeSetting(configFile, enabled);
+      ctx.ui.notify(
+        `Ultracode context auto-injection: ${enabled ? "on" : "off"}`,
+        "info",
+      );
+    } catch (error) {
+      ctx.ui.notify(
+        `Could not update the ultracode setting: ${error instanceof Error ? error.message : String(error)}`,
+        "error",
+      );
+    }
+    return { action: "handled" };
+  });
+}

--- a/pi/extensions/pi-harness/index.ts
+++ b/pi/extensions/pi-harness/index.ts
@@ -45,6 +45,7 @@ import setupAsukuNotify from "./features/asuku-notify/index";
 import setupAskUserQuestion from "./features/ask-user-question/index";
 import setupBtw from "./features/btw/index";
 import setupChildRuns from "./features/child-runs/index";
+import setupUltracodeSettings from "./features/ultracode-settings/index";
 
 // This hook runs before the permission boundary, so it must not resolve any
 // executable through an inherited repository-influenced PATH. If a required
@@ -84,6 +85,11 @@ const setupHarness = (
   // adapter before any permission handler can call ctx.ui.confirm. The bridge
   // remains best-effort and preserves the original TUI dialog on failure.
   setupAsukuNotify(pi, config);
+  // Consume the namespaced settings input before permission task correlation;
+  // a handled command must not remain as pending task text for the next turn.
+  if (!config.isChild && config.features["hook-bridge"]) {
+    setupUltracodeSettings(pi, config.paths.localConfigFile);
+  }
   let codexStageModes = consumeCodexStageModes(config.isChild);
   let codexStageExecutable:
     | ReturnType<typeof createCodexStageExecutablePin>

--- a/pi/extensions/pi-harness/lib/pi-like.ts
+++ b/pi/extensions/pi-harness/lib/pi-like.ts
@@ -37,6 +37,12 @@ export interface InputEvent {
   streamingBehavior?: "steer" | "followUp";
 }
 
+/** Returned by input handlers to transform or consume raw user input. */
+export type InputEventResult =
+  | { action: "continue" }
+  | { action: "transform"; text: string; images?: unknown[] }
+  | { action: "handled" };
+
 export interface ContextEvent {
   type: "context";
   messages: unknown[];
@@ -152,7 +158,7 @@ export interface AgentStartInjection {
 
 export interface PiEventResultMap {
   session_start: void;
-  input: void;
+  input: InputEventResult | undefined | void;
   before_agent_start: AgentStartInjection | undefined | void;
   context: ContextUpdate | undefined | void;
   turn_end: void;

--- a/tests/pi-harness/fake-pi.ts
+++ b/tests/pi-harness/fake-pi.ts
@@ -29,6 +29,7 @@ import type {
   FooterDataLike,
   GenericEvent,
   InputEvent,
+  InputEventResult,
   ModelLike,
   NotifyLevel,
   PiEventHandler,
@@ -112,6 +113,8 @@ export interface FakePi extends PiLike {
   readonly events: EventBus;
   emitSessionStart(payload: SessionStartEvent): Promise<void>;
   emitInput(payload: InputEvent): Promise<void>;
+  /** Emit input and expose Pi's terminal action for command-consumption tests. */
+  emitInputResult(payload: InputEvent): Promise<InputEventResult | undefined>;
   emitBeforeAgentStart(
     payload: BeforeAgentStartEvent,
   ): Promise<AgentStartInjection | undefined>;
@@ -314,6 +317,26 @@ export const createFakePi = (
       store.after_provider_response.push(handler),
   };
 
+  const emitInputResult = async (
+    payload: InputEvent,
+  ): Promise<InputEventResult | undefined> => {
+    let current = payload;
+    for (const handler of store.input) {
+      const result = await handler(current, ctx);
+      if (result?.action === "handled") return result;
+      if (result?.action === "transform") {
+        current = {
+          ...current,
+          text: result.text,
+          images: result.images ?? current.images,
+        };
+      }
+    }
+    return current.text !== payload.text || current.images !== payload.images
+      ? { action: "transform", text: current.text, images: current.images }
+      : { action: "continue" };
+  };
+
   return {
     events,
     on<K extends PiEventName>(event: K, handler: PiEventHandler<K>) {
@@ -346,8 +369,9 @@ export const createFakePi = (
       for (const handler of store.session_start) await handler(payload, ctx);
     },
     async emitInput(payload) {
-      for (const handler of store.input) await handler(payload, ctx);
+      await emitInputResult(payload);
     },
+    emitInputResult,
     async emitBeforeAgentStart(payload) {
       let current = payload;
       let injection: AgentStartInjection | undefined;

--- a/tests/pi-harness/ultracode-setting.test.ts
+++ b/tests/pi-harness/ultracode-setting.test.ts
@@ -1,0 +1,342 @@
+import { chmod, lstat, mkdir, readFile, symlink } from "node:fs/promises";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import type { HarnessConfig } from "../../pi/extensions/pi-harness/config";
+import setupHookBridge from "../../pi/extensions/pi-harness/features/hook-bridge/index";
+import type { BridgeHookSpec } from "../../pi/extensions/pi-harness/features/hook-bridge/registry";
+import setupUltracodeSettings, {
+  readUltracodeSetting,
+  writeUltracodeSetting,
+} from "../../pi/extensions/pi-harness/features/ultracode-settings/index";
+import { setupHarness } from "../../pi/extensions/pi-harness/index";
+import { resolvePaths } from "../../pi/extensions/pi-harness/lib/paths";
+import { runHook } from "../../pi/extensions/pi-harness/lib/run-hook";
+import {
+  cleanupTestDirectory,
+  createTestFile,
+  setupTestDirectory,
+} from "../test-helpers";
+import { createFakePi } from "./fake-pi";
+
+const makeConfig = (home: string): HarnessConfig => ({
+  isChild: false,
+  features: {
+    "hook-bridge": true,
+    subagent: false,
+    workflow: false,
+    "bit-task": false,
+    statusline: false,
+    "provider-log": false,
+    "asuku-notify": false,
+    "ask-user-question": false,
+  },
+  trust: { trustedRoots: [] },
+  paths: resolvePaths(home),
+});
+
+test("persists ultracode auto-injection without replacing unrelated config", async () => {
+  const home = await setupTestDirectory("pi-ultracode-setting");
+  const configFile = join(home, ".pi", "agent", "pi-harness.local.json");
+  try {
+    await createTestFile(
+      configFile,
+      JSON.stringify({
+        features: { workflow: false },
+        ultracode: { note: "keep" },
+      }),
+    );
+
+    writeUltracodeSetting(configFile, true);
+
+    expect(readUltracodeSetting(configFile)).toEqual({
+      autoInjectContext: true,
+    });
+    expect(JSON.parse(await readFile(configFile, "utf8"))).toEqual({
+      features: { workflow: false },
+      ultracode: { note: "keep", autoInjectContext: true },
+    });
+  } finally {
+    await cleanupTestDirectory(home);
+  }
+});
+
+test("updates a symlinked config target without replacing the link", async () => {
+  const home = await setupTestDirectory("pi-ultracode-setting-link");
+  const target = join(home, "machine-local.json");
+  const configFile = join(home, "pi-harness.local.json");
+  try {
+    await createTestFile(target, "{}\n");
+    await symlink(target, configFile);
+
+    writeUltracodeSetting(configFile, true);
+
+    const linkStats = await lstat(configFile);
+    expect(linkStats.isSymbolicLink()).toBe(true);
+    expect(readUltracodeSetting(configFile).autoInjectContext).toBe(true);
+  } finally {
+    await cleanupTestDirectory(home);
+  }
+});
+
+test("refuses to replace a dangling config symlink", async () => {
+  const home = await setupTestDirectory("pi-ultracode-setting-dangling");
+  const configFile = join(home, "pi-harness.local.json");
+  try {
+    await symlink(join(home, "missing.json"), configFile);
+
+    expect(() => writeUltracodeSetting(configFile, true)).toThrow();
+    const linkStats = await lstat(configFile);
+    expect(linkStats.isSymbolicLink()).toBe(true);
+  } finally {
+    await cleanupTestDirectory(home);
+  }
+});
+
+test("refuses to overwrite malformed local config", async () => {
+  const home = await setupTestDirectory("pi-ultracode-setting-malformed");
+  const configFile = join(home, "pi-harness.local.json");
+  try {
+    await createTestFile(configFile, "{not-json");
+
+    expect(() => writeUltracodeSetting(configFile, true)).toThrow();
+    expect(await readFile(configFile, "utf8")).toBe("{not-json");
+    expect(readUltracodeSetting(configFile)).toEqual({
+      autoInjectContext: false,
+      error: "pi-harness.local.json could not be parsed",
+    });
+  } finally {
+    await cleanupTestDirectory(home);
+  }
+});
+
+test("settings input toggles ultracode without registering a conflicting command", async () => {
+  const home = await setupTestDirectory("pi-ultracode-command");
+  const configFile = join(home, ".pi", "agent", "pi-harness.local.json");
+  const pi = createFakePi();
+  const emit = (text: string) =>
+    pi.emitInputResult({ type: "input", text, source: "interactive" });
+  try {
+    setupUltracodeSettings(pi, configFile);
+    expect(pi.commands.has("settings")).toBe(false);
+
+    expect(await emit("/settings")).toEqual({ action: "continue" });
+    expect(await emit("/settings another-feature on")).toEqual({
+      action: "continue",
+    });
+    expect(pi.notifications).toHaveLength(0);
+
+    expect(await emit("/settings ultracode on")).toEqual({
+      action: "handled",
+    });
+    expect(readUltracodeSetting(configFile).autoInjectContext).toBe(true);
+    expect(pi.notifications.at(-1)).toEqual({
+      message: "Ultracode context auto-injection: on",
+      level: "info",
+    });
+
+    await emit("/settings ultracode status");
+    expect(pi.notifications.at(-1)?.message).toBe(
+      "Ultracode context auto-injection: on",
+    );
+
+    await emit("/settings ultracode off");
+    expect(readUltracodeSetting(configFile).autoInjectContext).toBe(false);
+
+    await emit("/settings ultracode maybe");
+    expect(pi.notifications.at(-1)).toEqual({
+      message: "Usage: /settings ultracode on|off|status",
+      level: "warning",
+    });
+  } finally {
+    await cleanupTestDirectory(home);
+  }
+});
+
+test("fake input result matches Pi aggregate transform behavior", async () => {
+  const pi = createFakePi();
+  const images = [{ type: "image" }];
+  pi.on("input", (event) => ({
+    action: "transform",
+    text: event.text.toUpperCase(),
+  }));
+
+  expect(
+    await pi.emitInputResult({
+      type: "input",
+      text: "request",
+      images,
+      source: "interactive",
+    }),
+  ).toEqual({ action: "transform", text: "REQUEST", images });
+});
+
+test("umbrella consumes settings before later input trackers", async () => {
+  const home = await setupTestDirectory("pi-ultracode-input-order");
+  try {
+    const pi = createFakePi();
+    setupHarness(pi, makeConfig(home));
+    let reachedLaterTracker = false;
+    pi.on("input", () => {
+      reachedLaterTracker = true;
+      return { action: "continue" };
+    });
+
+    expect(
+      await pi.emitInputResult({
+        type: "input",
+        text: "/settings ultracode on",
+        source: "interactive",
+      }),
+    ).toEqual({ action: "handled" });
+    expect(reachedLaterTracker).toBe(false);
+  } finally {
+    await cleanupTestDirectory(home);
+  }
+});
+
+test("umbrella omits settings input when the bridge is inactive", async () => {
+  const home = await setupTestDirectory("pi-ultracode-inactive");
+  try {
+    const configs: HarnessConfig[] = [
+      {
+        ...makeConfig(home),
+        features: { ...makeConfig(home).features, "hook-bridge": false },
+      },
+      { ...makeConfig(home), isChild: true },
+    ];
+    for (const config of configs) {
+      const pi = createFakePi();
+      setupHarness(pi, config);
+      expect(
+        await pi.emitInputResult({
+          type: "input",
+          text: "/settings ultracode on",
+          source: "interactive",
+        }),
+      ).toEqual({ action: "continue" });
+      expect(pi.notifications).toHaveLength(0);
+    }
+    expect(readUltracodeSetting(resolvePaths(home).localConfigFile)).toEqual({
+      autoInjectContext: false,
+    });
+  } finally {
+    await cleanupTestDirectory(home);
+  }
+});
+
+const hookPath = join(
+  import.meta.dir,
+  "..",
+  "..",
+  "claude",
+  ".claude",
+  "hooks",
+  "user_prompt_submit",
+  "ultracode_codex_context.sh",
+);
+
+const runUltracodeHook = async (
+  home: string,
+  prompt: string,
+  piConfigFile?: string,
+): Promise<string> => {
+  const bin = join(home, ".bun", "bin");
+  const temporary = join(home, "tmp");
+  await mkdir(bin, { recursive: true });
+  await mkdir(temporary, { recursive: true });
+  const codex = join(bin, "codex");
+  await createTestFile(codex, "#!/bin/sh\nexit 0\n");
+  await chmod(codex, 0o700);
+  const result = await runHook(hookPath, JSON.stringify({ prompt }), {
+    cwd: home,
+    env: {
+      HOME: home,
+      TMPDIR: temporary,
+      PATH: `${bin}:${process.env.PATH ?? "/usr/bin:/bin"}`,
+      PI_HARNESS_LOCAL_CONFIG_FILE: piConfigFile,
+    },
+    timeoutMs: 5_000,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.timedOut).toBe(false);
+  return result.stdout;
+};
+
+test("hook bridge supplies the Pi-local config path", async () => {
+  const home = await setupTestDirectory("pi-ultracode-hook-bridge");
+  const script = join(home, "config-path-hook.sh");
+  const configReference = `${String.fromCharCode(36)}{PI_HARNESS_LOCAL_CONFIG_FILE:-}`;
+  try {
+    await createTestFile(
+      script,
+      [
+        "#!/usr/bin/env bash",
+        "cat > /dev/null",
+        `jq -n --arg ctx "${configReference}" '{hookSpecificOutput:{additionalContext:$ctx}}'`,
+      ].join("\n"),
+    );
+    const pi = createFakePi({ cwd: home });
+    const config = makeConfig(home);
+    const registry: BridgeHookSpec[] = [
+      {
+        id: "ultracode-config-path",
+        stage: "before_agent_start",
+        script,
+        timeoutMs: 5_000,
+        maxOutputBytes: 65_536,
+      },
+    ];
+    setupHookBridge(pi, config, { registry });
+
+    const injection = await pi.emitBeforeAgentStart({
+      type: "before_agent_start",
+      prompt: "ordinary request",
+    });
+    expect(injection?.message?.content).toBe(config.paths.localConfigFile);
+  } finally {
+    await cleanupTestDirectory(home);
+  }
+});
+
+test("hook keeps Claude keyword-only and honors Pi auto-injection", async () => {
+  const home = await setupTestDirectory("pi-ultracode-hook");
+  const configFile = join(home, ".pi", "agent", "pi-harness.local.json");
+  try {
+    expect(await runUltracodeHook(home, "ordinary request")).toBe("");
+    expect(await runUltracodeHook(home, "please use ultracode")).toContain(
+      "additionalContext",
+    );
+
+    writeUltracodeSetting(configFile, true);
+    expect(await runUltracodeHook(home, "ordinary request")).toBe("");
+    expect(
+      await runUltracodeHook(home, "ordinary request", configFile),
+    ).toContain("additionalContext");
+
+    writeUltracodeSetting(configFile, false);
+    expect(await runUltracodeHook(home, "ordinary request", configFile)).toBe(
+      "",
+    );
+
+    await createTestFile(
+      configFile,
+      JSON.stringify({ ultracode: { autoInjectContext: "true" } }),
+    );
+    expect(await runUltracodeHook(home, "ordinary request", configFile)).toBe(
+      "",
+    );
+    await createTestFile(configFile, "{not-json");
+    expect(await runUltracodeHook(home, "ordinary request", configFile)).toBe(
+      "",
+    );
+    await createTestFile(
+      configFile,
+      '{}\n{"ultracode":{"autoInjectContext":true}}\n',
+    );
+    expect(await runUltracodeHook(home, "ordinary request", configFile)).toBe(
+      "",
+    );
+  } finally {
+    await cleanupTestDirectory(home);
+  }
+});


### PR DESCRIPTION
## Summary

- add `/settings ultracode on|off|status` without colliding with Pi built-ins
- persist automatic ultracode context injection in `pi-harness.local.json` while preserving keyword-only behavior when disabled
- scope persistent activation to the Pi hook bridge so direct Claude hooks remain keyword-only
- validate malformed configuration, symlinks, parent/child lifecycle, and input-handler ordering

## Test plan

- [x] `bun test` (1973 passed, 2 skipped)
- [x] `bun run tsc`
- [x] `bun run lint` (only pre-existing Hearth warnings)
- [x] Prettier check for changed TypeScript files
- [x] shellcheck for `ultracode_codex_context.sh`
- [x] `bun run check:pi-imports`
- [x] `bun run check:pi-baseline`
- [x] `bun run check:pi-compat`