### PR TITLE
fix(pi): prevent Hearth cleanup from blocking live reload

### DIFF
--- a/pi/extensions/hearth-tools/engine.ts
+++ b/pi/extensions/hearth-tools/engine.ts
@@ -189,12 +189,31 @@ const LEGACY_ENGINE_SLOT_V2 = Symbol.for(
 const LEGACY_ENGINE_SLOT_V1 = Symbol.for(
   "ushironoko.pi-hearth-tools.engine.v1",
 );
+const RETIRED_ENGINE_SLOT = Symbol.for(
+  "ushironoko.pi-hearth-tools.retired-engines.v1",
+);
 
 interface GlobalWithEngine {
   [ENGINE_SLOT]?: HearthEngineRuntime;
   [LEGACY_ENGINE_SLOT_V2]?: unknown;
   [LEGACY_ENGINE_SLOT_V1]?: unknown;
+  [RETIRED_ENGINE_SLOT]?: unknown[];
 }
+
+const retireLegacyEngines = (host: GlobalWithEngine): void => {
+  let retired = host[RETIRED_ENGINE_SLOT];
+  for (const legacy of [
+    host[LEGACY_ENGINE_SLOT_V2],
+    host[LEGACY_ENGINE_SLOT_V1],
+  ]) {
+    if (legacy === undefined) continue;
+    retired ??= [];
+    if (!retired.includes(legacy)) retired.push(legacy);
+  }
+  if (retired !== undefined) host[RETIRED_ENGINE_SLOT] = retired;
+  delete host[LEGACY_ENGINE_SLOT_V2];
+  delete host[LEGACY_ENGINE_SLOT_V1];
+};
 
 export class HearthEngineRestartRequiredError extends Error {
   constructor() {
@@ -243,11 +262,14 @@ export const getOrCreateEngineRuntime = (
   shell: ShellSpec,
 ): HearthEngineRuntime => {
   const host = globalThis as GlobalWithEngine;
-  // A live /reload must release pre-graph and pre-gate global roots before
-  // constructing v3. A 0.1.0 Engine in the v2 slot has no graph methods and
-  // cannot satisfy the current runtime even when its ordinary options match.
-  delete host[LEGACY_ENGINE_SLOT_V2];
-  delete host[LEGACY_ENGINE_SLOT_V1];
+  // A live /reload must detach pre-graph and pre-gate slots before constructing
+  // v3. Keep their native runtimes strongly reachable, though: dropping a warm
+  // HearthEngine during extension reload can block native finalization and
+  // prevent Pi from ever loading the new extension. Hearth has no async close
+  // boundary, so an ordinary forward migration deliberately keeps at most the
+  // two named legacy runtimes (including their caches, optimizer, and shells)
+  // until the process restarts.
+  retireLegacyEngines(host);
   const options = createOptions(cwd, config, shell);
   const existing = host[ENGINE_SLOT];
   if (existing !== undefined) {
@@ -271,4 +293,5 @@ export const clearProcessEngineForTests = (): void => {
   delete host[ENGINE_SLOT];
   delete host[LEGACY_ENGINE_SLOT_V2];
   delete host[LEGACY_ENGINE_SLOT_V1];
+  delete host[RETIRED_ENGINE_SLOT];
 };

--- a/tests/pi-harness/hearth-tools-startup.test.ts
+++ b/tests/pi-harness/hearth-tools-startup.test.ts
@@ -630,14 +630,19 @@ describe("hearth-tools startup", () => {
     ).rejects.toThrow(COLLISION_ERROR);
   });
 
-  test("releases pre-graph process slots before creating the current runtime", async () => {
+  test("retires pre-graph runtimes without dropping them during reload", async () => {
     const legacySlots = [
       Symbol.for("ushironoko.pi-hearth-tools.engine.v1"),
       Symbol.for("ushironoko.pi-hearth-tools.engine.v2"),
     ];
-    for (const legacySlot of legacySlots) {
-      Reflect.set(globalThis, legacySlot, { engine: {}, options: {} });
-    }
+    const legacyRuntimes = legacySlots.map((legacySlot) => {
+      const runtime = { engine: {}, options: {} };
+      Reflect.set(globalThis, legacySlot, runtime);
+      return runtime;
+    });
+    const retiredSlot = Symbol.for(
+      "ushironoko.pi-hearth-tools.retired-engines.v1",
+    );
     const fake = fakePi();
     await setupHearthTools(fake.pi, {
       loadModule: async () => ({ HearthEngine: FakeEngine as never }),
@@ -653,7 +658,24 @@ describe("hearth-tools startup", () => {
     for (const legacySlot of legacySlots) {
       expect(Reflect.has(globalThis, legacySlot)).toBe(false);
     }
+    expect(Reflect.get(globalThis, retiredSlot)).toEqual([
+      legacyRuntimes[1],
+      legacyRuntimes[0],
+    ]);
     expect(FakeEngine.constructed).toHaveLength(1);
+
+    await fake.emit("session_shutdown");
+    await setupHearthTools(fake.pi, {
+      loadModule: async () => ({ HearthEngine: FakeEngine as never }),
+      getAgentDir: () => "/agent",
+      loadConfig: () => ({ ...DEFAULT_HEARTH_TOOLS_CONFIG }),
+      createSettings: (() => settings) as never,
+      fatal: (message) => {
+        throw new Error(message);
+      },
+    });
+    await fake.emit("session_start", { reason: "reload" });
+    expect(Reflect.get(globalThis, retiredSlot)).toHaveLength(2);
   });
 
   test("clears caches after mutation hooks and child completion", async () => {


### PR DESCRIPTION
## Summary

- detach incompatible v1/v2 Hearth Engine slots without allowing their native runtimes to finalize during live reload
- retain retired legacy runtimes until process restart while constructing and reusing only the v3 runtime
- cover legacy retirement, strong reachability, and repeated reload behavior

## Rationale

Pi awaits extension shutdown and resource reload serially. Releasing the final reference to a warm legacy native Engine inside that path can block reload before the v3 extension is initialized. Hearth 0.1.1 has no asynchronous close boundary, so the bounded forward-migration path intentionally retains up to the two known legacy runtimes, including their caches, optimizer, and warm shells, until process restart.

## Testing

- `bun test tests/pi-harness/hearth-tools-native.test.ts tests/pi-harness/hearth-tools-graph.test.ts tests/pi-harness/hearth-tools-startup.test.ts tests/pi-harness/hearth-tool-status.test.ts` — 44 pass
- `bun test` outside the effect sandbox — 1973 pass, 2 skip, 0 fail
- `bun run tsc`
- `bun run lint` — 0 errors; 9 pre-existing hexadecimal-style warnings
- Prettier check for the changed files
- `git diff --check`