### PR TITLE
feat(pi): show BTW answers in a dedicated pane

### DIFF
--- a/pi/README.md
+++ b/pi/README.md
@@ -543,9 +543,13 @@ answers in a read-only child while the parent agent may continue streaming.
 the snapshot. `--wait` is recognized only as the first complete command-line
 token; text entered in the question dialog is always treated literally. With no
 question (`/btw` or `/btw --wait`), TUI/RPC UI modes open that dialog. The
-command requires one of those UI-capable modes; RPC answers are also sent through
-the UI notification channel. Print/JSON mode reports an unsupported-mode error
-instead of producing an invisible answer.
+command requires one of those UI-capable modes. TUI answers open a dedicated
+full-screen pane rather than appearing in the parent transcript; use Up/Down to
+move through older/newer BTW answers on the active branch, PgUp/PgDn or Home/End
+to scroll a long answer, and Escape/Left/b/q to close it. `/btw-history` reopens
+the latest saved answer without making a model request. RPC answers continue to
+use the UI notification channel; `/btw-history` itself is TUI-only. Print/JSON
+mode reports an unsupported-mode error instead of producing an invisible answer.
 
 The default snapshot contains only messages already recorded on the parent's
 active SessionManager leaf when the inline command is accepted, or when the
@@ -573,10 +577,11 @@ concurrent requests to the selected
 provider/model, so provider concurrency limits, rate limits, and quota apply to
 both; either request can fail or be cancelled without aborting the other.
 
-Successful Q/A records are appended as custom entries in the parent session.
-They remain visible after resuming that parent (hidden records are replayed
-after parent compaction) but are never sent to its LLM, and no independently
-resumable child session or child file is created. Stored and rendered fields are
+Successful Q/A records are appended as hidden custom entries in the parent
+session. They are not rendered into the normal transcript, remain available in
+the dedicated pane after resuming that parent (hidden records are replayed after
+parent compaction), and are never sent to its LLM. No independently resumable
+child session or child file is created. Stored and pane-rendered fields are
 terminal-control sanitized. A persistent parent must already contain one
 completed assistant response so this history can be durably retained. Deleting
 the parent session therefore deletes BTW history with it. BTW is not registered

--- a/pi/extensions/pi-harness/features/btw/index.ts
+++ b/pi/extensions/pi-harness/features/btw/index.ts
@@ -18,10 +18,11 @@ import {
   SessionManager,
   SettingsManager,
 } from "@earendil-works/pi-coding-agent";
-import { Text } from "@earendil-works/pi-tui";
+import type { Component, OverlayHandle, TUI } from "@earendil-works/pi-tui";
 import type { TSchema } from "typebox";
 import type { PiLike } from "../../lib/pi-like";
 import { stripTerminalControls } from "../../lib/terminal-text";
+import { BtwAnswerPaneComponent } from "./ui";
 
 const HISTORY_TYPE = "pi-harness:btw";
 const STATUS_KEY = "pi-harness-btw";
@@ -32,6 +33,10 @@ const ANSWER_MAX_BYTES = 64 * 1024;
 const ERROR_MAX_BYTES = 4 * 1024;
 const TRUNCATION_MARKER = "\n\n[BTW answer truncated in parent history.]";
 const ERROR_TRUNCATION_MARKER = "…";
+const EMPTY_OVERLAY_COMPONENT: Component = {
+  render: () => [],
+  invalidate: () => {},
+};
 
 // pi's grep/find wrappers auto-install missing rg/fd binaries. Keep the BTW
 // capability set to built-ins that never perform package or binary installs.
