### PR TITLE
docs(pi): expand graph tool guidance

### DIFF
--- a/pi/SYSTEM.md
+++ b/pi/SYSTEM.md
@@ -13,7 +13,7 @@ Guidelines:
 
 - Use bash for file operations like ls, rg, find.
 - Use read to examine files instead of cat or sed.
-- When `hearth_graph` is available, successful `read` and `grep` calls warm its module index. Use `definitions`, `deps`, `rdeps`, and `neighborhood` to trace symbols, assess change impact, and explore project structure instead of repeating broad searches; verify exact source with `read` before editing.
+- When `hearth_graph` is available, use its read-only structural index for comprehensive codebase exploration and change-impact analysis. Successful `read` and `grep` calls warm its module index. Use `symbols`, `outline`, `search`, and `definitions` to discover code, then `deps`, `rdeps`, and `neighborhood` to trace dependencies and identify affected areas instead of repeating broad text searches; verify exact source with `read` before editing.
 - Inspect `PI_*` environment variables when current model or session details are relevant.
 - Use edit for precise changes; every edits[].oldText must match exactly.
 - When changing multiple separate locations in one file, use one edit call with multiple entries in edits[] instead of multiple edit calls.

--- a/tests/config/pi-system-prompt.test.ts
+++ b/tests/config/pi-system-prompt.test.ts
@@ -39,12 +39,16 @@ describe("global pi system prompt", () => {
 
     expect(prompt).toContain("When `hearth_graph` is available");
     expect(prompt).toContain(
-      "successful `read` and `grep` calls warm its module index",
+      "Successful `read` and `grep` calls warm its module index",
     );
+    expect(prompt).toContain("read-only structural index");
+    expect(prompt).toContain("comprehensive codebase exploration");
+    expect(prompt).toContain("change-impact analysis");
     expect(prompt).toContain(
-      "`definitions`, `deps`, `rdeps`, and `neighborhood`",
+      "`symbols`, `outline`, `search`, and `definitions`",
     );
-    expect(prompt).toContain("assess change impact");
+    expect(prompt).toContain("`deps`, `rdeps`, and `neighborhood`");
+    expect(prompt).toContain("identify affected areas");
     expect(prompt).toContain("verify exact source with `read` before editing");
   });
 


### PR DESCRIPTION
## Summary

- describe `hearth_graph` as a read-only structural index for comprehensive codebase exploration and change-impact analysis
- distinguish discovery operations from dependency and affected-area tracing operations
- strengthen the system prompt regression test

## Verification

- `bun test tests/config/pi-system-prompt.test.ts`
- `bun run lint` (0 errors; 9 pre-existing number-literal-case warnings)
- `git diff --check`