### PR TITLE
feat(pi): show Hearth graph query titles

### DIFF
--- a/pi/extensions/hearth-tools/graph.ts
+++ b/pi/extensions/hearth-tools/graph.ts
@@ -1,7 +1,9 @@
 import {
   defineTool,
+  truncateToVisualLines,
   type ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
+import type { Component } from "@earendil-works/pi-tui";
 import type {
   GraphDepEdge,
   GraphMeta,
@@ -11,6 +13,8 @@ import type {
 } from "@hearthdev/napi";
 import { isAbsolute, relative, resolve, sep } from "node:path";
 import type { HearthAccessGate } from "./engine";
+import { withStatusTitle } from "./status-title";
+import { stripTerminalControls } from "./terminal-text";
 
 export const HEARTH_GRAPH_TOOL_NAME = "hearth_graph";
 
@@ -27,6 +31,7 @@ const MAX_CONTENT_LINES = MAX_OUTPUT_LINES - 1;
 const MAX_CONTENT_BYTES = MAX_OUTPUT_BYTES - OUTPUT_NOTICE_RESERVE_BYTES;
 const MAX_FIELD_LENGTH = 500;
 const MAX_PATH_LENGTH = 4_096;
+const MAX_RAW_FIELD_LENGTH = MAX_PATH_LENGTH;
 const MAX_SYMBOL_TEXT_LENGTH = 512;
 
 const GRAPH_OPERATIONS = [
@@ -162,16 +167,87 @@ const waitAbortable = async <T>(
   }
 };
 
+const rawFieldPrefix = (
+  value: string,
+): { text: string; truncated: boolean } => {
+  let end = Math.min(value.length, MAX_RAW_FIELD_LENGTH);
+  const last = value.charCodeAt(end - 1);
+  if (last >= 55_296 && last <= 56_319) end -= 1;
+  return { text: value.slice(0, end), truncated: end < value.length };
+};
+
 const boundedField = (value: string): string => {
-  const escaped = value
+  const raw = rawFieldPrefix(value);
+  const escaped = stripTerminalControls(raw.text)
     .replaceAll("\\", "\\\\")
     .replaceAll("\r", String.raw`\r`)
     .replaceAll("\n", String.raw`\n`)
     .replaceAll("\t", String.raw`\t`);
-  return escaped.length <= MAX_FIELD_LENGTH
+  return !raw.truncated && escaped.length <= MAX_FIELD_LENGTH
     ? escaped
     : `${escaped.slice(0, MAX_FIELD_LENGTH)}…`;
 };
+
+const graphCallOperation = (value: unknown): GraphOperation | undefined =>
+  typeof value === "string" &&
+  (GRAPH_OPERATIONS as readonly string[]).includes(value)
+    ? (value as GraphOperation)
+    : undefined;
+
+const graphCallField = (value: unknown): string | undefined =>
+  typeof value === "string" ? boundedField(value) : undefined;
+
+interface UnvalidatedGraphCallArgs {
+  operation?: unknown;
+  path?: unknown;
+  query?: unknown;
+  name?: unknown;
+}
+
+const unvalidatedGraphCallArgs = (value: unknown): UnvalidatedGraphCallArgs =>
+  typeof value === "object" && value !== null
+    ? (value as UnvalidatedGraphCallArgs)
+    : {};
+
+const graphCallTarget = (
+  params: UnvalidatedGraphCallArgs,
+): string | undefined => {
+  switch (graphCallOperation(params.operation)) {
+    case "symbols":
+    case "outline":
+    case "deps":
+    case "rdeps":
+    case "neighborhood": {
+      return graphCallField(params.path);
+    }
+    case "search": {
+      const query = graphCallField(params.query);
+      return query === undefined ? undefined : `"${query}"`;
+    }
+    case "definitions": {
+      return graphCallField(params.name);
+    }
+    case "status":
+    case undefined: {
+      return undefined;
+    }
+  }
+};
+
+class GraphCallTitle implements Component {
+  constructor(private text = "") {}
+
+  setText(text: string): void {
+    this.text = text;
+  }
+
+  render(width: number): string[] {
+    return truncateToVisualLines(this.text, Number.MAX_SAFE_INTEGER, width)
+      .visualLines;
+  }
+
+  invalidate(): void {}
+}
 
 const withinRoot = (root: string, input: string): string | undefined => {
   const absolute = resolve(root, input);
@@ -676,57 +752,76 @@ export const createHearthGraphDefinition = (
   gate: HearthAccessGate,
   observer: HearthGraphRuntime,
 ): ToolDefinition<typeof GraphParameters, Record<string, unknown>> =>
-  defineTool({
-    name: HEARTH_GRAPH_TOOL_NAME,
-    label: "Hearth Graph",
-    description:
-      "Query the current project module graph and symbol index. Supports symbols, outlines, symbol search, definitions, dependencies, reverse dependencies, neighborhoods, and build status.",
-    promptSnippet:
-      "Query the Hearth project symbol index and module dependency graph",
-    promptGuidelines: [
-      "Use hearth_graph after locating relevant files when symbol definitions or module dependency direction would reduce further text searching.",
-      "Treat approximate graph guarantees and unresolved imports as incomplete evidence; confirm consequential conclusions with read or grep.",
-      "Graph paths are restricted to the current project and traversal depth is bounded.",
-    ],
-    executionMode: "sequential",
-    parameters: GraphParameters,
-    async execute(_id, params, signal) {
-      await observer.flush(signal);
-      const result = await observer.runQuery(
-        () =>
-          gate.shared(() =>
-            runGraphQuery(engine, root, params.operation, params, signal),
-          ),
-        signal,
-      );
-      if (params.operation !== "status") {
-        observer.markProjectComplete(result.meta.guarantee === "exact");
-      }
-      const observerStatus = observer.status();
-      const effectiveGuarantee = observerStatus.projectComplete
-        ? result.meta.guarantee
-        : "approximate";
-      const formatted = formatGraphResult(
-        root,
-        params.operation,
-        result,
-        observerStatus,
-      );
-      return {
-        content: [{ type: "text", text: formatted.text }],
-        details: {
-          operation: params.operation,
-          nativeMeta: result.meta,
-          effectiveGuarantee,
-          scope: observerStatus.projectComplete
-            ? "project"
-            : "observed-partial",
-          observer: observerStatus,
-          truncated: formatted.truncated,
-          outputLines: formatted.outputLines,
-          outputBytes: formatted.outputBytes,
-          omittedRows: formatted.omittedRows,
-        },
-      };
-    },
-  });
+  withStatusTitle(
+    defineTool({
+      name: HEARTH_GRAPH_TOOL_NAME,
+      label: "Hearth Graph",
+      description:
+        "Query the current project module graph and symbol index. Supports symbols, outlines, symbol search, definitions, dependencies, reverse dependencies, neighborhoods, and build status.",
+      promptSnippet:
+        "Query the Hearth project symbol index and module dependency graph",
+      promptGuidelines: [
+        "Use hearth_graph after locating relevant files when symbol definitions or module dependency direction would reduce further text searching.",
+        "Treat approximate graph guarantees and unresolved imports as incomplete evidence; confirm consequential conclusions with read or grep.",
+        "Graph paths are restricted to the current project and traversal depth is bounded.",
+      ],
+      executionMode: "sequential",
+      parameters: GraphParameters,
+      renderCall(args, theme, context) {
+        const title =
+          context.lastComponent instanceof GraphCallTitle
+            ? context.lastComponent
+            : new GraphCallTitle();
+        const callArgs = unvalidatedGraphCallArgs(args);
+        const operation = graphCallOperation(callArgs.operation);
+        const target = graphCallTarget(callArgs);
+        const callTitle =
+          operation === undefined ? "graph_…" : `graph_${operation}`;
+        let content = theme.fg("toolTitle", theme.bold(callTitle));
+        if (target !== undefined) {
+          content += ` ${theme.fg("muted", target)}`;
+        }
+        title.setText(content);
+        return title;
+      },
+      async execute(_id, params, signal) {
+        await observer.flush(signal);
+        const result = await observer.runQuery(
+          () =>
+            gate.shared(() =>
+              runGraphQuery(engine, root, params.operation, params, signal),
+            ),
+          signal,
+        );
+        if (params.operation !== "status") {
+          observer.markProjectComplete(result.meta.guarantee === "exact");
+        }
+        const observerStatus = observer.status();
+        const effectiveGuarantee = observerStatus.projectComplete
+          ? result.meta.guarantee
+          : "approximate";
+        const formatted = formatGraphResult(
+          root,
+          params.operation,
+          result,
+          observerStatus,
+        );
+        return {
+          content: [{ type: "text", text: formatted.text }],
+          details: {
+            operation: params.operation,
+            nativeMeta: result.meta,
+            effectiveGuarantee,
+            scope: observerStatus.projectComplete
+              ? "project"
+              : "observed-partial",
+            observer: observerStatus,
+            truncated: formatted.truncated,
+            outputLines: formatted.outputLines,
+            outputBytes: formatted.outputBytes,
+            omittedRows: formatted.omittedRows,
+          },
+        };
+      },
+    }),
+  );

--- a/pi/extensions/hearth-tools/terminal-text.ts
+++ b/pi/extensions/hearth-tools/terminal-text.ts
@@ -1,0 +1,79 @@
+const consumeCsi = (value: string, start: number): number => {
+  for (let index = start; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 64 && code <= 126) return index + 1;
+  }
+  return value.length;
+};
+
+const consumeControlString = (value: string, start: number): number => {
+  for (let index = start; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code === 7 || code === 156) return index + 1;
+    if (
+      value[index] === "\u001b" &&
+      index + 1 < value.length &&
+      value[index + 1] === "\\"
+    ) {
+      return index + 2;
+    }
+  }
+  return value.length;
+};
+
+/** Remove terminal control sequences before unvalidated tool text reaches TUI. */
+export const stripTerminalControls = (
+  value: string,
+  lineFeedReplacement = "\n",
+): string => {
+  let output = "";
+  let index = 0;
+  while (index < value.length) {
+    const code = value.charCodeAt(index);
+    if (value[index] === "\u001b") {
+      const next = value[index + 1];
+      if (next === "[") index = consumeCsi(value, index + 2);
+      else if (
+        next === "]" ||
+        next === "P" ||
+        next === "X" ||
+        next === "^" ||
+        next === "_"
+      ) {
+        index = consumeControlString(value, index + 2);
+      } else index += index + 1 < value.length ? 2 : 1;
+      continue;
+    }
+    if (code === 155) {
+      index = consumeCsi(value, index + 1);
+      continue;
+    }
+    if (
+      code === 157 ||
+      code === 144 ||
+      code === 152 ||
+      code === 158 ||
+      code === 159
+    ) {
+      index = consumeControlString(value, index + 1);
+      continue;
+    }
+    if (value[index] === "\n") {
+      output += lineFeedReplacement;
+      index += 1;
+      continue;
+    }
+    if (value[index] === "\t") {
+      output += "  ";
+      index += 1;
+      continue;
+    }
+    if (code <= 31 || (code >= 127 && code <= 159)) {
+      index += 1;
+      continue;
+    }
+    output += value[index];
+    index += 1;
+  }
+  return output;
+};

--- a/tests/pi-harness/hearth-tools-graph.test.ts
+++ b/tests/pi-harness/hearth-tools-graph.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import type { Theme } from "@earendil-works/pi-coding-agent";
 import {
   HearthEngine,
   type GraphMeta,
@@ -15,6 +16,7 @@ import {
   formatGraphResult,
   HearthGraphObserver,
 } from "../../pi/extensions/hearth-tools/graph";
+import { stripTerminalControls } from "../../pi/extensions/hearth-tools/terminal-text";
 
 const roots: string[] = [];
 const root = async (): Promise<string> => {
@@ -60,6 +62,39 @@ const resultText = (
   return content?.type === "text" ? content.text : "";
 };
 
+const ansi = new RegExp(String.raw`\u001B\[[0-9;]*m`, "g");
+const visibleText = (text: string): string => text.replace(ansi, "").trimEnd();
+const renderTheme = {
+  getFgAnsi(color: string) {
+    return color === "success" ? "\x1b[32m" : "\x1b[31m";
+  },
+  fg(_color: string, text: string) {
+    return `\x1b[36m${text}\x1b[39m`;
+  },
+  bold(text: string) {
+    return `\x1b[1m${text}\x1b[22m`;
+  },
+} as Theme;
+const renderContext = (
+  args: Record<string, unknown>,
+  overrides: Record<string, unknown> = {},
+) =>
+  ({
+    args,
+    toolCallId: "graph-call",
+    invalidate() {},
+    lastComponent: undefined,
+    state: undefined,
+    cwd: "/workspace",
+    executionStarted: true,
+    argsComplete: true,
+    isPartial: true,
+    expanded: false,
+    showImages: true,
+    isError: false,
+    ...overrides,
+  }) as never;
+
 afterEach(async () => {
   await Promise.all(
     roots.splice(0).map((path) => rm(path, { recursive: true, force: true })),
@@ -67,6 +102,147 @@ afterEach(async () => {
 });
 
 describe("Hearth graph integration", () => {
+  test("makes the operation and primary target visible in the call title", () => {
+    const tool = createHearthGraphDefinition(
+      "/workspace",
+      {} as never,
+      {} as never,
+      {} as never,
+    );
+    const { renderCall } = tool;
+    if (renderCall === undefined)
+      throw new Error("missing graph call renderer");
+    const args = { operation: "definitions" as const, name: "run" };
+
+    const pending = renderCall(args, renderTheme, renderContext(args));
+    expect(visibleText(pending.render(120).join("\n"))).toBe(
+      "graph_definitions run",
+    );
+
+    const settled = renderCall(
+      args,
+      renderTheme,
+      renderContext(args, { lastComponent: pending, isPartial: false }),
+    );
+    expect(settled).toBe(pending);
+    expect(visibleText(settled.render(120).join("\n"))).toBe(
+      "✓ graph_definitions run",
+    );
+    expect(
+      settled.render(20).every((line) => visibleText(line).length <= 20),
+    ).toBe(true);
+    expect(
+      settled.render(1).every((line) => visibleText(line).length <= 1),
+    ).toBe(true);
+
+    const depsArgs = { operation: "deps" as const, path: "src/run.ts" };
+    const deps = renderCall(depsArgs, renderTheme, renderContext(depsArgs));
+    expect(visibleText(deps.render(120).join("\n"))).toBe(
+      "graph_deps src/run.ts",
+    );
+
+    const rdepsArgs = { operation: "rdeps" as const, path: "src/value.ts" };
+    const rdeps = renderCall(rdepsArgs, renderTheme, renderContext(rdepsArgs));
+    expect(visibleText(rdeps.render(120).join("\n"))).toBe(
+      "graph_rdeps src/value.ts",
+    );
+
+    const searchArgs = { operation: "search" as const, query: "graph use" };
+    const failed = renderCall(
+      searchArgs,
+      renderTheme,
+      renderContext(searchArgs, { isPartial: false, isError: true }),
+    );
+    expect(visibleText(failed.render(120).join("\n"))).toBe(
+      '✗ graph_search "graph use"',
+    );
+    expect(tool.renderResult).toBeUndefined();
+  });
+
+  test("sanitizes unvalidated call arguments without losing failure feedback", () => {
+    const tool = createHearthGraphDefinition(
+      "/workspace",
+      {} as never,
+      {} as never,
+      {} as never,
+    );
+    const { renderCall } = tool;
+    if (renderCall === undefined)
+      throw new Error("missing graph call renderer");
+
+    expect(
+      stripTerminalControls(
+        "safe\x1b[31m red\x1b[0m\x1b]2;spoof\x07\u0000\u009dhidden\u009c text",
+      ),
+    ).toBe("safe red text");
+
+    const unsafeArgs = {
+      operation: "search",
+      query: "\x1b]2;spoof\x07graph\x1b[31m use\x1b[0m\u0000\u009dhidden\u009c",
+    };
+    const unsafe = renderCall(
+      unsafeArgs as never,
+      renderTheme,
+      renderContext(unsafeArgs),
+    );
+    const unsafeRendered = unsafe.render(120).join("\n");
+    expect(unsafeRendered).not.toContain("\x1b]2;spoof");
+    expect(unsafeRendered).not.toContain("\x07");
+    expect(unsafeRendered).not.toContain("\u0000");
+    expect(unsafeRendered).not.toContain("hidden");
+    expect(visibleText(unsafeRendered)).toBe('graph_search "graph use"');
+
+    const oversizedArgs = {
+      operation: "search",
+      query: `${"\x1b[31m".repeat(2_000)}tail`,
+    };
+    const oversized = renderCall(
+      oversizedArgs as never,
+      renderTheme,
+      renderContext(oversizedArgs),
+    );
+    expect(visibleText(oversized.render(120).join("\n"))).toBe(
+      'graph_search "…"',
+    );
+
+    const malformedArgs = { operation: "search", query: null };
+    const malformed = renderCall(
+      malformedArgs as never,
+      renderTheme,
+      renderContext(malformedArgs, { isPartial: false, isError: true }),
+    );
+    expect(visibleText(malformed.render(120).join("\n"))).toBe(
+      "✗ graph_search",
+    );
+
+    const nullArgs = renderCall(
+      null as never,
+      renderTheme,
+      renderContext(
+        {},
+        {
+          args: null,
+          isPartial: false,
+          isError: true,
+        },
+      ),
+    );
+    expect(visibleText(nullArgs.render(120).join("\n"))).toBe("✗ graph_…");
+
+    const invalidOperationArgs = {
+      operation: "\x1b]2;spoof\x07search",
+      query: "hidden target",
+    };
+    const invalidOperation = renderCall(
+      invalidOperationArgs as never,
+      renderTheme,
+      renderContext(invalidOperationArgs),
+    );
+    const invalidOperationRendered = invalidOperation.render(120).join("\n");
+    expect(invalidOperationRendered).not.toContain("\x1b]2;spoof");
+    expect(visibleText(invalidOperationRendered)).toBe("graph_…");
+  });
+
   test("incrementally indexes observed files and exposes project graph queries", async () => {
     const cwd = await root();
     await mkdir(join(cwd, "src"), { recursive: true });


### PR DESCRIPTION
## Summary

- render explicit Hearth graph calls as `graph_<operation>` titles such as `graph_deps` and `graph_rdeps`
- keep primary path, query, or symbol plus settled success/error status visible
- sanitize and bound pre-validation streamed arguments before terminal rendering
- preserve the raw graph result fallback for inspectable evidence

## Verification

- `bun test tests/pi-harness/hearth-tool-status.test.ts tests/pi-harness/hearth-tools-graph.test.ts tests/pi-harness/hearth-tools-native.test.ts tests/pi-harness/hearth-tools-startup.test.ts tests/pi-harness/check-pi-imports.test.ts` — 76 pass, 263 assertions
- `bun run tsc` — pass
- `bun run check:pi-imports` — pass
- `bun run lint` — 0 errors; 9 pre-existing warnings in `adapters.ts`
- `git diff --check` — pass

## Full-suite note

A full `bun test` run was attempted in the local harness. It reached 1858 passes and 2 skips, with 106 environment-dependent failures from sandbox runtime initialization, local port binding, and local permission-judge/Ollama tests. The one change-related import self-containment failure found during that run was fixed and is covered by the passing focused suite above.