@@ -514,12 +519,138 @@ const setupBtw = (
   let running = false;
   let activeAbort: BtwCancellationController | undefined;
   let activeOperation: Promise<void> | undefined;
+  let paneClose: (() => void) | undefined;
+  let paneHandle: OverlayHandle | undefined;
+  let paneTui: TUI | undefined;
+  let panePromise: Promise<void> | undefined;
   let sessionGeneration = 0;
   let branchGeneration = 0;
+
+  const closePane = (): void => {
+    const close = paneClose;
+    const handle = paneHandle;
+    const tui = paneTui;
+    paneClose = undefined;
+    paneHandle = undefined;
+    paneTui = undefined;
+    if (close === undefined) return;
+    if (handle === undefined || tui === undefined) {
+      close();
+      return;
+    }
+
+    // Pi 0.80's custom-overlay done callback always pops the newest overlay,
+    // not the overlay that owns the callback. Remove our owned overlay by
+    // handle and temporarily put a sentinel on top for done() to consume, so a
+    // newer unrelated overlay survives while Pi still resolves/disposes the
+    // custom component normally.
+    const sentinel = tui.showOverlay(EMPTY_OVERLAY_COMPONENT, {
+      nonCapturing: true,
+    });
+    try {
+      handle.hide();
+      close();
+    } finally {
+      sentinel.hide();
+    }
+  };
+  const openPane = (
+    ctx: ExtensionCommandContext,
+    selected?: BtwHistoryData,
+  ): void => {
+    const histories = new Map<string, BtwHistoryData>();
+    for (const entry of ctx.sessionManager.getBranch()) {
+      if (
+        entry.type === "custom" &&
+        entry.customType === HISTORY_TYPE &&
+        isHistoryData(entry.data)
+      ) {
+        histories.set(entry.data.id, entry.data);
+      }
+    }
+    if (selected !== undefined) histories.set(selected.id, selected);
+    const ordered = [...histories.values()];
+
+    const { ui } = ctx;
+    const selectedRecord = selected ?? ordered.at(-1);
+    if (selectedRecord === undefined) {
+      ui.notify("No BTW answers are available on this branch.", "warning");
+      return;
+    }
+    if (typeof ui.custom !== "function") {
+      ui.notify("BTW answer pane requires custom TUI support.", "warning");
+      return;
+    }
+    closePane();
+
+    let detailPromise: Promise<void>;
+    try {
+      detailPromise = ui.custom<void>(
+        (tui, theme, keybindings, done) => {
+          let closed = false;
+          const close = (): void => {
+            if (closed) return;
+            closed = true;
+            if (paneClose === close) {
+              paneClose = undefined;
+              paneHandle = undefined;
+              paneTui = undefined;
+            }
+            done(undefined);
+          };
+          paneClose = close;
+          paneTui = tui;
+          return new BtwAnswerPaneComponent(
+            ordered,
+            selectedRecord.id,
+            tui,
+            keybindings,
+            closePane,
+            theme,
+          );
+        },
+        {
+          overlay: true,
+          overlayOptions: {
+            width: "100%",
+            maxHeight: "100%",
+            anchor: "center",
+            margin: 0,
+          },
+          onHandle: (handle) => {
+            if (panePromise === detailPromise) paneHandle = handle;
+          },
+        },
+      );
+    } catch (error) {
+      ui.notify(
+        `BTW answer pane could not open: ${errorText(error)}`,
+        "warning",
+      );
+      return;
+    }
+
+    panePromise = detailPromise;
+    void detailPromise
+      .catch((error) => {
+        ui.notify(
+          `BTW answer pane could not open: ${errorText(error)}`,
+          "warning",
+        );
+      })
+      .finally(() => {
+        if (panePromise !== detailPromise) return;
+        panePromise = undefined;
+        paneClose = undefined;
+        paneHandle = undefined;
+        paneTui = undefined;
+      });
+  };
 
   pi.on("session_start", () => {
     sessionGeneration += 1;
     activeAbort?.abort();
+    closePane();
     requestHearthService();
   });
   pi.on("session_before_tree", () => {
@@ -528,10 +659,12 @@ const setupBtw = (
     // answer must never move from its snapshotted branch to another branch.
     branchGeneration += 1;
     activeAbort?.abort();
+    closePane();
   });
   pi.on("session_shutdown", async () => {
     sessionGeneration += 1;
     activeAbort?.abort();
+    closePane();
     const operation = activeOperation;
     await operation;
     unsubscribeHearthReady();
@@ -582,34 +715,19 @@ const setupBtw = (
     description: "Cancel the active BTW side question",
     handler: cancelActive,
   });
-
-  pi.registerEntryRenderer<BtwHistoryData>(
-    HISTORY_TYPE,
-    (entry, { expanded }, theme) => {
-      if (!isHistoryData(entry.data)) {
-        return new Text(
-          theme.fg("warning", "BTW history entry is malformed"),
-          1,
-          0,
-        );
+  pi.registerCommand("btw-history", {
+    description: "Open BTW answer history for the active branch",
+    handler: async (_args, ctx) => {
+      if (ctx.mode !== "tui") {
+        if (!ctx.hasUI) {
+          throw new Error("BTW answer history requires TUI mode");
+        }
+        ctx.ui.notify("BTW answer history requires TUI mode.", "warning");
+        return;
       }
-      const { data } = entry;
-      const question = stripTerminalControls(data.question);
-      const answer = stripTerminalControls(data.answer);
-      const model = stripTerminalControls(data.model);
-      let text = `${theme.fg("accent", theme.bold("BTW"))}\n`;
-      text += `${theme.fg("muted", "Q:")} ${question}\n\n${answer}`;
-      if (expanded) {
-        text += `\n\n${theme.fg(
-          "dim",
-          `${model} · ${new Date(data.createdAt).toLocaleString()}${
-            data.answerTruncated ? " · retained answer truncated" : ""
-          }`,
-        )}`;
-      }
-      return new Text(text, 1, 0);
+      openPane(ctx);
     },
-  );
+  });
 
   pi.registerCommand("btw", {
     description:
@@ -718,6 +836,8 @@ const setupBtw = (
           pi.appendEntry<BtwHistoryData>(HISTORY_TYPE, record);
           if (uiMode === "rpc") {
             ui.notify(`BTW\nQ: ${record.question}\n\n${record.answer}`, "info");
+          } else if (uiMode === "tui") {
+            openPane(ctx, record);
           }
         } catch (error) {
           if (!invocationIsStale() && !invocationAbort.signal.aborted) {

--- a/pi/extensions/pi-harness/features/btw/ui.ts
+++ b/pi/extensions/pi-harness/features/btw/ui.ts
@@ -1,0 +1,277 @@
+import type { ThemeColor } from "@earendil-works/pi-coding-agent";
+import {
+  Box,
+  Container,
+  Text,
+  type Component,
+  truncateToWidth as truncateStyledToWidth,
+} from "@earendil-works/pi-tui";
+import {
+  stripTerminalControls,
+  truncateToWidth,
+  visibleWidth,
+} from "../../lib/terminal-text";
+import type { BtwHistoryData } from "./index";
+
+interface KeybindingsLike {
+  matches(data: string, keybinding: string): boolean;
+}
+
+interface TuiLike {
+  terminal: { rows: number };
+  requestRender(force?: boolean): void;
+}
+
+interface BtwPaneTheme {
+  fg(color: ThemeColor, text: string): string;
+  bg(color: "selectedBg", text: string): string;
+  bold(text: string): string;
+}
+
+const plainTheme: BtwPaneTheme = {
+  fg: (_color, text) => text,
+  bg: (_color, text) => text,
+  bold: (text) => text,
+};
+
+const resolveTheme = (value: unknown): BtwPaneTheme => {
+  if (typeof value !== "object" || value === null) return plainTheme;
+  const candidate = value as Partial<BtwPaneTheme>;
+  return typeof candidate.fg === "function" &&
+    typeof candidate.bg === "function" &&
+    typeof candidate.bold === "function"
+    ? (candidate as BtwPaneTheme)
+    : plainTheme;
+};
+
+const styledLine = (value: string, width: number, suffix = ""): string => {
+  const safeWidth = Math.max(1, width);
+  return value.includes("\u001b")
+    ? truncateStyledToWidth(value, safeWidth, suffix)
+    : truncateToWidth(value, safeWidth, suffix);
+};
+
+const defaultKeyMatches = (data: string, keybinding: string): boolean => {
+  const legacyKeys: Record<string, string[]> = {
+    "tui.editor.cursorLeft": ["left", "\u001b[D"],
+    "tui.editor.cursorLineStart": ["home", "\u001b[H", "\u001b[1~"],
+    "tui.editor.cursorLineEnd": ["end", "\u001b[F", "\u001b[4~"],
+    "tui.select.up": ["up", "\u001b[A"],
+    "tui.select.down": ["down", "\u001b[B"],
+    "tui.select.pageUp": ["pageup", "\u001b[5~"],
+    "tui.select.pageDown": ["pagedown", "\u001b[6~"],
+    "tui.select.cancel": ["escape", "\u001b"],
+  };
+  if (legacyKeys[keybinding]?.includes(data)) return true;
+  if (!data.startsWith("\u001b[")) return false;
+
+  const kittySequence = data.slice(2);
+  const kittyPatterns: Partial<Record<string, RegExp>> = {
+    "tui.editor.cursorLeft": /^1;1(?::[12])?D$/,
+    "tui.editor.cursorLineStart": /^(?:1;1(?::[12])?H|7;1(?::[12])?~)$/,
+    "tui.editor.cursorLineEnd": /^(?:1;1(?::[12])?F|8;1(?::[12])?~)$/,
+    "tui.select.up": /^1;1(?::[12])?A$/,
+    "tui.select.down": /^1;1(?::[12])?B$/,
+    "tui.select.pageUp": /^5;1(?::[12])?~$/,
+    "tui.select.pageDown": /^6;1(?::[12])?~$/,
+    "tui.select.cancel": /^27(?:;1)?(?::[12])?u$/,
+  };
+  return kittyPatterns[keybinding]?.test(kittySequence) ?? false;
+};
+
+const contentLines = (
+  record: BtwHistoryData,
+  width: number,
+  theme: BtwPaneTheme,
+): string[] => {
+  const root = new Container();
+  const metadata = new Box(1, 0, (text) => theme.bg("selectedBg", text));
+  metadata.addChild(
+    new Text(
+      `${theme.fg("accent", theme.bold("Question"))}\n${theme.fg(
+        "text",
+        stripTerminalControls(record.question),
+      )}`,
+      0,
+      0,
+    ),
+  );
+  metadata.addChild(
+    new Text(
+      theme.fg(
+        "muted",
+        `${stripTerminalControls(record.model)} · ${new Date(record.createdAt).toLocaleString()}${
+          record.answerTruncated ? " · retained answer truncated" : ""
+        }`,
+      ),
+      0,
+      0,
+    ),
+  );
+  root.addChild(metadata);
+  root.addChild(new Text(theme.fg("accent", theme.bold("Answer")), 0, 0));
+  const answer = new Box(1, 0);
+  answer.addChild(
+    new Text(theme.fg("text", stripTerminalControls(record.answer)), 0, 0),
+  );
+  root.addChild(answer);
+  return root.render(Math.max(1, width));
+};
+
+/** Full-screen BTW answer viewer with branch-local history navigation. */
+export class BtwAnswerPaneComponent implements Component {
+  private selectedIndex: number;
+  private offset = 0;
+  private lastMaxOffset = 0;
+  private lastViewport = 1;
+  private readonly theme: BtwPaneTheme;
+
+  constructor(
+    private readonly histories: readonly BtwHistoryData[],
+    selectedId: string | undefined,
+    private readonly tui: TuiLike,
+    private readonly keybindings: KeybindingsLike,
+    private readonly onClose: () => void,
+    theme?: unknown,
+  ) {
+    this.theme = resolveTheme(theme);
+    const selectedIndex = histories.findIndex((item) => item.id === selectedId);
+    this.selectedIndex =
+      selectedIndex === -1 ? Math.max(0, histories.length - 1) : selectedIndex;
+  }
+
+  render(width: number): string[] {
+    const safeWidth = Math.max(1, width);
+    const height = Math.max(1, this.tui.terminal.rows);
+    const showTitle = height >= 2;
+    const showHint = height >= 3;
+    const chrome = Number(showTitle) + Number(showHint);
+    const viewport = Math.max(1, height - chrome);
+    this.lastViewport = viewport;
+
+    const selected = this.histories[this.selectedIndex];
+    const allLines =
+      selected === undefined
+        ? new Text(
+            this.theme.fg("warning", "No BTW answers are available."),
+            0,
+            0,
+          ).render(safeWidth)
+        : contentLines(selected, safeWidth, this.theme);
+    this.lastMaxOffset = Math.max(0, allLines.length - viewport);
+    this.offset = Math.min(this.offset, this.lastMaxOffset);
+
+    const visible = allLines.slice(this.offset, this.offset + viewport);
+    while (visible.length < viewport) visible.push("");
+
+    const historyPosition =
+      selected === undefined
+        ? "0/0"
+        : `${this.selectedIndex + 1}/${this.histories.length}`;
+    const title = `${this.theme.fg("toolTitle", this.theme.bold(" BTW answer"))} ${this.theme.fg("muted", historyPosition)} `;
+    const borderWidth = Math.max(1, safeWidth - visibleWidth(title));
+    const border = this.theme.fg("borderMuted", "─".repeat(borderWidth));
+    const first = allLines.length === 0 ? 0 : this.offset + 1;
+    const last = Math.min(allLines.length, this.offset + viewport);
+    const scrollPosition = `${first}-${last}/${allLines.length}`;
+
+    const output: string[] = [];
+    if (showTitle) output.push(styledLine(`${title}${border}`, safeWidth));
+    output.push(...visible.map((item) => styledLine(item, safeWidth)));
+    if (showHint) {
+      const hint = this.theme.fg(
+        "dim",
+        "↑ older  ↓ newer  PgUp/PgDn scroll  Home/End  Esc/←/b close  ",
+      );
+      output.push(
+        styledLine(
+          `${hint}${this.theme.fg("muted", scrollPosition)}`,
+          safeWidth,
+        ),
+      );
+    }
+    return output.slice(0, height);
+  }
+
+  handleInput(data: string): void {
+    if (
+      data === "q" ||
+      data === "b" ||
+      this.matches(data, "tui.select.cancel") ||
+      this.matches(data, "tui.editor.cursorLeft") ||
+      defaultKeyMatches(data, "tui.select.cancel") ||
+      defaultKeyMatches(data, "tui.editor.cursorLeft")
+    ) {
+      this.onClose();
+      return;
+    }
+
+    if (
+      data === "k" ||
+      this.matches(data, "tui.select.up") ||
+      defaultKeyMatches(data, "tui.select.up")
+    ) {
+      this.selectHistory(this.selectedIndex - 1);
+      return;
+    }
+    if (
+      data === "j" ||
+      this.matches(data, "tui.select.down") ||
+      defaultKeyMatches(data, "tui.select.down")
+    ) {
+      this.selectHistory(this.selectedIndex + 1);
+      return;
+    }
+
+    const page = Math.max(1, this.lastViewport - 1);
+    if (
+      this.matches(data, "tui.select.pageUp") ||
+      defaultKeyMatches(data, "tui.select.pageUp")
+    ) {
+      this.offset = Math.max(0, this.offset - page);
+    } else if (
+      this.matches(data, "tui.select.pageDown") ||
+      defaultKeyMatches(data, "tui.select.pageDown")
+    ) {
+      this.offset = Math.min(this.lastMaxOffset, this.offset + page);
+    } else if (
+      this.matches(data, "tui.editor.cursorLineStart") ||
+      defaultKeyMatches(data, "tui.editor.cursorLineStart")
+    ) {
+      this.offset = 0;
+    } else if (
+      this.matches(data, "tui.editor.cursorLineEnd") ||
+      defaultKeyMatches(data, "tui.editor.cursorLineEnd")
+    ) {
+      this.offset = this.lastMaxOffset;
+    } else return;
+    this.tui.requestRender();
+  }
+
+  invalidate(): void {}
+
+  getSelectedId(): string | undefined {
+    return this.histories[this.selectedIndex]?.id;
+  }
+
+  getOffset(): number {
+    return this.offset;
+  }
+
+  private selectHistory(index: number): void {
+    const next = Math.max(0, Math.min(this.histories.length - 1, index));
+    if (next === this.selectedIndex || this.histories.length === 0) return;
+    this.selectedIndex = next;
+    this.offset = 0;
+    this.lastMaxOffset = 0;
+    this.tui.requestRender();
+  }
+
+  private matches(data: string, keybinding: string): boolean {
+    try {
+      return this.keybindings.matches(data, keybinding);
+    } catch {
+      return false;
+    }
+  }
+}

--- a/tests/pi-harness/btw.test.ts
+++ b/tests/pi-harness/btw.test.ts
@@ -8,7 +8,6 @@ import {
   buildSessionContext,
   createEventBus,
   type CreateAgentSessionOptions,
-  type EntryRenderer,
   type ExtensionCommandContext,
   type ExtensionContext,
   type ModelRegistry,
@@ -36,6 +35,8 @@ import { loadConfig } from "../../pi/extensions/pi-harness/config";
 import { setupHarness } from "../../pi/extensions/pi-harness/index";
 import type { PiLike } from "../../pi/extensions/pi-harness/lib/pi-like";
 import { resolvePaths } from "../../pi/extensions/pi-harness/lib/paths";
+import { visibleWidth } from "../../pi/extensions/pi-harness/lib/terminal-text";
+import { BtwAnswerPaneComponent } from "../../pi/extensions/pi-harness/features/btw/ui";
 import { createFakePi } from "./fake-pi";
 
 const parentModel = {
@@ -420,7 +421,7 @@ interface CommandHarness {
   pi: PiLike;
   command: (name?: string) => RegisteredCommand;
   shortcut: (name: string) => (ctx: ExtensionContext) => Promise<void> | void;
-  renderer: () => EntryRenderer<BtwHistoryData>;
+  rendererRegistered(): boolean;
   entries: { customType: string; data: unknown }[];
   emitSessionBeforeTree(): Promise<void>;
   emitSessionCompact(ctx: ExtensionCommandContext): Promise<void>;
@@ -436,7 +437,7 @@ const commandHarness = (
     string,
     (ctx: ExtensionContext) => Promise<void> | void
   >();
-  let renderer: EntryRenderer<BtwHistoryData> | undefined;
+  let rendererRegistrations = 0;
   let compactHandler:
     | ((
         event: { type: string },
@@ -477,11 +478,8 @@ const commandHarness = (
     ) {
       shortcuts.set(name, options.handler);
     },
-    registerEntryRenderer(
-      customType: string,
-      value: EntryRenderer<BtwHistoryData>,
-    ) {
-      if (customType === HISTORY_TYPE) renderer = value;
+    registerEntryRenderer(customType: string) {
+      if (customType === HISTORY_TYPE) rendererRegistrations += 1;
     },
     appendEntry(customType: string, data: unknown) {
       entries.push({ customType, data });
@@ -501,10 +499,7 @@ const commandHarness = (
       if (!shortcut) throw new Error(`${name} shortcut was not registered`);
       return shortcut;
     },
-    renderer: () => {
-      if (!renderer) throw new Error("renderer was not registered");
-      return renderer;
-    },
+    rendererRegistered: () => rendererRegistrations > 0,
     entries,
     emitSessionBeforeTree: async () => {
       await beforeTreeHandler?.();
@@ -521,11 +516,30 @@ const commandHarness = (
   };
 };
 
+interface FakeOverlayHandle {
+  hide(): void;
+  setHidden(hidden: boolean): void;
+  isHidden(): boolean;
+  focus(): void;
+  unfocus(): void;
+  isFocused(): boolean;
+}
+
+interface CustomPaneCall {
+  component: BtwAnswerPaneComponent;
+  options: unknown;
+  isClosed(): boolean;
+  hasHandle(): boolean;
+  isMounted(): boolean;
+}
+
 interface ContextHarness {
   ctx: ExtensionCommandContext;
   order: string[];
   notifications: { message: string; level?: string }[];
   statuses: { key: string; value: string | undefined }[];
+  panes: CustomPaneCall[];
+  mountForeignOverlay(): { isMounted(): boolean };
   sessionManager: SessionManager;
 }
 
@@ -533,7 +547,8 @@ const commandContext = (
   options: {
     hasUI?: boolean;
     idle?: boolean;
-    mode?: "tui" | "rpc";
+    mode?: "tui" | "rpc" | "json" | "print";
+    customUi?: boolean;
   } = {},
 ): ContextHarness => {
   const sessionManager = SessionManager.inMemory("/repo");
@@ -541,7 +556,96 @@ const commandContext = (
   const order: string[] = [];
   const notifications: { message: string; level?: string }[] = [];
   const statuses: { key: string; value: string | undefined }[] = [];
+  const panes: CustomPaneCall[] = [];
+  const overlayStack: FakeOverlayHandle[] = [];
+  const mounted = new Set<FakeOverlayHandle>();
+  let focused: FakeOverlayHandle | undefined;
   let idle = options.idle ?? false;
+
+  const showOverlay = (): FakeOverlayHandle => {
+    let hidden = false;
+    const handle: FakeOverlayHandle = {
+      hide: () => {
+        const index = overlayStack.indexOf(handle);
+        if (index !== -1) overlayStack.splice(index, 1);
+        mounted.delete(handle);
+        if (focused === handle) focused = overlayStack.at(-1);
+      },
+      setHidden: (value) => {
+        hidden = value;
+      },
+      isHidden: () => hidden,
+      focus: () => {
+        focused = handle;
+      },
+      unfocus: () => {
+        if (focused === handle) focused = undefined;
+      },
+      isFocused: () => focused === handle,
+    };
+    overlayStack.push(handle);
+    mounted.add(handle);
+    focused = handle;
+    return handle;
+  };
+  const hideTopOverlay = (): void => {
+    const handle = overlayStack.at(-1);
+    handle?.hide();
+  };
+  const tui = {
+    terminal: { rows: 16 },
+    requestRender: () => {},
+    showOverlay: (_component: unknown, _options?: unknown) => showOverlay(),
+  };
+  const custom = <T>(
+    factory: (
+      value: typeof tui,
+      theme: {
+        fg(color: string, text: string): string;
+        bg(color: string, text: string): string;
+        bold(text: string): string;
+      },
+      keybindings: { matches(data: string, keybinding: string): boolean },
+      done: (result: T) => void,
+    ) => BtwAnswerPaneComponent,
+    customOptions?: unknown,
+  ): Promise<T> =>
+    new Promise<T>((resolve) => {
+      let closed = false;
+      let ownedHandle: FakeOverlayHandle | undefined;
+      const component = factory(
+        tui,
+        {
+          fg: (_color, text) => text,
+          bg: (_color, text) => text,
+          bold: (text) => text,
+        },
+        { matches: () => false },
+        (result) => {
+          if (closed) return;
+          closed = true;
+          hideTopOverlay();
+          resolve(result);
+        },
+      );
+      panes.push({
+        component,
+        options: customOptions,
+        isClosed: () => closed,
+        hasHandle: () => ownedHandle !== undefined,
+        isMounted: () => ownedHandle !== undefined && mounted.has(ownedHandle),
+      });
+      queueMicrotask(() => {
+        if (closed) return;
+        ownedHandle = showOverlay();
+        const onHandle = (
+          customOptions as
+            | { onHandle?: (handle: FakeOverlayHandle) => void }
+            | undefined
+        )?.onHandle;
+        onHandle?.(ownedHandle);
+      });
+    });
   const ctx = {
     cwd: "/repo",
     hasUI: options.hasUI ?? true,
@@ -558,6 +662,7 @@ const commandContext = (
       setStatus: (key: string, value: string | undefined) => {
         statuses.push({ key, value });
       },
+      ...(options.customUi === false ? {} : { custom }),
     },
     isIdle: () => idle,
     waitForIdle: async () => {
@@ -566,8 +671,144 @@ const commandContext = (
     },
     getSystemPrompt: () => "current system",
   } as unknown as ExtensionCommandContext;
-  return { ctx, order, notifications, statuses, sessionManager };
+  return {
+    ctx,
+    order,
+    notifications,
+    statuses,
+    panes,
+    mountForeignOverlay: () => {
+      const handle = showOverlay();
+      return { isMounted: () => mounted.has(handle) };
+    },
+    sessionManager,
+  };
 };
+
+const historyRecord = (
+  id: string,
+  question: string,
+  answer: string,
+  createdAt: number,
+): BtwHistoryData => ({
+  version: 1,
+  id,
+  question,
+  answer,
+  answerTruncated: false,
+  model: "test-provider/test-model",
+  createdAt,
+});
+
+const answerPane = (
+  histories: BtwHistoryData[],
+  selectedId?: string,
+  rows = 10,
+) => {
+  let renders = 0;
+  let closes = 0;
+  const component = new BtwAnswerPaneComponent(
+    histories,
+    selectedId,
+    {
+      terminal: { rows },
+      requestRender: () => {
+        renders += 1;
+      },
+    },
+    { matches: () => false },
+    () => {
+      closes += 1;
+    },
+  );
+  return {
+    component,
+    renderCount: () => renders,
+    closeCount: () => closes,
+  };
+};
+
+describe("BTW answer pane", () => {
+  test("starts on the selected latest answer and switches history with Up/Down", () => {
+    const oldest = historyRecord("oldest", "old question", "old answer", 1);
+    const middle = historyRecord(
+      "middle",
+      "middle question",
+      "middle answer",
+      2,
+    );
+    const latest = historyRecord(
+      "latest",
+      "latest question",
+      "latest answer",
+      3,
+    );
+    const pane = answerPane([oldest, middle, latest], latest.id);
+
+    expect(pane.component.getSelectedId()).toBe("latest");
+    expect(pane.component.render(60).join("\n")).toContain("latest answer");
+
+    pane.component.handleInput("up");
+    expect(pane.component.getSelectedId()).toBe("middle");
+    expect(pane.component.render(60).join("\n")).toContain("middle answer");
+
+    pane.component.handleInput("up");
+    pane.component.handleInput("up");
+    expect(pane.component.getSelectedId()).toBe("oldest");
+    pane.component.handleInput("down");
+    expect(pane.component.getSelectedId()).toBe("middle");
+    expect(pane.renderCount()).toBe(3);
+  });
+
+  test("scrolls long answers with page and boundary keys and resets on history change", () => {
+    const long = historyRecord(
+      "long",
+      "long question",
+      Array.from({ length: 30 }, (_, index) => `answer line ${index}`).join(
+        "\n",
+      ),
+      2,
+    );
+    const pane = answerPane(
+      [historyRecord("short", "short question", "short answer", 1), long],
+      long.id,
+      8,
+    );
+    pane.component.render(40);
+
+    pane.component.handleInput("pagedown");
+    expect(pane.component.getOffset()).toBeGreaterThan(0);
+    pane.component.handleInput("end");
+    expect(pane.component.render(40).join("\n")).toContain("answer line 29");
+    pane.component.handleInput("home");
+    expect(pane.component.getOffset()).toBe(0);
+
+    pane.component.handleInput("pagedown");
+    pane.component.handleInput("up");
+    expect(pane.component.getSelectedId()).toBe("short");
+    expect(pane.component.getOffset()).toBe(0);
+  });
+
+  test("sanitizes and width-bounds content and supports detail-view close keys", () => {
+    const unsafe = historyRecord(
+      "unsafe",
+      "question\u001b]2;owned\u0007safe",
+      "answer\u001b[31m red\u001b[0m 界😀".repeat(8),
+      1,
+    );
+    const pane = answerPane([unsafe], unsafe.id, 12);
+    const lines = pane.component.render(24);
+    expect(lines.join("\n")).not.toContain("\u001b");
+    expect(lines.join("\n")).toContain("questionsafe");
+    expect(lines.every((item) => visibleWidth(item) <= 24)).toBe(true);
+
+    pane.component.handleInput("escape");
+    pane.component.handleInput("left");
+    pane.component.handleInput("b");
+    pane.component.handleInput("q");
+    expect(pane.closeCount()).toBe(4);
+  });
+});
 
 describe("BTW parent command", () => {
   test("starts from an immediate snapshot and retains Q/A only as a parent custom entry", async () => {
@@ -606,7 +847,20 @@ describe("BTW parent command", () => {
       },
     ]);
 
-    // Custom entries are durable/renderable session state, not LLM messages.
+    expect(harness.rendererRegistered()).toBe(false);
+    expect(context.panes).toHaveLength(1);
+    expect(context.panes[0]?.component.getSelectedId()).toBe("btw-1");
+    expect(context.panes[0]?.options).toMatchObject({
+      overlay: true,
+      overlayOptions: {
+        width: "100%",
+        maxHeight: "100%",
+        anchor: "center",
+        margin: 0,
+      },
+    });
+
+    // Custom entries are durable hidden session state, not LLM messages.
     context.sessionManager.appendCustomEntry(
       HISTORY_TYPE,
       harness.entries[0].data,
@@ -614,6 +868,143 @@ describe("BTW parent command", () => {
     expect(
       buildSessionContext(context.sessionManager.getEntries()).messages,
     ).toEqual([userMessage("main question")]);
+  });
+
+  test("loads branch history into the pane and closes it on tree and session changes", async () => {
+    const harness = commandHarness();
+    const context = commandContext({ idle: true });
+    context.sessionManager.appendCustomEntry(
+      HISTORY_TYPE,
+      historyRecord("older", "older question", "older answer", 1),
+    );
+    context.sessionManager.appendCustomEntry(HISTORY_TYPE, {
+      version: 1,
+      id: "malformed",
+      question: "ignored",
+    });
+    let invocation = 0;
+    setupBtw(harness.pi, {
+      now: () => 10 + invocation,
+      createId: () => `current-${++invocation}`,
+      answerQuestion: async () => `current answer ${invocation + 1}`,
+    });
+
+    await harness.command().handler("current question", context.ctx);
+    await waitFor(() => context.panes.length === 1);
+    const [firstPane] = context.panes;
+    await waitFor(() => firstPane?.hasHandle() === true);
+    expect(firstPane?.component.getSelectedId()).toBe("current-1");
+    firstPane?.component.handleInput("up");
+    expect(firstPane?.component.getSelectedId()).toBe("older");
+    expect(firstPane?.component.render(60).join("\n")).toContain(
+      "older answer",
+    );
+
+    const foreignOverlay = context.mountForeignOverlay();
+    expect(foreignOverlay.isMounted()).toBe(true);
+    await harness.emitSessionBeforeTree();
+    expect(firstPane?.isClosed()).toBe(true);
+    expect(firstPane?.isMounted()).toBe(false);
+    expect(foreignOverlay.isMounted()).toBe(true);
+
+    await harness.command().handler("another question", context.ctx);
+    await waitFor(() => context.panes.length === 2);
+    const [, secondPane] = context.panes;
+    await waitFor(() => secondPane?.hasHandle() === true);
+    expect(secondPane?.isClosed()).toBe(false);
+    await harness.emitSessionStart();
+    expect(secondPane?.isClosed()).toBe(true);
+    expect(secondPane?.isMounted()).toBe(false);
+    expect(foreignOverlay.isMounted()).toBe(true);
+  });
+
+  test("reopens persisted history without a model call and preserves branch order", async () => {
+    const harness = commandHarness();
+    const context = commandContext({ idle: true });
+    context.sessionManager.appendCustomEntry(
+      HISTORY_TYPE,
+      historyRecord("first", "first question", "first answer", 100),
+    );
+    context.sessionManager.appendCustomEntry(
+      HISTORY_TYPE,
+      historyRecord("second", "second question", "second answer", 1),
+    );
+    let answerCalls = 0;
+    setupBtw(harness.pi, {
+      answerQuestion: async () => {
+        answerCalls += 1;
+        return "unexpected";
+      },
+    });
+
+    await harness.command("btw-history").handler("", context.ctx);
+    expect(context.panes).toHaveLength(1);
+    const [firstPane] = context.panes;
+    expect(firstPane?.component.getSelectedId()).toBe("second");
+    firstPane?.component.handleInput("up");
+    expect(firstPane?.component.getSelectedId()).toBe("first");
+    firstPane?.component.handleInput("b");
+    expect(firstPane?.isClosed()).toBe(true);
+
+    await harness.command("btw-history").handler("", context.ctx);
+    expect(context.panes).toHaveLength(2);
+    expect(context.panes[1]?.component.getSelectedId()).toBe("second");
+    expect(answerCalls).toBe(0);
+  });
+
+  test("reports unavailable or unsupported BTW history without opening a pane", async () => {
+    const emptyHarness = commandHarness();
+    const emptyContext = commandContext({ idle: true });
+    setupBtw(emptyHarness.pi);
+    await emptyHarness.command("btw-history").handler("", emptyContext.ctx);
+    expect(emptyContext.panes).toHaveLength(0);
+    expect(emptyContext.notifications.at(-1)).toEqual({
+      message: "No BTW answers are available on this branch.",
+      level: "warning",
+    });
+
+    const rpcHarness = commandHarness();
+    const rpcContext = commandContext({ idle: true, mode: "rpc" });
+    rpcContext.sessionManager.appendCustomEntry(
+      HISTORY_TYPE,
+      historyRecord("saved", "question", "answer", 1),
+    );
+    setupBtw(rpcHarness.pi);
+    await rpcHarness.command("btw-history").handler("", rpcContext.ctx);
+    expect(rpcContext.panes).toHaveLength(0);
+    expect(rpcContext.notifications.at(-1)).toEqual({
+      message: "BTW answer history requires TUI mode.",
+      level: "warning",
+    });
+
+    const printHarness = commandHarness();
+    const printContext = commandContext({
+      idle: true,
+      mode: "print",
+      hasUI: false,
+    });
+    setupBtw(printHarness.pi);
+    await expect(
+      printHarness.command("btw-history").handler("", printContext.ctx),
+    ).rejects.toThrow("BTW answer history requires TUI mode");
+  });
+
+  test("warns without mixing the answer into notifications when custom TUI is unavailable", async () => {
+    const harness = commandHarness();
+    const context = commandContext({ idle: true, customUi: false });
+    setupBtw(harness.pi, {
+      answerQuestion: async () => "pane-only answer",
+    });
+
+    await harness.command().handler("question", context.ctx);
+    await waitFor(() => harness.entries.length === 1);
+    expect(context.panes).toHaveLength(0);
+    expect(context.notifications).toEqual([
+      {
+        message: "BTW answer pane requires custom TUI support.",
+        level: "warning",
+      },
+    ]);
   });
 
   test("freezes an inline default snapshot before yielding to parent updates", async () => {
@@ -1337,7 +1728,7 @@ describe("BTW parent command", () => {
     ).toBe(true);
   });
 
-  test("sanitizes terminal controls before persistence and rendering", async () => {
+  test("sanitizes terminal controls before persistence and pane rendering", async () => {
     const harness = commandHarness();
     const context = commandContext({ idle: true });
     setupBtw(harness.pi, {
@@ -1349,21 +1740,10 @@ describe("BTW parent command", () => {
     const data = harness.entries[0].data as BtwHistoryData;
     expect(JSON.stringify(data)).not.toContain("\u001b");
 
-    const component = harness.renderer()(
-      {
-        data: {
-          ...data,
-          answer: "raw\u001b[31mcontrol",
-          model: "model\u001b]2;owned\u0007",
-        },
-      } as never,
-      { expanded: true },
-      {
-        fg: (_color: string, text: string) => text,
-        bold: (text: string) => text,
-      } as never,
-    );
-    expect(component?.render(80).join("\n")).not.toContain("\u001b");
+    await waitFor(() => context.panes.length === 1);
+    const rendered = context.panes[0]?.component.render(80).join("\n") ?? "";
+    expect(rendered).not.toContain("\u001b");
+    expect(rendered).toContain("answersafe");
 
     const emptyHarness = commandHarness();
     const emptyContext = commandContext({ idle: true });
@@ -1417,15 +1797,10 @@ describe("BTW parent command", () => {
     }
   });
 
-  test("renders malformed resumed history defensively", () => {
+  test("does not register a transcript renderer for persisted BTW history", () => {
     const harness = commandHarness();
     setupBtw(harness.pi);
-    const renderer = harness.renderer();
-    const component = renderer({ data: null } as never, { expanded: false }, {
-      fg: (_color: string, text: string) => text,
-      bold: (text: string) => text,
-    } as never);
-    expect(component?.render(80).join("\n")).toContain("malformed");
+    expect(harness.rendererRegistered()).toBe(false);
   });
 });
 
@@ -1438,6 +1813,7 @@ describe("BTW umbrella lifecycle", () => {
     parentConfig.features.workflow = false;
     setupHarness(parent, parentConfig);
     expect(parent.commands.has("btw")).toBe(true);
+    expect(parent.commands.has("btw-history")).toBe(true);
     expect(parent.commands.has("btw-cancel")).toBe(true);
     expect(parent.shortcuts.has("ctrl+alt+b")).toBe(true);
 
@@ -1447,5 +1823,6 @@ describe("BTW umbrella lifecycle", () => {
     childConfig.features.workflow = false;
     setupHarness(child, childConfig);
     expect(child.commands.has("btw")).toBe(false);
+    expect(child.commands.has("btw-history")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- render TUI BTW answers in a dedicated full-screen pane instead of the parent transcript
- navigate branch-local BTW history with Up/Down and reopen saved answers with `/btw-history`
- preserve RPC notifications, durable hidden history, compaction recovery, and safe stacked-overlay lifecycle handling
- add focused UI, persistence, lifecycle, unsupported-mode, and compatibility coverage

## Verification

- `bun test tests/pi-harness/btw.test.ts` — 36 pass
- `bun run tsc`
- `bun run lint` — no warnings in changed files; 9 pre-existing hexadecimal-style warnings in `pi/extensions/hearth-tools/adapters.ts`
- Prettier check for all changed files
- `bun run check:pi-imports`
- `bun run check:pi-compat` — global pi 0.83.0 / local baseline 0.80.7
- `git diff --check`

## Full-suite note

`bun test` reached 1892 pass / 2 skip / 105 fail. The failures are environment-dependent and outside this change: local permission/Ollama judge suites, the real Bash sandbox smoke test, and `Bun.serve({ port: 0 })` logproxy tests failing to bind in the execution sandbox.