### PR TITLE
feat(pi-harness): run /btw in parallel by default

### DIFF
--- a/pi/README.md
+++ b/pi/README.md
@@ -528,14 +528,25 @@ plugins, and provider-log is a request/status logger (not full logproxy).
 
 ## BTW side questions
 
-`/btw <question>` answers a side question from a stable snapshot of the active
-parent-session leaf without adding the question or answer to the parent model's
-context. With no inline argument, TUI/RPC UI modes open a short input dialog.
-The command requires one of those UI-capable modes; RPC answers are also sent
-through the UI notification channel. Print/JSON mode reports an unsupported-mode
-error instead of producing an invisible answer.
+`/btw <question>` immediately snapshots the active parent-session leaf and
+answers in a read-only child while the parent agent may continue streaming.
+`/btw --wait <question>` instead waits for the parent to settle before taking
+the snapshot. `--wait` is recognized only as the first complete command-line
+token; text entered in the question dialog is always treated literally. With no
+question (`/btw` or `/btw --wait`), TUI/RPC UI modes open that dialog. The
+command requires one of those UI-capable modes; RPC answers are also sent through
+the UI notification channel. Print/JSON mode reports an unsupported-mode error
+instead of producing an invisible answer.
 
-Each invocation creates an in-memory child, copies the parent's resolved
+The default snapshot contains only messages already recorded on the parent's
+active SessionManager leaf when the inline command is accepted, or when the
+question dialog returns. It excludes partial streaming assistant content and
+assistant responses, tool results, steering, or follow-ups recorded after that
+point. Settled mode includes entries recorded through the idle boundary. In
+both modes, the copied question and answer remain outside the parent model's
+context.
+
+Each invocation creates an in-memory child, copies the snapshot's resolved
 (compaction-aware) messages, current model/thinking level, and system prompt,
 and disposes the child immediately after the answer. The child loads no
 extensions, skills, prompt templates, themes, or newly discovered context
@@ -546,15 +557,22 @@ same filesystem read scope as the parent session (this is a read-only boundary,
 not a filesystem sandbox). The `grep`/`find` wrappers are deliberately omitted
 because they can auto-install missing `rg`/`fd` binaries. `bash`, `edit`, and
 `write` are explicitly denied and the active set is checked before the model
-runs.
+runs. The conversation snapshot is not a filesystem snapshot: `read` and `ls`
+inspect the same live workspace as the parent and may observe state before,
+after, or during its concurrent file updates. Parent and child also make
+concurrent requests to the selected
+provider/model, so provider concurrency limits, rate limits, and quota apply to
+both; either request can fail or be cancelled without aborting the other.
 
 Successful Q/A records are appended as custom entries in the parent session.
 They remain visible after resuming that parent (hidden records are replayed
 after parent compaction) but are never sent to its LLM, and no independently
 resumable child session or child file is created. Stored and rendered fields are
-terminal-control sanitized. Deleting the parent session therefore deletes BTW
-history with it. BTW is not registered inside `PI_HARNESS_CHILD=1` child
-profiles, and one parent session runs at most one BTW invocation at a time.
+terminal-control sanitized. A persistent parent must already contain one
+completed assistant response so this history can be durably retained. Deleting
+the parent session therefore deletes BTW history with it. BTW is not registered
+inside `PI_HARNESS_CHILD=1` child profiles, and one parent session runs at most
+one BTW invocation at a time.
 Cancel a slow BTW request with `/btw-cancel` or `Ctrl+Alt+B`; parent session
 shutdown also aborts and disposes the child.
 

--- a/pi/extensions/pi-harness/features/btw/index.ts
+++ b/pi/extensions/pi-harness/features/btw/index.ts
@@ -78,6 +78,11 @@ interface BtwHistoryData {
   createdAt: number;
 }
 
