### PR TITLE
feat(pi): prompt before trusting repositories

### DIFF
--- a/pi/README.md
+++ b/pi/README.md
@@ -90,7 +90,16 @@ feature toggles live in `~/.pi/agent/pi-harness.local.json` (machine-local):
 ```
 
 `trustedRoots` gates every feature that executes repository-defined commands
-(formatter, lint/typecheck/test) — fail-closed, symlink-resolved.
+(formatter, lint/typecheck/test) — fail-closed, symlink-resolved. When an
+interactive parent pi starts in an untrusted Git repository, the harness asks
+once per process whether to trust its canonical top-level directory. It uses
+the same Git common-directory identity rules as project memory, so a distinct
+nested repository does not inherit trust merely by containment, while a
+registered linked worktree can inherit its trusted repository identity.
+Approval serializes and atomically appends the directory to the machine-local
+file without discarding unrelated settings, then activates it for the current
+session. Denial, non-interactive modes, child processes, non-Git directories,
+and validation failures leave the configuration unchanged.
 
 Child pi processes spawned by subagent/workflow receive `PI_HARNESS_CHILD=1`
 and keep only the safety layer (no recursion, no duplicate notifications).

--- a/pi/extensions/pi-harness/features/trust-prompt/index.ts
+++ b/pi/extensions/pi-harness/features/trust-prompt/index.ts
@@ -1,0 +1,221 @@
+import { realpath } from "node:fs/promises";
+import { isAbsolute } from "node:path";
+import type { HarnessConfig } from "../../config";
+import {
+  runBoundedCommand,
+  type RunBoundedCommand,
+} from "../../lib/bounded-process";
+import { sanitizeChildEnv } from "../../lib/child-env";
+import type { PiLike } from "../../lib/pi-like";
+import { appendTrustedRoot, type TrustConfig } from "../../lib/trust";
+import {
+  MemoryRepositoryError,
+  resolveMemoryRepository,
+  type RunRepositoryGit,
+} from "../agent-memory/repository";
+
+const GIT_TIMEOUT_MS = 2_000;
+const GIT_OUTPUT_MAX_BYTES = 64 * 1_024;
+const TRUST_DISCOVERY_PATH = "/usr/bin:/bin:/usr/sbin:/sbin";
+const PROCESS_ATTEMPT_LIMIT = 256;
+const PROCESS_ATTEMPTS_KEY = Symbol.for(
+  "pi-harness.trust-prompt.attempted-roots.v1",
+);
+const fatalDecoder = new TextDecoder(undefined, { fatal: true });
+
+type RepositoryTrust = "trusted" | "untrusted" | "unavailable";
+
+export interface TrustPromptDependencies {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly runCommand?: RunBoundedCommand;
+  readonly realpath?: (path: string) => Promise<string>;
+  readonly appendTrustedRoot?: (
+    configFile: string,
+    root: string,
+  ) => TrustConfig;
+  readonly attemptedRoots?: Set<string>;
+  readonly repositoryTrust?: (
+    cwd: string,
+    trust: TrustConfig,
+    runGit: RunRepositoryGit,
+    resolveRealpath: (path: string) => Promise<string>,
+    signal?: AbortSignal,
+  ) => Promise<RepositoryTrust>;
+}
+
+const hasControlCharacter = (value: string): boolean =>
+  [...value].some((character) => {
+    const codePoint = character.codePointAt(0);
+    return codePoint !== undefined && (codePoint <= 31 || codePoint === 127);
+  });
+
+const processAttemptedRoots = (): Set<string> => {
+  const existing: unknown = Reflect.get(globalThis, PROCESS_ATTEMPTS_KEY);
+  if (existing instanceof Set) return existing as Set<string>;
+  const created = new Set<string>();
+  Reflect.set(globalThis, PROCESS_ATTEMPTS_KEY, created);
+  return created;
+};
+
+const rememberAttempt = (attemptedRoots: Set<string>, root: string): void => {
+  if (attemptedRoots.size >= PROCESS_ATTEMPT_LIMIT) attemptedRoots.clear();
+  attemptedRoots.add(root);
+};
+
+const createGitRunner = (deps: TrustPromptDependencies): RunRepositoryGit => {
+  const invoke = deps.runCommand ?? runBoundedCommand;
+  return async (cwd, args, signal) => {
+    const result = await invoke("git", args, {
+      cwd,
+      env: sanitizeChildEnv(
+        deps.env ?? process.env,
+        { PATH: TRUST_DISCOVERY_PATH },
+        { cwd },
+      ),
+      signal,
+      timeoutMs: GIT_TIMEOUT_MS,
+      stdoutMaxBytes: GIT_OUTPUT_MAX_BYTES,
+      stderrMaxBytes: GIT_OUTPUT_MAX_BYTES,
+    });
+    return {
+      exitCode: result.exitCode,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    };
+  };
+};
+
+const repositoryRoot = async (
+  cwd: string,
+  runGit: RunRepositoryGit,
+  resolveRealpath: (path: string) => Promise<string>,
+  signal?: AbortSignal,
+): Promise<string | undefined> => {
+  let result;
+  try {
+    result = await runGit(
+      cwd,
+      ["rev-parse", "--path-format=absolute", "--show-toplevel"],
+      signal,
+    );
+  } catch {
+    return undefined;
+  }
+  if (result.exitCode !== 0) return undefined;
+
+  let output: string;
+  try {
+    output = fatalDecoder.decode(result.stdout);
+  } catch {
+    return undefined;
+  }
+  let lineEndingLength = 0;
+  if (output.endsWith("\r\n")) lineEndingLength = 2;
+  else if (output.endsWith("\n")) lineEndingLength = 1;
+  if (lineEndingLength === 0) return undefined;
+  const root = output.slice(0, -lineEndingLength);
+  if (
+    root === "" ||
+    root.includes("\n") ||
+    root.includes("\r") ||
+    !isAbsolute(root) ||
+    hasControlCharacter(root)
+  ) {
+    return undefined;
+  }
+  try {
+    return await resolveRealpath(root);
+  } catch {
+    return undefined;
+  }
+};
+
+const defaultRepositoryTrust = async (
+  cwd: string,
+  trust: TrustConfig,
+  runGit: RunRepositoryGit,
+  resolveRealpath: (path: string) => Promise<string>,
+  signal?: AbortSignal,
+): Promise<RepositoryTrust> => {
+  try {
+    await resolveMemoryRepository(
+      cwd,
+      trust,
+      { runGit, realpath: resolveRealpath },
+      signal,
+    );
+    return "trusted";
+  } catch (error) {
+    return error instanceof MemoryRepositoryError && error.kind === "untrusted"
+      ? "untrusted"
+      : "unavailable";
+  }
+};
+
+const errorMessage = (error: unknown): string => {
+  if (error instanceof SyntaxError) {
+    return "pi-harness.local.json could not be parsed";
+  }
+  return error instanceof Error ? error.message : String(error);
+};
+
+export default function setupTrustPrompt(
+  pi: PiLike,
+  config: HarnessConfig,
+  deps: TrustPromptDependencies = {},
+): void {
+  if (config.isChild) return;
+
+  const attemptedRoots = deps.attemptedRoots ?? processAttemptedRoots();
+  const resolveRealpath = deps.realpath ?? realpath;
+  const runGit = createGitRunner(deps);
+  const resolveTrust = deps.repositoryTrust ?? defaultRepositoryTrust;
+
+  pi.on("session_start", async (_event, ctx) => {
+    if (!ctx.hasUI || (ctx.mode !== undefined && ctx.mode !== "tui")) return;
+
+    const cwd = ctx.cwd ?? process.cwd();
+    const root = await repositoryRoot(cwd, runGit, resolveRealpath, ctx.signal);
+    if (root === undefined || attemptedRoots.has(root)) return;
+
+    const trust = await resolveTrust(
+      cwd,
+      config.trust,
+      runGit,
+      resolveRealpath,
+      ctx.signal,
+    );
+    if (trust !== "untrusted") return;
+    rememberAttempt(attemptedRoots, root);
+
+    let allowed: boolean;
+    try {
+      allowed = await ctx.ui.confirm(
+        "Trust this repository?",
+        `Allow pi-harness to use project memory and run repository-defined checks for:\n\n${root}\n\nOnly approve repositories you trust. Approval adds this path to ~/.pi/agent/pi-harness.local.json.`,
+        { signal: ctx.signal },
+      );
+    } catch {
+      attemptedRoots.delete(root);
+      return;
+    }
+    if (!allowed) return;
+
+    try {
+      const update = deps.appendTrustedRoot ?? appendTrustedRoot;
+      const next = update(config.paths.localConfigFile, root);
+      config.trust.trustedRoots.splice(
+        0,
+        config.trust.trustedRoots.length,
+        ...next.trustedRoots,
+      );
+      ctx.ui.notify(`Trusted repository: ${root}`, "info");
+    } catch (error) {
+      attemptedRoots.delete(root);
+      ctx.ui.notify(
+        `Could not trust repository: ${errorMessage(error)}`,
+        "error",
+      );
+    }
+  });
+}

--- a/pi/extensions/pi-harness/features/ultracode-settings/index.ts
+++ b/pi/extensions/pi-harness/features/ultracode-settings/index.ts
@@ -1,15 +1,4 @@
-import { randomUUID } from "node:crypto";
-import {
-  lstatSync,
-  mkdirSync,
-  readFileSync,
-  realpathSync,
-  renameSync,
-  statSync,
-  unlinkSync,
-  writeFileSync,
-} from "node:fs";
-import { basename, dirname, join } from "node:path";
+import { readLocalConfig, updateLocalConfig } from "../../lib/local-config";
 import type { PiLike } from "../../lib/pi-like";
 
 export interface UltracodeSettingState {
@@ -19,27 +8,6 @@ export interface UltracodeSettingState {
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
-
-const isMissingFile = (error: unknown): boolean =>
-  isRecord(error) && error.code === "ENOENT";
-
-const readConfig = (
-  configFile: string,
-): { root: Record<string, unknown>; raw: string | undefined } => {
-  let raw: string;
-  try {
-    raw = readFileSync(configFile, "utf8");
-  } catch (error) {
-    if (isMissingFile(error)) return { root: {}, raw: undefined };
-    throw error;
-  }
-
-  const parsed: unknown = JSON.parse(raw);
-  if (!isRecord(parsed)) {
-    throw new Error("pi-harness.local.json must contain an object");
-  }
-  return { root: parsed, raw };
-};
 
 const configErrorMessage = (error: unknown): string => {
   if (error instanceof SyntaxError) {
@@ -52,7 +20,7 @@ export const readUltracodeSetting = (
   configFile: string,
 ): UltracodeSettingState => {
   try {
-    const { root } = readConfig(configFile);
+    const { root } = readLocalConfig(configFile);
     const { ultracode } = root;
     if (ultracode === undefined) return { autoInjectContext: false };
     if (!isRecord(ultracode)) {
@@ -78,80 +46,21 @@ export const readUltracodeSetting = (
   }
 };
 
-const writableConfigPath = (configFile: string): string => {
-  let symbolicLink: boolean;
-  try {
-    symbolicLink = lstatSync(configFile).isSymbolicLink();
-  } catch (error) {
-    if (isMissingFile(error)) return configFile;
-    throw error;
-  }
-  // Resolve an existing link outside the ENOENT fallback so a dangling link
-  // fails instead of being silently replaced by a regular config file.
-  return symbolicLink ? realpathSync(configFile) : configFile;
-};
-
-const currentRaw = (configFile: string): string | undefined => {
-  try {
-    return readFileSync(configFile, "utf8");
-  } catch (error) {
-    if (isMissingFile(error)) return undefined;
-    throw error;
-  }
-};
-
 export const writeUltracodeSetting = (
   configFile: string,
   autoInjectContext: boolean,
 ): void => {
-  const target = writableConfigPath(configFile);
-  const { root, raw } = readConfig(target);
-  const existing = root.ultracode;
-  if (existing !== undefined && !isRecord(existing)) {
-    throw new Error("ultracode must contain an object");
-  }
-  root.ultracode = {
-    ...existing,
-    autoInjectContext,
-  };
-
-  const directory = dirname(target);
-  mkdirSync(directory, { recursive: true, mode: 0o700 });
-  const temporary = join(
-    directory,
-    `.${basename(target)}.${process.pid}.${randomUUID()}.tmp`,
-  );
-  let mode = 0o600;
-  try {
-    mode = statSync(target).mode & 0o777;
-  } catch (error) {
-    if (!isMissingFile(error)) throw error;
-  }
-
-  const removeTemporary = (): void => {
-    try {
-      unlinkSync(temporary);
-    } catch {
-      // Best-effort cleanup: never mask the original write failure.
+  updateLocalConfig(configFile, (root) => {
+    const existing = root.ultracode;
+    if (existing !== undefined && !isRecord(existing)) {
+      throw new Error("ultracode must contain an object");
     }
-  };
-  try {
-    writeFileSync(temporary, `${JSON.stringify(root, null, 2)}\n`, {
-      encoding: "utf8",
-      flag: "wx",
-      mode,
-    });
-    if (currentRaw(target) !== raw) {
-      throw new Error(
-        "pi-harness.local.json changed concurrently; retry the command",
-      );
-    }
-    renameSync(temporary, target);
-  } catch (error) {
-    removeTemporary();
-    throw error;
-  }
-  removeTemporary();
+    root.ultracode = {
+      ...existing,
+      autoInjectContext,
+    };
+    return { changed: true, value: undefined };
+  });
 };
 
 const usage = "Usage: /settings ultracode on|off|status";

--- a/pi/extensions/pi-harness/index.ts
+++ b/pi/extensions/pi-harness/index.ts
@@ -46,6 +46,7 @@ import setupAskUserQuestion from "./features/ask-user-question/index";
 import setupBtw from "./features/btw/index";
 import setupChildRuns from "./features/child-runs/index";
 import setupUltracodeSettings from "./features/ultracode-settings/index";
+import setupTrustPromptFeature from "./features/trust-prompt/index";
 
 // This hook runs before the permission boundary, so it must not resolve any
 // executable through an inherited repository-influenced PATH. If a required
@@ -64,6 +65,7 @@ const PERMISSION_PREFLIGHT_PATH = [
 // to lib/pi-like.ts. Shapes verified against tests/fixtures/pi-harness/raw/.
 interface SetupHarnessOptions extends PermissionBlockerOptions {
   readonly setupBashSandbox?: typeof setupBashSandboxFeature;
+  readonly setupTrustPrompt?: typeof setupTrustPromptFeature;
   readonly consumeCodexStageCapability?: typeof consumeCodexStageCapability;
   readonly createCodexStageExecutablePin?: typeof createCodexStageExecutablePin;
 }
@@ -75,6 +77,7 @@ const setupHarness = (
 ): void => {
   const {
     setupBashSandbox: createBashSandbox = setupBashSandboxFeature,
+    setupTrustPrompt = setupTrustPromptFeature,
     consumeCodexStageCapability:
       consumeCodexStageModes = consumeCodexStageCapability,
     createCodexStageExecutablePin:
@@ -85,6 +88,9 @@ const setupHarness = (
   // adapter before any permission handler can call ctx.ui.confirm. The bridge
   // remains best-effort and preserves the original TUI dialog on failure.
   setupAsukuNotify(pi, config);
+  // Trust onboarding is parent-only and registers before any feature that
+  // consumes the trust snapshot during session_start.
+  if (!config.isChild) setupTrustPrompt(pi, config);
   // Consume the namespaced settings input before permission task correlation;
   // a handled command must not remain as pending task text for the next turn.
   if (!config.isChild && config.features["hook-bridge"]) {

--- a/pi/extensions/pi-harness/lib/local-config.ts
+++ b/pi/extensions/pi-harness/lib/local-config.ts
@@ -1,0 +1,213 @@
+import { randomUUID } from "node:crypto";
+import {
+  chmodSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
+
+export interface LocalConfigMutation<T> {
+  readonly changed: boolean;
+  readonly value: T;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const isMissingFile = (error: unknown): boolean =>
+  isRecord(error) && error.code === "ENOENT";
+
+const isExistingFile = (error: unknown): boolean =>
+  isRecord(error) && error.code === "EEXIST";
+
+const LOCK_STALE_MS = 5 * 60 * 1_000;
+
+const writableConfigPath = (configFile: string): string => {
+  let symbolicLink: boolean;
+  try {
+    symbolicLink = lstatSync(configFile).isSymbolicLink();
+  } catch (error) {
+    if (isMissingFile(error)) return configFile;
+    throw error;
+  }
+  // Never replace the machine-local symlink itself. A dangling link fails
+  // closed instead of silently becoming a regular config file.
+  return symbolicLink ? realpathSync(configFile) : configFile;
+};
+
+export const readLocalConfig = (
+  configFile: string,
+): { root: Record<string, unknown>; raw: string | undefined } => {
+  let raw: string;
+  try {
+    raw = readFileSync(configFile, "utf8");
+  } catch (error) {
+    if (isMissingFile(error)) return { root: {}, raw: undefined };
+    throw error;
+  }
+
+  const parsed: unknown = JSON.parse(raw);
+  if (!isRecord(parsed)) {
+    throw new Error("pi-harness.local.json must contain an object");
+  }
+  return { root: parsed, raw };
+};
+
+const currentRaw = (configFile: string): string | undefined => {
+  try {
+    return readFileSync(configFile, "utf8");
+  } catch (error) {
+    if (isMissingFile(error)) return undefined;
+    throw error;
+  }
+};
+
+const releaseLock = (lockFile: string, token: string): void => {
+  try {
+    if (readFileSync(lockFile, "utf8") === token) unlinkSync(lockFile);
+  } catch {
+    // Best-effort cleanup must not mask the update result. A missing or
+    // replaced lock is never unlinked on behalf of another writer.
+  }
+};
+
+const processIsAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return !isRecord(error) || error.code !== "ESRCH";
+  }
+};
+
+const lockOwnerPid = (token: string): number | undefined => {
+  const match = /^(\d+):[0-9a-f-]+$/.exec(token);
+  if (match?.[1] === undefined) return undefined;
+  const pid = Number(match[1]);
+  return Number.isSafeInteger(pid) && pid > 0 ? pid : undefined;
+};
+
+const recoverOrphanedLock = (lockFile: string): boolean => {
+  try {
+    const before = lstatSync(lockFile);
+    if (!before.isFile() || before.isSymbolicLink()) return false;
+    const token = readFileSync(lockFile, "utf8");
+    const ownerPid = lockOwnerPid(token);
+    const expired = Date.now() - before.mtimeMs >= LOCK_STALE_MS;
+    if (!expired && (ownerPid === undefined || processIsAlive(ownerPid))) {
+      return false;
+    }
+
+    // Recheck identity and contents immediately before unlinking so a writer
+    // that replaced the observed orphan is not removed on its behalf.
+    const after = lstatSync(lockFile);
+    if (
+      after.dev !== before.dev ||
+      after.ino !== before.ino ||
+      readFileSync(lockFile, "utf8") !== token
+    ) {
+      return false;
+    }
+    unlinkSync(lockFile);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Serializes pi-harness writers around one complete read-modify-rename cycle.
+ * The byte comparison additionally catches editors that do not honor the lock.
+ */
+export const updateLocalConfig = <T>(
+  configFile: string,
+  mutate: (root: Record<string, unknown>) => LocalConfigMutation<T>,
+): T => {
+  const target = writableConfigPath(configFile);
+  const directory = dirname(target);
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+
+  const lockFile = join(directory, `.${basename(target)}.lock`);
+  const lockToken = `${process.pid}:${randomUUID()}`;
+  let lockCreated = false;
+  for (let attempt = 0; attempt < 2 && !lockCreated; attempt += 1) {
+    try {
+      writeFileSync(lockFile, lockToken, {
+        encoding: "utf8",
+        flag: "wx",
+        mode: 0o600,
+      });
+      lockCreated = true;
+      chmodSync(lockFile, 0o600);
+    } catch (error) {
+      if (lockCreated) {
+        releaseLock(lockFile, lockToken);
+        throw error;
+      }
+      if (
+        !isExistingFile(error) ||
+        attempt > 0 ||
+        !recoverOrphanedLock(lockFile)
+      ) {
+        if (isExistingFile(error)) {
+          throw new Error("pi-harness.local.json update already in progress");
+        }
+        throw error;
+      }
+    }
+  }
+
+  try {
+    const { root, raw } = readLocalConfig(target);
+    const mutation = mutate(root);
+    if (!mutation.changed) return mutation.value;
+
+    const temporary = join(
+      directory,
+      `.${basename(target)}.${process.pid}.${randomUUID()}.tmp`,
+    );
+    let mode = 0o600;
+    try {
+      mode = statSync(target).mode & 0o777;
+    } catch (error) {
+      if (!isMissingFile(error)) throw error;
+    }
+
+    const removeTemporary = (): void => {
+      try {
+        unlinkSync(temporary);
+      } catch {
+        // Best-effort cleanup must not mask the original write failure.
+      }
+    };
+    try {
+      writeFileSync(temporary, `${JSON.stringify(root, null, 2)}\n`, {
+        encoding: "utf8",
+        flag: "wx",
+        mode,
+      });
+      // writeFile's mode is filtered by umask; restore the exact saved mode
+      // before publishing the replacement.
+      chmodSync(temporary, mode);
+      if (currentRaw(target) !== raw) {
+        throw new Error(
+          "pi-harness.local.json changed concurrently; update was not applied",
+        );
+      }
+      renameSync(temporary, target);
+    } catch (error) {
+      removeTemporary();
+      throw error;
+    }
+    removeTemporary();
+    return mutation.value;
+  } finally {
+    releaseLock(lockFile, lockToken);
+  }
+};

--- a/pi/extensions/pi-harness/lib/trust.ts
+++ b/pi/extensions/pi-harness/lib/trust.ts
@@ -8,8 +8,9 @@
  * this gate first. Unknown roots, unreadable config, and symlink escapes all
  * resolve to "not trusted" — features then skip silently.
  */
-import { readFileSync, realpathSync } from "node:fs";
-import { sep } from "node:path";
+import { lstatSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { dirname, join, sep } from "node:path";
+import { updateLocalConfig } from "./local-config";
 
 export interface TrustConfig {
   trustedRoots: string[];
@@ -42,6 +43,38 @@ export const loadTrustConfig = (localConfigFile: string): TrustConfig => {
 };
 
 /**
+ * Atomically adds one canonical path to the machine-local trust config while
+ * preserving unrelated keys and the existing file mode. The returned config
+ * is suitable for replacing the active in-memory trust snapshot.
+ */
+export const appendTrustedRoot = (
+  configFile: string,
+  requestedRoot: string,
+): TrustConfig => {
+  const canonicalRoot = realpathSync(requestedRoot);
+  return updateLocalConfig(configFile, (root) => {
+    const existing = root.trustedRoots;
+    if (
+      existing !== undefined &&
+      (!Array.isArray(existing) ||
+        existing.some((value) => typeof value !== "string"))
+    ) {
+      throw new Error("trustedRoots must be an array of strings");
+    }
+    const trustedRoots = existing === undefined ? [] : [...existing];
+    if (trustedRoots[0] === canonicalRoot) {
+      return { changed: false, value: { trustedRoots } };
+    }
+    const prioritizedRoots = [
+      canonicalRoot,
+      ...trustedRoots.filter((value) => value !== canonicalRoot),
+    ];
+    root.trustedRoots = prioritizedRoots;
+    return { changed: true, value: { trustedRoots: prioritizedRoots } };
+  });
+};
+
+/**
  * Pure containment check on already-canonicalized paths.
  */
 export const isPathWithin = (candidate: string, root: string): boolean => {
@@ -50,9 +83,43 @@ export const isPathWithin = (candidate: string, root: string): boolean => {
   return candidate.startsWith(prefix);
 };
 
+type GitBoundary = string | null | undefined;
+
+const isMissingPath = (error: unknown): boolean => {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  return code === "ENOENT" || code === "ENOTDIR";
+};
+
+/**
+ * Returns the nearest canonical directory containing a real .git file or
+ * directory. null means no repository marker; undefined means fail closed.
+ */
+const nearestGitBoundary = (candidate: string): GitBoundary => {
+  let cursor: string;
+  try {
+    cursor = statSync(candidate).isDirectory() ? candidate : dirname(candidate);
+  } catch {
+    return undefined;
+  }
+
+  while (true) {
+    try {
+      const marker = lstatSync(join(cursor, ".git"));
+      return marker.isFile() || marker.isDirectory() ? cursor : undefined;
+    } catch (error) {
+      if (!isMissingPath(error)) return undefined;
+    }
+    const parent = dirname(cursor);
+    if (parent === cursor) return null;
+    cursor = parent;
+  }
+};
+
 /**
  * Returns the CANONICAL trusted root that contains `cwd` (symlinks resolved on
- * both sides), or undefined when `cwd` is not within any trusted root. Callers
+ * both sides), or undefined when `cwd` is not within any trusted root. A Git
+ * checkout grants containment trust only inside the same nearest .git boundary;
+ * a non-Git container may still grant trust to repositories below it. Callers
  * that spawn repository-defined commands pass this canonical root down as a
  * boundary so a shell-side project-root re-discovery cannot ascend past it into
  * an untrusted parent (statusline TOCTOU fix). Any resolution failure is
@@ -68,10 +135,20 @@ export const matchedTrustedRoot = (
   } catch {
     return undefined;
   }
+  const candidateBoundary = nearestGitBoundary(realCwd);
+  if (candidateBoundary === undefined) return undefined;
+
   for (const root of config.trustedRoots) {
     try {
       const realRoot = realpathSync(root);
-      if (isPathWithin(realCwd, realRoot)) return realRoot;
+      if (!isPathWithin(realCwd, realRoot)) continue;
+      const rootBoundary = nearestGitBoundary(realRoot);
+      if (
+        rootBoundary !== undefined &&
+        (rootBoundary === null || rootBoundary === candidateBoundary)
+      ) {
+        return realRoot;
+      }
     } catch {
       // Unresolvable root entries never grant trust.
     }

--- a/tests/pi-harness/harness-composition.test.ts
+++ b/tests/pi-harness/harness-composition.test.ts
@@ -208,6 +208,32 @@ describe("pi-harness coordination browser composition", () => {
     expect(registered.tools).not.toContain("subagent_status");
   });
 
+  test("registers startup trust onboarding only for the parent profile", () => {
+    const parentConfig = config("pi-composition-trust-parent", {
+      subagent: false,
+      workflow: false,
+      "bit-task": false,
+    });
+    let registrations = 0;
+    setupHarness(createFakePi({ cwd: parentConfig.paths.home }), parentConfig, {
+      setupTrustPrompt: () => {
+        registrations += 1;
+      },
+    });
+
+    setupHarness(
+      createFakePi({ cwd: parentConfig.paths.home }),
+      { ...parentConfig, isChild: true },
+      {
+        setupTrustPrompt: () => {
+          registrations += 1;
+        },
+      },
+    );
+
+    expect(registrations).toBe(1);
+  });
+
   test("keeps the mandatory permission policy when Codex launcher pinning fails", async () => {
     const value = {
       ...config("pi-composition-codex-pin-failure", {

--- a/tests/pi-harness/trust-prompt.test.ts
+++ b/tests/pi-harness/trust-prompt.test.ts
@@ -1,0 +1,355 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { execFile } from "node:child_process";
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  stat,
+  symlink,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import {
+  loadConfig,
+  type HarnessConfig,
+} from "../../pi/extensions/pi-harness/config";
+import setupTrustPrompt from "../../pi/extensions/pi-harness/features/trust-prompt/index";
+import type { RunBoundedCommand } from "../../pi/extensions/pi-harness/lib/bounded-process";
+import { resolvePaths } from "../../pi/extensions/pi-harness/lib/paths";
+import {
+  appendTrustedRoot,
+  matchedTrustedRoot,
+} from "../../pi/extensions/pi-harness/lib/trust";
+import { createFakePi } from "./fake-pi";
+
+const execFileAsync = promisify(execFile);
+const roots: string[] = [];
+
+const temporaryRoot = async (): Promise<string> => {
+  const created = await mkdtemp(join(tmpdir(), "pi-trust-prompt-"));
+  const root = await realpath(created);
+  roots.push(root);
+  return root;
+};
+
+const configFor = (home: string): HarnessConfig =>
+  loadConfig({}, resolvePaths(home));
+
+const successfulGitRoot =
+  (root: string): RunBoundedCommand =>
+  async (_command, _args, _options) => ({
+    exitCode: 0,
+    stdout: Buffer.from(`${root}\n`),
+    stderr: Buffer.alloc(0),
+    stdoutTruncated: false,
+  });
+
+const untrustedRepository = async () => "untrusted" as const;
+const trustedRepository = async () => "trusted" as const;
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("pi-harness startup trust prompt", () => {
+  test("persists approval without discarding local settings and activates trust immediately", async () => {
+    const home = await temporaryRoot();
+    const repository = join(home, "repository");
+    await mkdir(repository);
+    const config = configFor(home);
+    await mkdir(join(home, ".pi", "agent"), { recursive: true });
+    await writeFile(
+      config.paths.localConfigFile,
+      `${JSON.stringify({ features: { statusline: false }, custom: { kept: true } })}\n`,
+      { mode: 0o640 },
+    );
+
+    let gitEnvironment: Record<string, string> | undefined;
+    const git = successfulGitRoot(repository);
+    const runCommand: RunBoundedCommand = async (command, args, options) => {
+      gitEnvironment = options.env;
+      return git(command, args, options);
+    };
+    const pi = createFakePi({ cwd: repository });
+    pi.queueConfirm(true);
+    setupTrustPrompt(pi, config, {
+      env: {
+        PATH: `${join(repository, "bin")}:/usr/bin`,
+        GIT_DIR: join(repository, "spoofed-git-dir"),
+      },
+      runCommand,
+      repositoryTrust: untrustedRepository,
+      attemptedRoots: new Set(),
+    });
+
+    await pi.emitSessionStart({ type: "session_start", reason: "startup" });
+
+    expect(pi.confirmDialogs).toHaveLength(1);
+    expect(gitEnvironment?.PATH).toBe("/usr/bin:/bin:/usr/sbin:/sbin");
+    expect(gitEnvironment?.GIT_DIR).toBeUndefined();
+    expect(pi.confirmDialogs[0]).toMatchObject({
+      title: "Trust this repository?",
+      message: expect.stringContaining(repository),
+    });
+    const persisted = JSON.parse(
+      await readFile(config.paths.localConfigFile, "utf8"),
+    ) as Record<string, unknown>;
+    expect(persisted).toMatchObject({
+      features: { statusline: false },
+      custom: { kept: true },
+      trustedRoots: [repository],
+    });
+    const configStat = await stat(config.paths.localConfigFile);
+    expect(configStat.mode & 0o777).toBe(0o640);
+    expect(config.trust.trustedRoots).toEqual([repository]);
+    expect(pi.notifications).toContainEqual({
+      message: `Trusted repository: ${repository}`,
+      level: "info",
+    });
+  });
+
+  test("does not write after denial or ask for the same root twice", async () => {
+    const home = await temporaryRoot();
+    const repository = join(home, "repository");
+    await mkdir(repository);
+    const config = configFor(home);
+    const pi = createFakePi({ cwd: repository });
+    pi.queueConfirm(false);
+    setupTrustPrompt(pi, config, {
+      runCommand: successfulGitRoot(repository),
+      repositoryTrust: untrustedRepository,
+    });
+
+    await pi.emitSessionStart({ type: "session_start", reason: "startup" });
+
+    const reloaded = createFakePi({ cwd: repository });
+    reloaded.queueConfirm(true);
+    setupTrustPrompt(reloaded, config, {
+      runCommand: successfulGitRoot(repository),
+      repositoryTrust: untrustedRepository,
+    });
+    await reloaded.emitSessionStart({
+      type: "session_start",
+      reason: "reload",
+    });
+
+    expect(pi.confirmDialogs).toHaveLength(1);
+    expect(reloaded.confirmDialogs).toHaveLength(0);
+    expect(config.trust.trustedRoots).toEqual([]);
+    await expect(
+      readFile(config.paths.localConfigFile, "utf8"),
+    ).rejects.toThrow();
+  });
+
+  test("skips non-interactive and already trusted sessions", async () => {
+    const home = await temporaryRoot();
+    const repository = join(home, "repository");
+    await mkdir(repository);
+    let commands = 0;
+    const invoke: RunBoundedCommand = async (...args) => {
+      commands += 1;
+      return successfulGitRoot(repository)(...args);
+    };
+
+    const nonInteractiveConfig = configFor(home);
+    const nonInteractive = createFakePi({
+      cwd: repository,
+      hasUI: false,
+      mode: "print",
+    });
+    setupTrustPrompt(nonInteractive, nonInteractiveConfig, {
+      runCommand: invoke,
+      repositoryTrust: untrustedRepository,
+      attemptedRoots: new Set(),
+    });
+    await nonInteractive.emitSessionStart({
+      type: "session_start",
+      reason: "startup",
+    });
+
+    const trustedConfig = configFor(home);
+    trustedConfig.trust.trustedRoots.push(repository);
+    const trusted = createFakePi({ cwd: repository });
+    setupTrustPrompt(trusted, trustedConfig, {
+      runCommand: invoke,
+      repositoryTrust: trustedRepository,
+      attemptedRoots: new Set(),
+    });
+    await trusted.emitSessionStart({
+      type: "session_start",
+      reason: "startup",
+    });
+
+    expect(commands).toBe(1);
+    expect(nonInteractive.confirmDialogs).toEqual([]);
+    expect(trusted.confirmDialogs).toEqual([]);
+  });
+
+  test("prompts for a nested Git repository that project memory does not inherit trust for", async () => {
+    const home = await temporaryRoot();
+    const outer = join(home, "outer");
+    const nested = join(outer, "nested");
+    await execFileAsync("git", ["init", "-q", outer]);
+    await execFileAsync("git", ["init", "-q", nested]);
+    const config = configFor(home);
+    config.trust.trustedRoots.push(outer);
+    const pi = createFakePi({ cwd: nested });
+    pi.queueConfirm(false);
+    setupTrustPrompt(pi, config, { attemptedRoots: new Set() });
+
+    await pi.emitSessionStart({ type: "session_start", reason: "startup" });
+
+    expect(pi.confirmDialogs).toHaveLength(1);
+    expect(pi.confirmDialogs[0]?.message).toContain(nested);
+    expect(matchedTrustedRoot(nested, config.trust)).toBeUndefined();
+  });
+
+  test("fails closed when the existing local config is malformed", async () => {
+    const home = await temporaryRoot();
+    const repository = join(home, "repository");
+    await mkdir(repository);
+    const config = configFor(home);
+    await mkdir(join(home, ".pi", "agent"), { recursive: true });
+    await writeFile(config.paths.localConfigFile, "{not-json\n");
+    const attemptedRoots = new Set<string>();
+    const pi = createFakePi({ cwd: repository });
+    pi.queueConfirm(true);
+    setupTrustPrompt(pi, config, {
+      runCommand: successfulGitRoot(repository),
+      repositoryTrust: untrustedRepository,
+      attemptedRoots,
+    });
+
+    await pi.emitSessionStart({ type: "session_start", reason: "startup" });
+
+    expect(config.trust.trustedRoots).toEqual([]);
+    expect(attemptedRoots.size).toBe(0);
+    expect(await readFile(config.paths.localConfigFile, "utf8")).toBe(
+      "{not-json\n",
+    );
+    expect(pi.notifications).toContainEqual({
+      message:
+        "Could not trust repository: pi-harness.local.json could not be parsed",
+      level: "error",
+    });
+  });
+
+  test("preserves trailing spaces in the canonical Git top-level", async () => {
+    const home = await temporaryRoot();
+    const repository = join(home, "repository ");
+    await mkdir(repository);
+    const config = configFor(home);
+    const pi = createFakePi({ cwd: repository });
+    pi.queueConfirm(true);
+    setupTrustPrompt(pi, config, {
+      runCommand: successfulGitRoot(repository),
+      repositoryTrust: untrustedRepository,
+      attemptedRoots: new Set(),
+    });
+
+    await pi.emitSessionStart({ type: "session_start", reason: "startup" });
+
+    expect(config.trust.trustedRoots).toEqual([repository]);
+    expect(pi.confirmDialogs[0]?.message).toContain(`${repository}\n\n`);
+  });
+
+  test("preserves the existing mode under a restrictive umask", async () => {
+    const home = await temporaryRoot();
+    const repository = join(home, "repository");
+    const configFile = join(home, "pi-harness.local.json");
+    await mkdir(repository);
+    await writeFile(configFile, "{}\n", { mode: 0o640 });
+
+    const previousUmask = process.umask(0o077);
+    try {
+      appendTrustedRoot(configFile, repository);
+    } finally {
+      process.umask(previousUmask);
+    }
+
+    const configStat = await stat(configFile);
+    expect(configStat.mode & 0o777).toBe(0o640);
+  });
+
+  test("refuses a competing local-config writer without losing data", async () => {
+    const home = await temporaryRoot();
+    const repository = join(home, "repository");
+    const configFile = join(home, "pi-harness.local.json");
+    const lockFile = join(home, ".pi-harness.local.json.lock");
+    await mkdir(repository);
+    await writeFile(configFile, '{"custom":"keep"}\n');
+    await writeFile(lockFile, "another-writer");
+
+    expect(() => appendTrustedRoot(configFile, repository)).toThrow(
+      "pi-harness.local.json update already in progress",
+    );
+    expect(JSON.parse(await readFile(configFile, "utf8"))).toEqual({
+      custom: "keep",
+    });
+  });
+
+  test("prioritizes an approved root inside project memory's bounded scan window", async () => {
+    const home = await temporaryRoot();
+    const repository = join(home, "repository");
+    const configFile = join(home, "pi-harness.local.json");
+    const staleRoots = Array.from({ length: 64 }, (_, index) =>
+      join(home, `stale-${index}`),
+    );
+    await mkdir(repository);
+    await writeFile(
+      configFile,
+      `${JSON.stringify({ trustedRoots: staleRoots })}\n`,
+    );
+
+    const updated = appendTrustedRoot(configFile, repository);
+
+    expect(updated.trustedRoots[0]).toBe(repository);
+    expect(updated.trustedRoots.slice(1)).toEqual(staleRoots);
+  });
+
+  test("recovers an expired orphaned local-config lock", async () => {
+    const home = await temporaryRoot();
+    const repository = join(home, "repository");
+    const configFile = join(home, "pi-harness.local.json");
+    const lockFile = join(home, ".pi-harness.local.json.lock");
+    await mkdir(repository);
+    await writeFile(configFile, "{}\n");
+    await writeFile(lockFile, "crashed-writer");
+    const staleTime = new Date(Date.now() - 10 * 60 * 1_000);
+    await utimes(lockFile, staleTime, staleTime);
+
+    expect(appendTrustedRoot(configFile, repository)).toEqual({
+      trustedRoots: [repository],
+    });
+    await expect(readFile(lockFile, "utf8")).rejects.toThrow();
+  });
+
+  test("updates a symlink target without replacing the machine-local symlink", async () => {
+    const root = await temporaryRoot();
+    const repository = join(root, "repository");
+    const target = join(root, "local-config.json");
+    const link = join(root, "pi-harness.local.json");
+    await mkdir(repository);
+    await writeFile(target, '{"custom":true}\n');
+    await symlink(target, link);
+
+    expect(appendTrustedRoot(link, repository)).toEqual({
+      trustedRoots: [repository],
+    });
+
+    const linkStat = await lstat(link);
+    expect(linkStat.isSymbolicLink()).toBe(true);
+    expect(JSON.parse(await readFile(target, "utf8"))).toEqual({
+      custom: true,
+      trustedRoots: [repository],
+    });
+  });
+});

--- a/tests/pi-harness/ultracode-setting.test.ts
+++ b/tests/pi-harness/ultracode-setting.test.ts
@@ -109,6 +109,26 @@ test("refuses to overwrite malformed local config", async () => {
   }
 });
 
+test("shares the local-config writer lock with trust onboarding", async () => {
+  const home = await setupTestDirectory("pi-ultracode-setting-lock");
+  const directory = join(home, ".pi", "agent");
+  const configFile = join(directory, "pi-harness.local.json");
+  const lockFile = join(directory, ".pi-harness.local.json.lock");
+  try {
+    await createTestFile(configFile, '{"custom":"keep"}\n');
+    await createTestFile(lockFile, "trust-writer");
+
+    expect(() => writeUltracodeSetting(configFile, true)).toThrow(
+      "pi-harness.local.json update already in progress",
+    );
+    expect(JSON.parse(await readFile(configFile, "utf8"))).toEqual({
+      custom: "keep",
+    });
+  } finally {
+    await cleanupTestDirectory(home);
+  }
+});
+
 test("settings input toggles ultracode without registering a conflicting command", async () => {
   const home = await setupTestDirectory("pi-ultracode-command");
   const configFile = join(home, ".pi", "agent", "pi-harness.local.json");


### PR DESCRIPTION
## Summary

- prompt interactive parent Pi sessions before trusting an untrusted Git repository, persist approval in `trustedRoots`, and activate it immediately
- discover repositories with a fixed root-owned Git PATH and align nested repository execution gates with project-memory identity rules while retaining linked-worktree inheritance
- serialize machine-local config updates through a shared atomic writer used by trust onboarding and ultracode settings, preserving symlinks, file modes, and recovering orphaned locks
- prioritize newly approved roots inside the bounded project-memory scan window and avoid repeated prompts across reloads in the same process
- document the onboarding behavior and add focused lifecycle, security, and persistence coverage

## Test plan

- [x] `bun test` (1986 passed, 2 skipped)
- [x] `bun run tsc`
- [x] `bun run lint` (only pre-existing Hearth warnings)
- [x] `bun run format`
- [x] `bun run check:pi-imports`
- [x] `bun run check:pi-rules`
- [x] `git diff --check`
- [x] two independent Codex review passes with all actionable findings resolved