+interface BtwInvocation {
+  mode: "parallel" | "settled";
+  question: string;
+}
+
 interface BtwSnapshot {
   cwd: string;
   parentSession?: string;
@@ -190,6 +195,15 @@ const assertQuestion = (question: string): void => {
   if (byteLength(question) > QUESTION_MAX_BYTES) {
     throw new Error(`BTW question exceeds ${QUESTION_MAX_BYTES} bytes`);
   }
+};
+
+const parseBtwInvocation = (args: string): BtwInvocation => {
+  const trimmed = args.trim();
+  const settled = /^--wait(?:\s+([\s\S]*))?$/u.exec(trimmed);
+  if (settled !== null) {
+    return { mode: "settled", question: settled[1]?.trim() ?? "" };
+  }
+  return { mode: "parallel", question: trimmed };
 };
 
 const seedSessionManager = (
@@ -401,13 +415,47 @@ const waitForIdleOrAbort = async (
   }
 };
 
+const captureSnapshot = (
+  pi: PiLike,
+  ctx: ExtensionCommandContext,
+  signal: BtwCancellationSignal,
+): BtwSnapshot => {
+  const { model } = ctx;
+  if (!model) throw new Error("No model selected for BTW");
+
+  // Keep all parent reads in one synchronous section. In particular, clone the
+  // resolved messages before the parent can append its in-flight response.
+  const parentSession = ctx.sessionManager.getSessionFile();
+  const parentEntries = ctx.sessionManager.getEntries();
+  const leafId = ctx.sessionManager.getLeafId();
+  const resolved = buildSessionContext(parentEntries, leafId);
+  const systemPrompt = ctx.getSystemPrompt();
+  const thinkingLevel = pi.getThinkingLevel();
+  const hasAssistant = parentEntries.some(
+    (entry) => entry.type === "message" && entry.message.role === "assistant",
+  );
+  if (parentSession !== undefined && !hasAssistant) {
+    throw new Error(
+      "BTW history is not durable until the parent completes its first assistant response",
+    );
+  }
+
+  return {
+    cwd: ctx.cwd,
+    parentSession,
+    systemPrompt,
+    messages: structuredClone(resolved.messages),
+    model,
+    modelRegistry: ctx.modelRegistry,
+    thinkingLevel,
+    signal,
+  };
+};
+
 const readQuestion = async (
-  args: string,
   ctx: ExtensionCommandContext,
   cancellation: BtwCancellationSignal,
 ): Promise<string | undefined> => {
-  const inline = args.trim();
-  if (inline !== "") return inline;
   if (!ctx.hasUI) {
     throw new Error("Usage: /btw <question> (interactive input unavailable)");
   }
@@ -471,6 +519,7 @@ const setupBtw = (
 
   pi.on("session_start", () => {
     sessionGeneration += 1;
+    activeAbort?.abort();
     requestHearthService();
   });
   pi.on("session_before_tree", () => {
@@ -564,9 +613,9 @@ const setupBtw = (
 
   pi.registerCommand("btw", {
     description:
-      "Ask a read-only side question without changing parent context",
+      "Ask a parallel read-only side question (--wait for settled context)",
     handler: async (args, ctx) => {
-      const { hasUI, ui, mode } = ctx;
+      const { hasUI, ui, mode: uiMode } = ctx;
       if (running) {
         if (hasUI) ui.notify("A BTW question is already running", "warning");
         return;
@@ -587,17 +636,29 @@ const setupBtw = (
         running = false;
       };
 
+      const invocation = parseBtwInvocation(args);
       let question: string;
+      let parallelSnapshot: BtwSnapshot | undefined;
       try {
         if (!hasUI) throw new Error("BTW requires TUI or RPC UI mode");
-        const input = await readQuestion(args, ctx, invocationAbort.signal);
+        const input =
+          invocation.question === ""
+            ? await readQuestion(ctx, invocationAbort.signal)
+            : invocation.question;
         if (input === undefined) {
+          releaseInvocation();
+          return;
+        }
+        if (invocationAbort.signal.aborted || invocationIsStale()) {
           releaseInvocation();
           return;
         }
         question = stripTerminalControls(input).trim();
         assertQuestion(question);
         if (!ctx.model) throw new Error("No model selected for BTW");
+        if (invocation.mode === "parallel") {
+          parallelSnapshot = captureSnapshot(pi, ctx, invocationAbort.signal);
+        }
       } catch (error) {
         releaseInvocation();
         if (!hasUI) throw error;
@@ -613,47 +674,29 @@ const setupBtw = (
       const operation = Promise.resolve().then(async () => {
         let statusSet = false;
         try {
-          if (!ctx.isIdle()) {
-            ui.notify("Waiting for the parent session to settle...", "info");
+          let snapshot = parallelSnapshot;
+          if (invocation.mode === "settled") {
+            if (!ctx.isIdle()) {
+              ui.notify("Waiting for the parent session to settle...", "info");
+            }
+            while (!ctx.isIdle()) {
+              const aborted = await waitForIdleOrAbort(
+                ctx,
+                invocationAbort.signal,
+              );
+              if (aborted || invocationIsStale()) return;
+            }
+            if (invocationAbort.signal.aborted || invocationIsStale()) return;
+            snapshot = captureSnapshot(pi, ctx, invocationAbort.signal);
+          } else if (invocationAbort.signal.aborted || invocationIsStale()) {
+            return;
           }
-          while (!ctx.isIdle()) {
-            const aborted = await waitForIdleOrAbort(
-              ctx,
-              invocationAbort.signal,
-            );
-            if (aborted || invocationIsStale()) return;
-          }
-          if (invocationAbort.signal.aborted || invocationIsStale()) return;
-          if (!ctx.model) throw new Error("No model selected for BTW");
-
-          const parentSession = ctx.sessionManager.getSessionFile();
-          const parentEntries = ctx.sessionManager.getEntries();
-          const hasAssistant = parentEntries.some(
-            (entry) =>
-              entry.type === "message" && entry.message.role === "assistant",
-          );
-          if (parentSession !== undefined && !hasAssistant) {
-            throw new Error(
-              "BTW history is not durable until the parent completes its first assistant response",
-            );
+          if (snapshot === undefined) {
+            throw new Error("BTW snapshot is unavailable");
           }
 
           ui.setStatus(STATUS_KEY, "btw: answering");
           statusSet = true;
-          const resolved = buildSessionContext(
-            parentEntries,
-            ctx.sessionManager.getLeafId(),
-          );
-          const snapshot: BtwSnapshot = {
-            cwd: ctx.cwd,
-            parentSession,
-            systemPrompt: ctx.getSystemPrompt(),
-            messages: structuredClone(resolved.messages),
-            model: ctx.model,
-            modelRegistry: ctx.modelRegistry,
-            thinkingLevel: pi.getThinkingLevel(),
-            signal: invocationAbort.signal,
-          };
           const rawAnswer = await answerQuestion(snapshot, question);
           if (invocationAbort.signal.aborted || invocationIsStale()) return;
           const answer = stripTerminalControls(rawAnswer.trim()).trim();
@@ -673,7 +716,7 @@ const setupBtw = (
             createdAt: now(),
           };
           pi.appendEntry<BtwHistoryData>(HISTORY_TYPE, record);
-          if (mode === "rpc") {
+          if (uiMode === "rpc") {
             ui.notify(`BTW\nQ: ${record.question}\n\n${record.answer}`, "info");
           }
         } catch (error) {
@@ -704,12 +747,15 @@ export {
   BTW_DENIED_TOOLS,
   BtwCancellationController,
   type BtwFeatureDependencies,
+  type BtwInvocation,
   type BtwForkDependencies,
   type BtwHistoryData,
   type BtwSnapshot,
   BTW_READ_ONLY_TOOLS,
+  captureSnapshot,
   ERROR_MAX_BYTES,
   HISTORY_TYPE,
+  parseBtwInvocation,
   QUESTION_MAX_BYTES,
   setupBtw as default,
   truncateUtf8,

--- a/tests/pi-harness/btw.test.ts
+++ b/tests/pi-harness/btw.test.ts
@@ -28,6 +28,7 @@ import setupBtw, {
   BTW_READ_ONLY_TOOLS,
   ERROR_MAX_BYTES,
   HISTORY_TYPE,
+  parseBtwInvocation,
   QUESTION_MAX_BYTES,
   truncateUtf8,
 } from "../../pi/extensions/pi-harness/features/btw/index";
@@ -82,6 +83,17 @@ const assistantMessage = (
   },
   stopReason,
   timestamp: 2,
+});
+
+const toolResultMessage = (
+  text: string,
+): Extract<AgentMessage, { role: "toolResult" }> => ({
+  role: "toolResult",
+  toolCallId: "tool-1",
+  toolName: "read",
+  content: [{ type: "text", text }],
+  isError: false,
+  timestamp: 3,
 });
 
 interface ChildHarness {
@@ -200,6 +212,43 @@ const snapshot = (): BtwSnapshot => ({
   model: parentModel,
   modelRegistry: {} as ModelRegistry,
   thinkingLevel: "low",
+});
+
+describe("BTW invocation parser", () => {
+  test("treats only a leading complete --wait token as settled mode", () => {
+    expect(parseBtwInvocation("")).toEqual({
+      mode: "parallel",
+      question: "",
+    });
+    expect(parseBtwInvocation("  side question  ")).toEqual({
+      mode: "parallel",
+      question: "side question",
+    });
+    expect(parseBtwInvocation("--wait")).toEqual({
+      mode: "settled",
+      question: "",
+    });
+    expect(parseBtwInvocation("  --wait   settled question  ")).toEqual({
+      mode: "settled",
+      question: "settled question",
+    });
+    expect(parseBtwInvocation("--wait\nmultiline question")).toEqual({
+      mode: "settled",
+      question: "multiline question",
+    });
+    expect(parseBtwInvocation("--waiting is literal")).toEqual({
+      mode: "parallel",
+      question: "--waiting is literal",
+    });
+    expect(parseBtwInvocation("--wait=literal")).toEqual({
+      mode: "parallel",
+      question: "--wait=literal",
+    });
+    expect(parseBtwInvocation("question --wait")).toEqual({
+      mode: "parallel",
+      question: "question --wait",
+    });
+  });
 });
 
 describe("BTW read-only fork runner", () => {
@@ -521,7 +570,7 @@ const commandContext = (
 };
 
 describe("BTW parent command", () => {
-  test("waits for a stable snapshot and retains Q/A only as a parent custom entry", async () => {
+  test("starts from an immediate snapshot and retains Q/A only as a parent custom entry", async () => {
     const harness = commandHarness();
     const context = commandContext();
     let received: BtwSnapshot | undefined;
@@ -538,7 +587,7 @@ describe("BTW parent command", () => {
     await harness.command().handler("  side question  ", context.ctx);
     await waitFor(() => harness.entries.length === 1);
 
-    expect(context.order).toEqual(["wait", "answer"]);
+    expect(context.order).toEqual(["answer"]);
     expect(received?.messages).toEqual([userMessage("main question")]);
     expect(received?.systemPrompt).toBe("current system");
     expect(received?.thinkingLevel).toBe("high");
@@ -565,6 +614,34 @@ describe("BTW parent command", () => {
     expect(
       buildSessionContext(context.sessionManager.getEntries()).messages,
     ).toEqual([userMessage("main question")]);
+  });
+
+  test("freezes an inline default snapshot before yielding to parent updates", async () => {
+    const harness = commandHarness();
+    const context = commandContext({ idle: false });
+    let received: BtwSnapshot | undefined;
+    setupBtw(harness.pi, {
+      answerQuestion: async (value) => {
+        received = value;
+        return "frozen answer";
+      },
+    });
+
+    const invocation = harness.command().handler("question", context.ctx);
+    context.sessionManager.appendMessage(
+      assistantMessage("assistant completed after acceptance"),
+    );
+    context.sessionManager.appendMessage(
+      toolResultMessage("tool result completed after acceptance"),
+    );
+    context.sessionManager.appendMessage(
+      userMessage("follow-up added after acceptance"),
+    );
+    await invocation;
+    await waitFor(() => harness.entries.length === 1);
+
+    expect(received?.messages).toEqual([userMessage("main question")]);
+    expect(context.order).toEqual([]);
   });
 
   test("replays hidden history after parent compaction", async () => {
@@ -596,7 +673,7 @@ describe("BTW parent command", () => {
   test("uses UI input when args are empty and reports missing model without running", async () => {
     const harness = commandHarness();
     const context = commandContext();
-    context.ctx.ui.input = async () => "from dialog";
+    context.ctx.ui.input = async () => "--wait remains a literal question";
     let questions: string[] = [];
     setupBtw(harness.pi, {
       answerQuestion: async (_snapshot, question) => {
@@ -606,7 +683,24 @@ describe("BTW parent command", () => {
     });
     await harness.command().handler("", context.ctx);
     await waitFor(() => questions.length === 1);
-    expect(questions).toEqual(["from dialog"]);
+    expect(questions).toEqual(["--wait remains a literal question"]);
+    expect(context.order).toEqual([]);
+
+    const settledHarness = commandHarness();
+    const settled = commandContext({ idle: false });
+    settled.ctx.ui.input = async () => "settled from dialog";
+    const settledQuestions: string[] = [];
+    setupBtw(settledHarness.pi, {
+      answerQuestion: async (_snapshot, question) => {
+        settled.order.push("answer");
+        settledQuestions.push(question);
+        return "ok";
+      },
+    });
+    await settledHarness.command().handler("--wait", settled.ctx);
+    await waitFor(() => settledQuestions.length === 1);
+    expect(settledQuestions).toEqual(["settled from dialog"]);
+    expect(settled.order).toEqual(["wait", "answer"]);
 
     const noModelHarness = commandHarness();
     const noModel = commandContext();
@@ -633,25 +727,36 @@ describe("BTW parent command", () => {
     expect(noUiHarness.entries).toHaveLength(0);
   });
 
-  test("rechecks idleness before taking the synchronous snapshot", async () => {
+  test("settled mode rechecks idleness before taking its snapshot", async () => {
     const harness = commandHarness();
     const context = commandContext({ idle: false });
     let waits = 0;
     context.ctx.waitForIdle = async () => {
       waits += 1;
       context.order.push("wait");
+      if (waits === 2) {
+        context.sessionManager.appendMessage(
+          userMessage("added while settling"),
+        );
+      }
     };
     context.ctx.isIdle = () => waits >= 2;
+    let received: BtwSnapshot | undefined;
     setupBtw(harness.pi, {
-      answerQuestion: async () => {
+      answerQuestion: async (snapshot) => {
+        received = snapshot;
         context.order.push("answer");
         return "ok";
       },
     });
 
-    await harness.command().handler("question", context.ctx);
+    await harness.command().handler("--wait question", context.ctx);
     await waitFor(() => context.order.includes("answer"));
     expect(context.order).toEqual(["wait", "wait", "answer"]);
+    expect(received?.messages).toEqual([
+      userMessage("main question"),
+      userMessage("added while settling"),
+    ]);
   });
 
   test("cancellation releases a permanently pending idle wait", async () => {
@@ -674,7 +779,7 @@ describe("BTW parent command", () => {
         },
       });
 
-      await harness.command().handler("question", context.ctx);
+      await harness.command().handler("--wait question", context.ctx);
       await waitStarted;
       const completion =
         trigger === "command"
@@ -811,6 +916,43 @@ describe("BTW parent command", () => {
     expect(harness.entries).toHaveLength(0);
   });
 
+  test("aborts an in-flight child when a replacement session starts", async () => {
+    const harness = commandHarness();
+    const context = commandContext({ idle: false });
+    let started!: () => void;
+    const hasStarted = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    let aborted = false;
+    let calls = 0;
+    setupBtw(harness.pi, {
+      answerQuestion: async (snapshot) => {
+        calls += 1;
+        if (calls > 1) return "fresh answer";
+        started();
+        return new Promise<string>((_resolve, reject) => {
+          snapshot.signal?.onAbort(() => {
+            aborted = true;
+            reject(new Error("replaced"));
+          });
+        });
+      },
+    });
+
+    const invocation = harness.command().handler("question", context.ctx);
+    await hasStarted;
+    await invocation;
+    await harness.emitSessionStart();
+    await waitFor(() => aborted);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(harness.entries).toHaveLength(0);
+
+    const freshContext = commandContext({ idle: true });
+    await harness.command().handler("fresh question", freshContext.ctx);
+    await waitFor(() => harness.entries.length === 1);
+    expect(calls).toBe(2);
+  });
+
   test("drops an answer when parent tree navigation changes the active branch", async () => {
     const harness = commandHarness();
     const context = commandContext({ idle: true });
@@ -872,6 +1014,184 @@ describe("BTW parent command", () => {
       if (sessionFile === undefined) throw new Error("missing session file");
       const persisted = await readFile(sessionFile, "utf8");
       expect(persisted).toContain(`"customType":"${HISTORY_TYPE}"`);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps a real parent session linear when BTW finishes during streaming", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "pi-btw-concurrent-"));
+    try {
+      const sessionManager = SessionManager.create("/repo", directory);
+      sessionManager.appendMessage(userMessage("completed parent prompt"));
+      sessionManager.appendMessage(assistantMessage("completed parent answer"));
+      const streamingPromptId = sessionManager.appendMessage(
+        userMessage("streaming parent prompt"),
+      );
+      const beforeBtw = structuredClone(
+        sessionManager.buildSessionContext().messages,
+      );
+
+      const context = commandContext({ idle: false });
+      Object.assign(context.ctx, { sessionManager });
+      const harness = commandHarness((customType, data) => {
+        sessionManager.appendCustomEntry(customType, data);
+      });
+      let received: BtwSnapshot | undefined;
+      setupBtw(harness.pi, {
+        answerQuestion: async (snapshot) => {
+          received = snapshot;
+          return "concurrent side answer";
+        },
+      });
+
+      await harness.command().handler("parallel side question", context.ctx);
+      await waitFor(() => harness.entries.length === 1);
+
+      expect(context.order).toEqual([]);
+      expect(received?.messages).toEqual(beforeBtw);
+      expect(sessionManager.buildSessionContext().messages).toEqual(beforeBtw);
+      const customEntry = sessionManager.getBranch().at(-1);
+      if (customEntry?.type !== "custom") {
+        throw new Error("missing concurrent BTW history entry");
+      }
+      expect(customEntry.parentId).toBe(streamingPromptId);
+      const history = customEntry.data as BtwHistoryData;
+
+      const completedStreamingAnswer = assistantMessage(
+        "completed streaming answer",
+      );
+      const parentAnswerId = sessionManager.appendMessage(
+        completedStreamingAnswer,
+      );
+      const completedToolResult = toolResultMessage(
+        "completed streaming tool result",
+      );
+      const toolResultId = sessionManager.appendMessage(completedToolResult);
+      const branch = sessionManager.getBranch();
+      const parentAnswerEntry = sessionManager.getEntry(parentAnswerId);
+      expect(parentAnswerEntry?.parentId).toBe(customEntry.id);
+      expect(sessionManager.getEntry(toolResultId)?.parentId).toBe(
+        parentAnswerId,
+      );
+      expect(sessionManager.getLeafId()).toBe(toolResultId);
+      expect(branch.map((entry) => entry.type)).toEqual([
+        "message",
+        "message",
+        "message",
+        "custom",
+        "message",
+        "message",
+      ]);
+      expect(
+        branch.flatMap((entry) =>
+          entry.type === "message" ? [entry.message] : [],
+        ),
+      ).toEqual([...beforeBtw, completedStreamingAnswer, completedToolResult]);
+      const parentContext = sessionManager.buildSessionContext().messages;
+      expect(parentContext).toEqual([
+        ...beforeBtw,
+        completedStreamingAnswer,
+        completedToolResult,
+      ]);
+      expect(JSON.stringify(parentContext)).not.toContain(
+        "parallel side question",
+      );
+      expect(JSON.stringify(parentContext)).not.toContain(
+        "concurrent side answer",
+      );
+
+      const tree = sessionManager.getTree();
+      expect(tree).toHaveLength(1);
+      let [node] = tree;
+      let nodeCount = 0;
+      while (node !== undefined) {
+        nodeCount += 1;
+        expect(node.children.length).toBeLessThanOrEqual(1);
+        [node] = node.children;
+      }
+      expect(nodeCount).toBe(branch.length);
+
+      const sessionFile = sessionManager.getSessionFile();
+      if (sessionFile === undefined) throw new Error("missing session file");
+      const resumed = SessionManager.open(sessionFile, directory);
+      expect(
+        resumed
+          .getBranch()
+          .map(({ id, parentId, type }) => ({ id, parentId, type })),
+      ).toEqual(
+        branch.map(({ id, parentId, type }) => ({ id, parentId, type })),
+      );
+      expect(resumed.getLeafId()).toBe(toolResultId);
+      expect(resumed.buildSessionContext().messages).toEqual(parentContext);
+      expect(
+        resumed
+          .getBranch()
+          .filter(
+            (entry) =>
+              entry.type === "custom" && entry.customType === HISTORY_TYPE,
+          ),
+      ).toHaveLength(1);
+
+      sessionManager.appendCompaction(
+        "compacted parent context",
+        parentAnswerId,
+        10_000,
+      );
+      harness.entries.length = 0;
+      await harness.emitSessionCompact(context.ctx);
+      expect(harness.entries).toHaveLength(1);
+
+      const visibleHistories = sessionManager
+        .buildContextEntries()
+        .filter(
+          (entry) =>
+            entry.type === "custom" &&
+            entry.customType === HISTORY_TYPE &&
+            (entry.data as BtwHistoryData | undefined)?.id === history.id,
+        );
+      const rawHistories = sessionManager
+        .getBranch()
+        .filter(
+          (entry) =>
+            entry.type === "custom" &&
+            entry.customType === HISTORY_TYPE &&
+            (entry.data as BtwHistoryData | undefined)?.id === history.id,
+        );
+      expect(visibleHistories).toHaveLength(1);
+      expect(rawHistories).toHaveLength(2);
+      const compactedContext = sessionManager.buildSessionContext().messages;
+      expect(JSON.stringify(compactedContext)).not.toContain(
+        "parallel side question",
+      );
+      expect(JSON.stringify(compactedContext)).not.toContain(
+        "concurrent side answer",
+      );
+
+      const resumedCompacted = SessionManager.open(sessionFile, directory);
+      expect(
+        resumedCompacted
+          .buildContextEntries()
+          .filter(
+            (entry) =>
+              entry.type === "custom" &&
+              entry.customType === HISTORY_TYPE &&
+              (entry.data as BtwHistoryData | undefined)?.id === history.id,
+          ),
+      ).toHaveLength(1);
+      expect(
+        resumedCompacted
+          .getBranch()
+          .filter(
+            (entry) =>
+              entry.type === "custom" &&
+              entry.customType === HISTORY_TYPE &&
+              (entry.data as BtwHistoryData | undefined)?.id === history.id,
+          ),
+      ).toHaveLength(2);
+      expect(resumedCompacted.buildSessionContext().messages).toEqual(
+        compactedContext,
+      );
     } finally {
       await rm(directory, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- capture the parent active-leaf context immediately and run `/btw` alongside parent streaming by default
- add leading-token `/btw --wait` compatibility mode while preserving cancellation, durability, and read-only isolation
- cover real SessionManager streaming, tool-result, compaction, and resume integrity and document snapshot/provider/filesystem boundaries

## Verification

- `bun test tests/pi-harness/btw.test.ts` (29 pass)
- `bun run check:pi-compat`
- `bun run run-all` (1979 pass, 2 skip, 0 fail)
- Codex design and final diff review (no actionable findings)

Closes #61