### PR TITLE
feat(pi): add sticky conversation viewport

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,10 @@
       },
     },
   },
+  "patchedDependencies": {
+    "@earendil-works/pi-coding-agent@0.83.0": "patches/@earendil-works%2Fpi-coding-agent@0.83.0.patch",
+    "@earendil-works/pi-tui@0.83.0": "patches/@earendil-works%2Fpi-tui@0.83.0.patch",
+  },
   "packages": {
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.1.3", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -16,9 +16,9 @@
         "react": "18.3.1",
       },
       "devDependencies": {
-        "@earendil-works/pi-ai": "0.80.7",
-        "@earendil-works/pi-coding-agent": "0.80.7",
-        "@earendil-works/pi-tui": "0.80.7",
+        "@earendil-works/pi-ai": "0.83.0",
+        "@earendil-works/pi-coding-agent": "0.83.0",
+        "@earendil-works/pi-tui": "0.83.0",
         "@prettier/plugin-oxc": "0.0.4",
         "@tskm/compiler": "0.4.1",
         "@tskm/core": "0.3.0",
@@ -110,13 +110,13 @@
 
     "@corsa-bind/napi-win32-x64-msvc": ["@corsa-bind/napi-win32-x64-msvc@0.35.0", "", { "os": "win32", "cpu": "x64" }, "sha512-m6+2E6cCWNKJfjAe/smuOofJAa2GImL4VYVQu8wQdI1GzdXAxHbXPMlmaYtfROKiObLKz/GaJMTIpaDnSlocEw=="],
 
-    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.80.7", "", { "dependencies": { "@earendil-works/pi-ai": "^0.80.7", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-EFjyAuoz2kn24sR9Q5A86sZCG6mD+nz58DCsA2I2wxgmS50cF1tSLCBOZaHKI5U9Y3pJs4BefeK3LRkB5TdJag=="],
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.83.0", "", { "dependencies": { "@earendil-works/pi-ai": "^0.83.0", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.3.7", "yaml": "2.9.0" } }, "sha512-RorGp9OH5l3ElpuC5a5ZQ2eWcchZGXflXRzVGkV99y3y6tT+LLNyxoYIdVKvTKWEObwhExeQbTH0fI2tE4iX4g=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.7", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-8RLKLwe5TFM9kKFMNu/lTzveduq4GxZbnlG6ba8FAhLeb5wJP4zbj1eBumKBRvggpFQnW5R/Vo2a8zTlHsV9SQ=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.83.0", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.3.7" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-m3IZD4g3er0V8TC9+Vpgw/sjTKqcJlkcIBy/JvsgRubuuik3tAVzyugUg4rVrShIkkOT69mEd34NEqKUIsl6JQ=="],
 
-    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.80.7", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.80.7", "@earendil-works/pi-ai": "^0.80.7", "@earendil-works/pi-tui": "^0.80.7", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-mxq3IClhdgmCrYiKuzKehs4QKCVJgKmlA70nUEzsgeNsGdxriT7o5sKQTCcxzVJkzDRMcHD/8tAP4/eGrV4gKQ=="],
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.83.0", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.83.0", "@earendil-works/pi-ai": "^0.83.0", "@earendil-works/pi-tui": "^0.83.0", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.3.7", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-uYhF+FsZxogoSX/AxBcUdiY+ZklubwaXyAoEGA2eQwsHcyEAhUYIKh/WLXe/a8+k8eTCmxb+ZN2Zo9mzQtzbWw=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.80.7", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-1B2++fLZfgI3XMzW2BTpuDuam2uyHnUUEmsOvi5R0Ne9RAt59WjFV0G8ozX6l1Xafa9P5Y3eT4aDtRr/v/CUTA=="],
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.83.0", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-IoYrb0rORjELmEpNtoCA/U8je3KopMkRAVJRdSzvXRvgb+Huo1gNh8Q5CSZvNOiYtDxJdj2tYZZHZ4B3+IN3hA=="],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
@@ -712,7 +712,7 @@
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
-    "typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
+    "typebox": ["typebox@1.3.7", "", {}, "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg=="],
 
     "undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
 

--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
     "react": "18.3.1"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "0.80.7",
-    "@earendil-works/pi-coding-agent": "0.80.7",
-    "@earendil-works/pi-tui": "0.80.7",
+    "@earendil-works/pi-ai": "0.83.0",
+    "@earendil-works/pi-coding-agent": "0.83.0",
+    "@earendil-works/pi-tui": "0.83.0",
     "@prettier/plugin-oxc": "0.0.4",
     "@tskm/compiler": "0.4.1",
     "@tskm/core": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "check:pi-schemas": "bun scripts/gen-pi-schemas.ts --check",
     "check:pi-compat": "bun scripts/check-pi-compat.ts",
     "check:pi-version": "bun scripts/check-pi-version.ts",
+    "apply:pi-patches": "bun scripts/apply-pi-patches.ts",
     "qualify:pi-permission-judge": "bun scripts/qualify-permission-judge.ts",
     "update:pi": "bun scripts/update-pi.ts",
     "gen:pi-schemas": "bun scripts/gen-pi-schemas.ts",
@@ -55,5 +56,9 @@
     "oxlint": "1.14.0",
     "prettier": "3.6.2",
     "vitest": "3.2.4"
+  },
+  "patchedDependencies": {
+    "@earendil-works/pi-tui@0.83.0": "patches/@earendil-works%2Fpi-tui@0.83.0.patch",
+    "@earendil-works/pi-coding-agent@0.83.0": "patches/@earendil-works%2Fpi-coding-agent@0.83.0.patch"
   }
 }

--- a/patches/@earendil-works%2Fpi-coding-agent@0.83.0.patch
+++ b/patches/@earendil-works%2Fpi-coding-agent@0.83.0.patch
@@ -1,0 +1,77 @@
+diff --git a/dist/modes/interactive/interactive-mode.js b/dist/modes/interactive/interactive-mode.js
+index 462e240c591ec86e57cf5d03ce41110d2e484fc4..97fc287b274760d6b3acccde0aa9777964e46244 100644
+--- a/dist/modes/interactive/interactive-mode.js
++++ b/dist/modes/interactive/interactive-mode.js
+@@ -175,6 +175,7 @@ export class InteractiveMode {
+     autocompleteProviderWrappers = [];
+     fdPath;
+     editorContainer;
++    fixedBottomContainer;
+     footer;
+     footerDataProvider;
+     // Stored so the same manager can be injected into custom editors, selectors, and extension UI.
+@@ -293,6 +294,7 @@ export class InteractiveMode {
+         this.editor = this.defaultEditor;
+         this.editorContainer = new Container();
+         this.editorContainer.addChild(this.editor);
++        this.fixedBottomContainer = new Container();
+         this.footerDataProvider = new FooterDataProvider(this.sessionManager.getCwd());
+         this.footer = new FooterComponent(this.session, this.footerDataProvider);
+         this.footer.setAutoCompactEnabled(this.session.autoCompactionEnabled);
+@@ -487,10 +489,11 @@ export class InteractiveMode {
+         this.ui.addChild(this.pendingMessagesContainer);
+         this.ui.addChild(this.statusContainer);
+         this.renderWidgets(); // Initialize with default spacer
+-        this.ui.addChild(this.widgetContainerAbove);
+-        this.ui.addChild(this.editorContainer);
+-        this.ui.addChild(this.widgetContainerBelow);
+-        this.ui.addChild(this.footer);
++        this.fixedBottomContainer.addChild(this.widgetContainerAbove);
++        this.fixedBottomContainer.addChild(this.editorContainer);
++        this.fixedBottomContainer.addChild(this.widgetContainerBelow);
++        this.fixedBottomContainer.addChild(this.footer);
++        this.ui.setFixedBottom(this.fixedBottomContainer, this.defaultEditor);
+         this.ui.setFocus(this.editor);
+         this.setupKeyHandlers();
+         this.setupEditorSubmitHandler();
+@@ -1582,20 +1585,20 @@ export class InteractiveMode {
+         }
+         // Remove current footer from UI
+         if (this.customFooter) {
+-            this.ui.removeChild(this.customFooter);
++            this.fixedBottomContainer.removeChild(this.customFooter);
+         }
+         else {
+-            this.ui.removeChild(this.footer);
++            this.fixedBottomContainer.removeChild(this.footer);
+         }
+         if (factory) {
+             // Create and add custom footer, passing the data provider
+             this.customFooter = factory(this.ui, theme, this.footerDataProvider);
+-            this.ui.addChild(this.customFooter);
++            this.fixedBottomContainer.addChild(this.customFooter);
+         }
+         else {
+             // Restore built-in footer
+             this.customFooter = undefined;
+-            this.ui.addChild(this.footer);
++            this.fixedBottomContainer.addChild(this.footer);
+         }
+         this.ui.requestRender();
+     }
+@@ -1900,6 +1903,7 @@ export class InteractiveMode {
+             this.editor = this.defaultEditor;
+         }
+         this.editorContainer.addChild(this.editor);
++        this.ui.setViewportPagingFocus(this.editor);
+         this.ui.setFocus(this.editor);
+         this.ui.requestRender();
+     }
+@@ -2102,6 +2106,7 @@ export class InteractiveMode {
+     }
+     setupEditorSubmitHandler() {
+         this.defaultEditor.onSubmit = async (text) => {
++            this.ui.followViewport();
+             text = text.trim();
+             if (!text)
+                 return;

--- a/patches/@earendil-works%2Fpi-tui@0.83.0.patch
+++ b/patches/@earendil-works%2Fpi-tui@0.83.0.patch
@@ -1,0 +1,326 @@
+diff --git a/dist/tui.d.ts b/dist/tui.d.ts
+index 85c381ed471a37d3dbf072705320779a67085b54..796b46170d19859bfbb21b3f127717a7ae4c17ad 100644
+--- a/dist/tui.d.ts
++++ b/dist/tui.d.ts
+@@ -139,7 +139,7 @@ export declare class Container implements Component {
+  */
+ export declare class TUI extends Container {
+     terminal: Terminal;
+-    private previousLines;
++    protected previousLines: string[];
+     private previousKittyImageIds;
+     private previousWidth;
+     private previousHeight;
+@@ -152,7 +152,7 @@ export declare class TUI extends Container {
+     private lastRenderAt;
+     private static readonly MIN_RENDER_INTERVAL_MS;
+     private cursorRow;
+-    private hardwareCursorRow;
++    protected hardwareCursorRow: number;
+     private showHardwareCursor;
+     private clearOnShrink;
+     private maxLinesRendered;
+@@ -167,6 +167,13 @@ export declare class TUI extends Container {
+     private focusOrderCounter;
+     private overlayStack;
+     private overlayFocusRestore;
++    private fixedBottomComponent;
++    private viewportPagingFocus;
++    private viewportOffset;
++    private viewportPageSize;
++    private viewportContentLength;
++    private viewportWidth;
++    private started;
+     constructor(terminal: Terminal, showHardwareCursor?: boolean, logDirectory?: string);
+     get fullRedraws(): number;
+     getShowHardwareCursor(): boolean;
+@@ -178,6 +185,16 @@ export declare class TUI extends Container {
+      * When false, empty rows remain (reduces redraws on slower terminals).
+      */
+     setClearOnShrink(enabled: boolean): void;
++    /**
++     * Reserve a screen-relative bottom area while the normal children render in
++     * an internally scrollable viewport. Passing null restores scrollback mode.
++     */
++    setFixedBottom(component: Component | null, pagingFocus?: Component | null): void;
++    setViewportPagingFocus(component: Component | null): void;
++    getViewportOffset(): number;
++    /** Scroll up with a positive row count and down with a negative count. */
++    scrollViewport(lines: number): void;
++    followViewport(): void;
+     setFocus(component: Component | null): void;
+     private setFocusInternal;
+     private clearOverlayFocusRestore;
+@@ -211,7 +228,8 @@ export declare class TUI extends Container {
+     stop(): void;
+     requestRender(force?: boolean): void;
+     private scheduleRender;
+-    private handleInput;
++    protected handleInput(data: string): void;
++    private consumeViewportInput;
+     private consumeOsc11BackgroundResponse;
+     private consumeTerminalColorSchemeReport;
+     private consumeCellSizeResponse;
+@@ -242,7 +260,10 @@ export declare class TUI extends Container {
+      * @returns Cursor position { row, col } or null if no marker found
+      */
+     private extractCursorPosition;
+-    private doRender;
++    private suppressPartialViewportImages;
++    private clipFixedBottom;
++    private renderFixedViewport;
++    protected doRender(): void;
+     /**
+      * Position the hardware cursor for IME candidate window.
+      * @param cursorPos The cursor position extracted from rendered output, or null
+diff --git a/dist/tui.js b/dist/tui.js
+index 7e6b41a8d95d7707d0e2d160dc64cd4b57fbf37f..6d4ab26e5c07ecc3ede0166f569f0203e0cc869a 100644
+--- a/dist/tui.js
++++ b/dist/tui.js
+@@ -5,11 +5,15 @@ import * as fs from "node:fs";
+ import * as os from "node:os";
+ import * as path from "node:path";
+ import { performance } from "node:perf_hooks";
++import { getKeybindings } from "./keybindings.js";
+ import { isKeyRelease, matchesKey } from "./keys.js";
+ import { isOsc11BackgroundColorResponse, parseOsc11BackgroundColor, parseTerminalColorSchemeReport, } from "./terminal-colors.js";
+ import { deleteKittyImage, getCapabilities, isImageLine, setCellDimensions } from "./terminal-image.js";
+ import { extractSegments, normalizeTerminalOutput, sliceByColumn, sliceWithWidth, visibleWidth } from "./utils.js";
+ const KITTY_SEQUENCE_PREFIX = "\x1b_G";
++const MOUSE_TRACKING_ENABLE = "\x1b[?1000h\x1b[?1006h";
++const MOUSE_TRACKING_DISABLE = "\x1b[?1006l\x1b[?1000l";
++const VIEWPORT_WHEEL_LINES = 3;
+ function parseKittyImageHeader(line) {
+     const sequenceStart = line.indexOf(KITTY_SEQUENCE_PREFIX);
+     if (sequenceStart === -1)
+@@ -138,6 +142,13 @@ export class TUI extends Container {
+     focusOrderCounter = 0;
+     overlayStack = [];
+     overlayFocusRestore = { status: "inactive" };
++    fixedBottomComponent = null;
++    viewportPagingFocus = null;
++    viewportOffset = 0;
++    viewportPageSize = 0;
++    viewportContentLength = 0;
++    viewportWidth = 0;
++    started = false;
+     constructor(terminal, showHardwareCursor, logDirectory) {
+         super();
+         this.terminal = terminal;
+@@ -172,6 +183,42 @@ export class TUI extends Container {
+     setClearOnShrink(enabled) {
+         this.clearOnShrink = enabled;
+     }
++    /**
++     * Reserve a screen-relative bottom area while the normal children render in
++     * an internally scrollable viewport. Passing null restores scrollback mode.
++     */
++    setFixedBottom(component, pagingFocus = null) {
++        const trackingChanged = Boolean(this.fixedBottomComponent) !== Boolean(component);
++        this.fixedBottomComponent = component;
++        this.viewportPagingFocus = component ? pagingFocus : null;
++        this.viewportOffset = 0;
++        this.viewportContentLength = 0;
++        this.viewportWidth = 0;
++        if (this.started && trackingChanged) {
++            this.terminal.write(component ? MOUSE_TRACKING_ENABLE : MOUSE_TRACKING_DISABLE);
++        }
++        this.requestRender(this.started);
++    }
++    setViewportPagingFocus(component) {
++        this.viewportPagingFocus = this.fixedBottomComponent ? component : null;
++    }
++    getViewportOffset() {
++        return this.viewportOffset;
++    }
++    /** Scroll up with a positive row count and down with a negative count. */
++    scrollViewport(lines) {
++        if (!this.fixedBottomComponent || !Number.isFinite(lines) || lines === 0)
++            return;
++        const maxOffset = Math.max(0, this.viewportContentLength - this.viewportPageSize);
++        this.viewportOffset = Math.max(0, Math.min(maxOffset, this.viewportOffset + Math.trunc(lines)));
++        this.requestRender();
++    }
++    followViewport() {
++        if (this.viewportOffset === 0)
++            return;
++        this.viewportOffset = 0;
++        this.requestRender();
++    }
+     setFocus(component) {
+         this.setFocusInternal({ component, overlayFocusRestore: "clear" });
+     }
+@@ -273,7 +320,9 @@ export class TUI extends Container {
+         }
+     }
+     isComponentMounted(component) {
+-        return this.children.some((child) => this.containsComponent(child, component));
++        return (this.children.some((child) => this.containsComponent(child, component)) ||
++            (this.fixedBottomComponent !== null &&
++                this.containsComponent(this.fixedBottomComponent, component)));
+     }
+     containsComponent(root, target) {
+         if (root === target)
+@@ -427,12 +476,17 @@ export class TUI extends Container {
+     }
+     invalidate() {
+         super.invalidate();
++        this.fixedBottomComponent?.invalidate?.();
+         for (const overlay of this.overlayStack)
+             overlay.component.invalidate?.();
+     }
+     start() {
+         this.stopped = false;
++        this.started = true;
+         this.terminal.start((data) => this.handleInput(data), () => this.requestRender());
++        if (this.fixedBottomComponent) {
++            this.terminal.write(MOUSE_TRACKING_ENABLE);
++        }
+         this.terminal.hideCursor();
+         if (this.terminalColorSchemeNotificationsEnabled) {
+             this.terminal.write("\x1b[?2031h");
+@@ -475,6 +529,7 @@ export class TUI extends Container {
+     }
+     stop() {
+         this.stopped = true;
++        this.started = false;
+         if (this.renderTimer) {
+             clearTimeout(this.renderTimer);
+             this.renderTimer = undefined;
+@@ -482,6 +537,9 @@ export class TUI extends Container {
+         if (this.terminalColorSchemeNotificationsEnabled) {
+             this.terminal.write("\x1b[?2031l");
+         }
++        if (this.fixedBottomComponent) {
++            this.terminal.write(MOUSE_TRACKING_DISABLE);
++        }
+         // Move cursor to the end of the content to prevent overwriting/artifacts on exit
+         if (this.previousLines.length > 0) {
+             // Overwrite the inverted cursor with a normal space to clear the artifact
+@@ -608,6 +666,10 @@ export class TUI extends Container {
+                 }
+             }
+         }
++        const activeFocusIsOverlay = this.overlayStack.some((o) => o.component === this.focusedComponent);
++        if (!activeFocusIsOverlay && this.consumeViewportInput(data)) {
++            return;
++        }
+         // Pass input to focused component (including Ctrl+C)
+         // The focused component can decide how to handle Ctrl+C
+         if (this.focusedComponent?.handleInput) {
+@@ -619,6 +681,37 @@ export class TUI extends Container {
+             this.requestRender();
+         }
+     }
++    consumeViewportInput(data) {
++        if (!this.fixedBottomComponent || this.focusedComponent !== this.viewportPagingFocus || isKeyRelease(data))
++            return false;
++        const keybindings = getKeybindings();
++        const maxOffset = Math.max(0, this.viewportContentLength - this.viewportPageSize);
++        if (keybindings.matches(data, "tui.editor.pageUp") &&
++            this.viewportPageSize > 0 &&
++            this.viewportOffset < maxOffset) {
++            this.scrollViewport(this.viewportPageSize);
++            return true;
++        }
++        if (keybindings.matches(data, "tui.editor.pageDown") &&
++            this.viewportPageSize > 0 &&
++            this.viewportOffset > 0) {
++            this.scrollViewport(-this.viewportPageSize);
++            return true;
++        }
++        const mouse = /^\x1b\[<(\d+);\d+;\d+M$/.exec(data);
++        if (!mouse)
++            return false;
++        const button = Number.parseInt(mouse[1], 10) & ~0x1c;
++        if (button === 64) {
++            this.scrollViewport(VIEWPORT_WHEEL_LINES);
++            return true;
++        }
++        if (button === 65) {
++            this.scrollViewport(-VIEWPORT_WHEEL_LINES);
++            return true;
++        }
++        return false;
++    }
+     consumeOsc11BackgroundResponse(data) {
+         if (this.pendingOsc11BackgroundReplies <= 0) {
+             return false;
+@@ -977,6 +1070,69 @@ export class TUI extends Container {
+         }
+         return null;
+     }
++    suppressPartialViewportImages(contentLines, start, end, visibleLines) {
++        for (let index = 0; index < end; index++) {
++            if (!isImageLine(contentLines[index] ?? ""))
++                continue;
++            const blockEnd = index + this.getKittyImageReservedRows(contentLines, index);
++            const overlaps = index < end && blockEnd > start;
++            const fullyVisible = index >= start && blockEnd <= end;
++            if (!overlaps || fullyVisible)
++                continue;
++            const clearStart = Math.max(index, start);
++            const clearEnd = Math.min(blockEnd, end);
++            for (let row = clearStart; row < clearEnd; row++) {
++                visibleLines[row - start] = "";
++            }
++        }
++        return visibleLines;
++    }
++    clipFixedBottom(lines, height) {
++        if (height <= 0)
++            return [];
++        if (lines.length <= height)
++            return lines;
++        const cursorLine = lines.findIndex((line) => line.includes(CURSOR_MARKER));
++        const tailStart = lines.length - height;
++        if (cursorLine < 0 || cursorLine >= tailStart)
++            return lines.slice(tailStart);
++        if (height === 1)
++            return [lines[cursorLine]];
++        return [lines[cursorLine], ...lines.slice(lines.length - height + 1)];
++    }
++    renderFixedViewport(contentLines, width, height) {
++        if (!this.fixedBottomComponent)
++            return contentLines;
++        let fixedLines = this.fixedBottomComponent.render(width);
++        if (fixedLines.length > height) {
++            fixedLines = this.clipFixedBottom(fixedLines, height);
++        }
++        const pageSize = Math.max(0, height - fixedLines.length);
++        const previousContentLength = this.viewportContentLength;
++        const contentDelta = contentLines.length - previousContentLength;
++        if (this.viewportOffset > 0) {
++            if (this.viewportWidth > 0 && this.viewportWidth !== width) {
++                const previousStart = Math.max(0, previousContentLength - this.viewportPageSize - this.viewportOffset);
++                const scaledStart = previousContentLength > 0
++                    ? Math.round((previousStart * contentLines.length) / previousContentLength)
++                    : 0;
++                this.viewportOffset = contentLines.length - pageSize - scaledStart;
++            }
++            else {
++                this.viewportOffset += contentDelta + this.viewportPageSize - pageSize;
++            }
++        }
++        this.viewportContentLength = contentLines.length;
++        this.viewportPageSize = pageSize;
++        this.viewportWidth = width;
++        const maxOffset = Math.max(0, contentLines.length - pageSize);
++        this.viewportOffset = Math.max(0, Math.min(maxOffset, this.viewportOffset));
++        const end = Math.max(0, contentLines.length - this.viewportOffset);
++        const start = Math.max(0, end - pageSize);
++        const visibleLines = this.suppressPartialViewportImages(contentLines, start, end, contentLines.slice(start, end));
++        const padding = Array.from({ length: pageSize - visibleLines.length }, () => "");
++        return [...visibleLines, ...padding, ...fixedLines];
++    }
+     doRender() {
+         if (this.stopped)
+             return;
+@@ -995,6 +1151,7 @@ export class TUI extends Container {
+         };
+         // Render all components to get new lines
+         let newLines = this.render(width);
++        newLines = this.renderFixedViewport(newLines, width, height);
+         // Composite overlays into the rendered lines (before differential compare)
+         if (this.overlayStack.length > 0) {
+             newLines = this.compositeOverlays(newLines, width, height);

--- a/pi/README.md
+++ b/pi/README.md
@@ -24,12 +24,13 @@ child-process behavior): `tests/fixtures/pi-harness/raw/`.
 ## Install
 
 ```bash
-bun install --frozen-lockfile                           # reproducible local test baseline
+bun install --frozen-lockfile                           # reproducible patched local baseline
 bun install -g @earendil-works/pi-coding-agent@0.83.0  # initial known-good global install
+bun run apply:pi-patches                                # pin editor/footer + verify global pi
 bun run src/index.ts install                            # deploys the symlinks
 pi                                                      # /login → provider of choice
 bun run check:pi-compat                                 # compile + offline real-pi RPC smoke
-bun run update:pi                                       # preflight, update, verify, auto-rollback
+bun run update:pi                                       # preflight, update, patch, verify, auto-rollback
 ```
 
 Select `transparent-dark` from `/settings` after installation. The theme keeps
@@ -37,17 +38,43 @@ only the user-message background opaque; tool, skill/custom-message, and
 selection backgrounds use the terminal default background.
 
 The exact versions in `package.json`/`bun.lock` are the **local development
-baseline**, not a global-version allowlist. A newer global pi is accepted when
-its public declarations compile the self-contained extensions and its real CLI
-passes the isolated RPC probe. `check:pi-version` remains as a backward-
-compatible alias for `check:pi-compat`.
+baseline**, not a global-version allowlist. A newer global pi remains compatible
+when its public declarations compile the self-contained extensions and its real
+CLI passes the isolated RPC probe. The sticky viewport is stricter: its two Bun
+`patchedDependencies` target exact package versions, and
+`apply:pi-patches` fails closed on version drift or source mismatch. Refresh and
+requalify both patches before accepting a newer global Pi. The safe updater may
+use an unsupported older installation as its known-good transition source and
+restore that same generation during rollback/recovery; the candidate must have
+an exact patch generation. When the source has a patch generation, retain its
+specification through rollout so automatic rollback can reapply it.
+Before modifying a global package, the applicator validates every target and
+atomically copies each target file onto a private inode; this prevents direct
+patching from mutating Bun cache files through shared hardlinks.
+`check:pi-version` remains as a backward-compatible alias for
+`check:pi-compat`.
+
+The viewport keeps extension widgets, the active editor, and the footer at the
+bottom of the terminal while conversation history scrolls internally. Use
+PageUp/PageDown or the mouse wheel to navigate history; submitting input follows
+the newest output again. Mouse tracking is enabled only while this viewport is
+active and is disabled on shutdown. Hold Shift when selecting terminal text in
+terminals that reserve ordinary dragging for mouse-reporting applications.
 
 Prefer `bun run update:pi` over raw `pi update`. It verifies the current install
-before mutation, locks concurrent updates, runs pi's self-update with the
-captured Bun installation, and checks the candidate. An incompatible candidate
-is automatically reinstalled at the previous version and verified again.
-Rollback is best-effort because Bun's registry/cache can be unavailable; a
-recovery journal and exact manual command are retained when restoration fails.
+and read-only probes its exact patch state before mutation, locks concurrent
+updates, runs pi's self-update with the captured Bun installation, applies the
+exact sticky patches, and checks the candidate. The recovery journal therefore
+preserves whether the source cohort was already patched across an interruption.
+An incompatible or unpatched candidate is automatically reinstalled at the
+previous version, repatched when required, and verified against the full
+recorded package cohort.
+Rollback is best-effort because Bun's registry/cache can be unavailable. When
+restoration fails, the recovery journal retains a forced install of the
+validated top-level package plus every recorded core package at its exact
+version. Rerun `bun run update:pi` when Bun's registry/cache is available; it
+executes that argv without a shell, reapplies required patches, and verifies the
+full restored cohort before clearing the journal.
 The compatibility smoke uses temporary HOME/config/session directories, runs
 no model turn/provider request, and never reads user auth or sessions.
 

--- a/pi/README.md
+++ b/pi/README.md
@@ -25,7 +25,7 @@ child-process behavior): `tests/fixtures/pi-harness/raw/`.
 
 ```bash
 bun install --frozen-lockfile                           # reproducible local test baseline
-bun install -g @earendil-works/pi-coding-agent@0.80.7  # initial known-good global install
+bun install -g @earendil-works/pi-coding-agent@0.83.0  # initial known-good global install
 bun run src/index.ts install                            # deploys the symlinks
 pi                                                      # /login → provider of choice
 bun run check:pi-compat                                 # compile + offline real-pi RPC smoke
@@ -375,7 +375,7 @@ config, a missing/incompatible native addon, or an effective competing override
 for one of the five built-in names or `hearth_graph` terminates pi at startup
 with exit code 1; there is no built-in fallback. Registration restores the prior
 active built-in names, so replacing `grep` does not enable it, then activates the
-new read-only `hearth_graph` tool. Pi 0.80.7 exposes only the first effective tool per
+new read-only `hearth_graph` tool. Pi 0.83.0 exposes only the first effective tool per
 name: a later inert losing registration cannot be enumerated, but it also cannot
 execute. Hearth checks effective ownership before registration, immediately
 after registration, before each agent turn, and again at the tool-call boundary.

--- a/pi/extensions/hearth-tools/adapters.ts
+++ b/pi/extensions/hearth-tools/adapters.ts
@@ -52,7 +52,7 @@ const GLOB_SCAN_MULTIPLIER = 100;
 const MILLISECONDS_PER_SECOND = 1_000;
 const HEARTH_SIGNAL_EXIT_CODE = -1;
 
-// Mirrors pi 0.80.7's bounded image sniffer and supported MIME contract.
+// Mirrors pi's bounded image sniffer and supported MIME contract.
 const IMAGE_TYPE_SNIFF_BYTES = 4_100;
 const ASCII_ENCODING = "ascii";
 const IMAGE_MIME = {

--- a/pi/extensions/pi-harness/lib/pi-like.ts
+++ b/pi/extensions/pi-harness/lib/pi-like.ts
@@ -252,6 +252,8 @@ export interface SessionManagerLike {
   getBranch(): unknown[];
   /** Stable Pi session identifier, including in-memory/no-session runtimes. */
   getSessionId?(): string;
+  /** Active JSONL session path; absent for in-memory/no-session runtimes. */
+  getSessionFile?(): string | undefined;
 }
 
 export interface CtxLike {

--- a/scripts/apply-pi-patches.ts
+++ b/scripts/apply-pi-patches.ts
@@ -1,0 +1,35 @@
+import { resolve } from "node:path";
+import { checkPiCompatibility } from "./pi-compat/index";
+import { discoverPiInstallation } from "./pi-compat/installation";
+import { applyPiPatches } from "./pi-compat/patches";
+import {
+  acquireUpdateLock,
+  assertNoPendingUpdateRecovery,
+  defaultUpdateJournalPath,
+  defaultUpdateLockPath,
+} from "./pi-compat/update-state";
+
+const repoRoot = resolve(import.meta.dir, "..");
+
+try {
+  const lock = await acquireUpdateLock(defaultUpdateLockPath());
+  try {
+    await assertNoPendingUpdateRecovery(defaultUpdateJournalPath());
+    const installation = await discoverPiInstallation();
+    await checkPiCompatibility(repoRoot);
+    const results = await applyPiPatches(installation, {
+      repoRoot,
+      verify: async () => {
+        await checkPiCompatibility(repoRoot);
+      },
+    });
+    console.log(
+      `apply-pi-patches: OK (${results.map(({ packageName, version, status }) => `${packageName}@${version} ${status}`).join(", ")})`,
+    );
+  } finally {
+    await lock.release();
+  }
+} catch (error) {
+  console.error(`apply-pi-patches: FAILED: ${String(error)}`);
+  process.exit(1);
+}

--- a/scripts/pi-compat/patches.ts
+++ b/scripts/pi-compat/patches.ts
@@ -1,0 +1,290 @@
+import { randomUUID } from "node:crypto";
+import {
+  access,
+  copyFile,
+  lstat,
+  readFile,
+  realpath,
+  rename,
+  rm,
+} from "node:fs/promises";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import type { PiInstallation } from "./installation";
+import { runCommand, type CommandResult, type CommandRunner } from "./process";
+
+export interface PiPatchSpec {
+  packageName: string;
+  version: string;
+  file: string;
+}
+
+export interface PiPatchResult {
+  packageName: string;
+  version: string;
+  status: "pending" | "applied" | "already-applied";
+}
+
+export interface ApplyPiPatchesOptions {
+  repoRoot?: string;
+  run?: CommandRunner;
+  specs?: readonly PiPatchSpec[];
+  allowUnsupported?: boolean;
+  checkOnly?: boolean;
+  verify?: () => Promise<void>;
+}
+
+export const PI_RUNTIME_PATCHES: readonly PiPatchSpec[] = [
+  {
+    packageName: "@earendil-works/pi-tui",
+    version: "0.83.0",
+    file: "patches/@earendil-works%2Fpi-tui@0.83.0.patch",
+  },
+  {
+    packageName: "@earendil-works/pi-coding-agent",
+    version: "0.83.0",
+    file: "patches/@earendil-works%2Fpi-coding-agent@0.83.0.patch",
+  },
+];
+
+const succeeded = (result: CommandResult): boolean =>
+  !result.timedOut && result.exitCode === 0;
+
+const failureSummary = (result: CommandResult): string =>
+  (result.stderr || result.stdout || `exit ${result.exitCode ?? "signal"}`)
+    .trim()
+    .slice(0, 2_000);
+
+const checkPatch = async (
+  run: CommandRunner,
+  packageRoot: string,
+  patchPath: string,
+  reverse: boolean,
+): Promise<CommandResult> =>
+  run(
+    [
+      "git",
+      "apply",
+      ...(reverse ? ["--reverse"] : []),
+      "--check",
+      "--whitespace=nowarn",
+      patchPath,
+    ],
+    { cwd: packageRoot, timeoutMs: 30_000, maxOutputBytes: 64 * 1024 },
+  );
+
+interface PatchPlan {
+  spec: PiPatchSpec;
+  packageRoot: string;
+  patchPath: string;
+  targets: string[];
+  status: "pending" | "already-applied";
+}
+
+const isWithin = (root: string, target: string): boolean => {
+  const relation = relative(root, target);
+  return (
+    relation === "" ||
+    (relation !== ".." &&
+      !relation.startsWith(`..${sep}`) &&
+      !isAbsolute(relation))
+  );
+};
+
+const patchTargets = async (
+  packageRoot: string,
+  patchPath: string,
+): Promise<string[]> => {
+  const canonicalRoot = await realpath(packageRoot);
+  const targets = new Set<string>();
+  const source = await readFile(patchPath, "utf8");
+  for (const line of source.split("\n")) {
+    if (!line.startsWith("+++ b/")) continue;
+    const path = line.slice("+++ b/".length).split("\t", 1)[0] ?? "";
+    if (
+      path === "" ||
+      isAbsolute(path) ||
+      path === ".." ||
+      path.startsWith(`..${sep}`)
+    ) {
+      throw new Error(`unsafe sticky patch target: ${path || "empty"}`);
+    }
+    const target = resolve(canonicalRoot, path);
+    if (!isWithin(canonicalRoot, target)) {
+      throw new Error(`sticky patch target escapes package root: ${path}`);
+    }
+    const metadata = await lstat(target);
+    if (!metadata.isFile()) {
+      throw new Error(`sticky patch target is not a regular file: ${path}`);
+    }
+    const canonicalTarget = await realpath(target);
+    if (!isWithin(canonicalRoot, canonicalTarget)) {
+      throw new Error(
+        `sticky patch target resolves outside package root: ${path}`,
+      );
+    }
+    targets.add(canonicalTarget);
+  }
+  if (targets.size === 0) {
+    throw new Error(`sticky patch has no existing file targets: ${patchPath}`);
+  }
+  return [...targets];
+};
+
+const detachFile = async (path: string): Promise<void> => {
+  const temporary = `${path}.pi-patch-${process.pid}-${randomUUID()}.tmp`;
+  try {
+    await copyFile(path, temporary);
+    await rename(temporary, path);
+  } finally {
+    await rm(temporary, { force: true });
+  }
+};
+
+export const applyPiPatches = async (
+  installation: PiInstallation,
+  options: ApplyPiPatchesOptions = {},
+): Promise<PiPatchResult[]> => {
+  const repoRoot = options.repoRoot ?? resolve(import.meta.dir, "../..");
+  const run = options.run ?? runCommand;
+  const specs = options.specs ?? PI_RUNTIME_PATCHES;
+  const selectedSpecs: PiPatchSpec[] = [];
+  const packageNames = new Set(specs.map(({ packageName }) => packageName));
+  for (const packageName of packageNames) {
+    const installed = installation.corePackages[packageName];
+    if (installed === undefined) {
+      throw new Error(`pi patch package is not installed: ${packageName}`);
+    }
+    const matching = specs.filter(
+      (spec) =>
+        spec.packageName === packageName && spec.version === installed.version,
+    );
+    if (matching.length === 0) {
+      if (options.allowUnsupported) return [];
+      const available = specs
+        .filter((spec) => spec.packageName === packageName)
+        .map(({ version }) => version)
+        .join(", ");
+      throw new Error(
+        `no ${packageName} sticky patch for ${installed.version}; available: ${available}`,
+      );
+    }
+    selectedSpecs.push(...matching);
+  }
+
+  const plans: PatchPlan[] = [];
+  // Validate every package and patch before mutating any global package.
+  for (const spec of selectedSpecs) {
+    const installed = installation.corePackages[spec.packageName];
+    if (installed === undefined) {
+      throw new Error(`pi patch package is not installed: ${spec.packageName}`);
+    }
+    const patchPath = join(repoRoot, spec.file);
+    await access(patchPath);
+    const targets = await patchTargets(installed.root, patchPath);
+    const pending = await checkPatch(run, installed.root, patchPath, false);
+    if (succeeded(pending)) {
+      plans.push({
+        spec,
+        packageRoot: installed.root,
+        patchPath,
+        targets,
+        status: "pending",
+      });
+      continue;
+    }
+
+    const alreadyApplied = await checkPatch(
+      run,
+      installed.root,
+      patchPath,
+      true,
+    );
+    if (!succeeded(alreadyApplied)) {
+      throw new Error(
+        `${spec.packageName} ${spec.version} does not match either side of its sticky patch: ${failureSummary(pending)}; reverse: ${failureSummary(alreadyApplied)}`,
+      );
+    }
+    plans.push({
+      spec,
+      packageRoot: installed.root,
+      patchPath,
+      targets,
+      status: "already-applied",
+    });
+  }
+
+  if (options.checkOnly) {
+    return plans.map(({ spec, status }) => ({
+      packageName: spec.packageName,
+      version: spec.version,
+      status: status === "pending" ? "pending" : "already-applied",
+    }));
+  }
+
+  const appliedPlans: PatchPlan[] = [];
+  const detachedTargets = new Set<string>();
+  try {
+    for (const plan of plans) {
+      if (plan.status === "already-applied") continue;
+      for (const target of plan.targets) {
+        if (detachedTargets.has(target)) continue;
+        await detachFile(target);
+        detachedTargets.add(target);
+      }
+      const applied = await run(
+        ["git", "apply", "--whitespace=nowarn", plan.patchPath],
+        {
+          cwd: plan.packageRoot,
+          timeoutMs: 30_000,
+          maxOutputBytes: 64 * 1024,
+        },
+      );
+      if (!succeeded(applied)) {
+        throw new Error(
+          `failed to apply ${plan.spec.packageName} sticky patch: ${failureSummary(applied)}`,
+        );
+      }
+      appliedPlans.push(plan);
+      const verified = await checkPatch(
+        run,
+        plan.packageRoot,
+        plan.patchPath,
+        true,
+      );
+      if (!succeeded(verified)) {
+        throw new Error(
+          `could not verify ${plan.spec.packageName} sticky patch after apply: ${failureSummary(verified)}`,
+        );
+      }
+    }
+    await options.verify?.();
+  } catch (error) {
+    const rollbackFailures: string[] = [];
+    for (const plan of appliedPlans.reverse()) {
+      const rolledBack = await run(
+        ["git", "apply", "--reverse", "--whitespace=nowarn", plan.patchPath],
+        {
+          cwd: plan.packageRoot,
+          timeoutMs: 30_000,
+          maxOutputBytes: 64 * 1024,
+        },
+      );
+      if (!succeeded(rolledBack)) {
+        rollbackFailures.push(
+          `${plan.spec.packageName}: ${failureSummary(rolledBack)}`,
+        );
+      }
+    }
+    const rollbackSuffix =
+      rollbackFailures.length === 0
+        ? ""
+        : `; patch rollback failed: ${rollbackFailures.join("; ")}`;
+    throw new Error(`${String(error)}${rollbackSuffix}`);
+  }
+
+  return plans.map(({ spec, status }) => ({
+    packageName: spec.packageName,
+    version: spec.version,
+    status: status === "pending" ? "applied" : "already-applied",
+  }));
+};

--- a/scripts/pi-compat/update-state.ts
+++ b/scripts/pi-compat/update-state.ts
@@ -1,6 +1,14 @@
+import { createHash, randomUUID } from "node:crypto";
 import { dirname, isAbsolute, join } from "node:path";
 import { homedir, tmpdir } from "node:os";
-import { mkdir, open, readFile, rename, rm, writeFile } from "node:fs/promises";
+import {
+  link,
+  mkdir,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import type { PiCompatibilityResult } from "./index";
 import type { PiInstallation } from "./installation";
 import { runCommand, type CommandResult, type CommandRunner } from "./process";
@@ -13,11 +21,29 @@ interface RecoveryJournal {
   previousVersion: string;
   previousSignature: string;
   rollbackArgv: string[];
+  rollbackPackages?: string[];
+  restorePatches?: boolean;
 }
+
+export type PiPatchPhase =
+  | "preflight"
+  | "candidate"
+  | "rollback"
+  | "recovery"
+  | "unchanged";
+
+export const allowsUnsupportedPatchGeneration = (
+  phase: PiPatchPhase,
+): boolean => phase === "preflight" || phase === "unchanged";
 
 export interface UpdatePiDependencies {
   checkCompatibility(): Promise<PiCompatibilityResult>;
   discover(): Promise<PiInstallation>;
+  inspectPatches?(installation: PiInstallation): Promise<boolean>;
+  applyPatches?(
+    installation: PiInstallation,
+    phase: PiPatchPhase,
+  ): Promise<boolean>;
   run?: CommandRunner;
   lockPath?: string;
   journalPath?: string;
@@ -38,6 +64,17 @@ interface UpdateLock {
   release(): Promise<void>;
 }
 
+export interface UpdateLockPublishState {
+  path: string;
+  publishPath: string;
+  token: string;
+}
+
+export interface UpdateLockTestSeams {
+  afterPublishPrepared?(state: UpdateLockPublishState): void | Promise<void>;
+  afterPublished?(state: UpdateLockPublishState): void | Promise<void>;
+}
+
 const processAlive = (pid: number): boolean => {
   try {
     process.kill(pid, 0);
@@ -47,53 +84,243 @@ const processAlive = (pid: number): boolean => {
   }
 };
 
+const lockOwner = (raw: string): number => Number(raw.split(":", 1)[0]);
+
+const createOwnedLock = async (
+  path: string,
+  pid: number,
+  testSeams?: UpdateLockTestSeams,
+): Promise<UpdateLock> => {
+  const nonce = randomUUID();
+  const state: UpdateLockPublishState = {
+    path,
+    publishPath: `${path}.publish-${pid}-${nonce}`,
+    token: `${pid}:${nonce}\n`,
+  };
+  await writeFile(state.publishPath, state.token, {
+    encoding: "utf8",
+    flag: "wx",
+    mode: 0o600,
+  });
+  await testSeams?.afterPublishPrepared?.(state);
+  try {
+    await link(state.publishPath, path);
+    await testSeams?.afterPublished?.(state);
+  } finally {
+    await rm(state.publishPath, { force: true }).catch(() => undefined);
+  }
+
+  const { token } = state;
+
+  let releasePromise: Promise<void> | undefined;
+  return {
+    release() {
+      releasePromise ??= (async () => {
+        const current = await readFile(path, "utf8").catch(() => undefined);
+        if (current !== token) {
+          throw new Error("pi update lock ownership changed before release");
+        }
+        await rm(path);
+      })();
+      return releasePromise;
+    },
+  };
+};
+
+const acquireUpdateLockInternal = async (
+  path: string,
+  pid: number,
+  depth: number,
+  recoveryRoot: string,
+  testSeams?: UpdateLockTestSeams,
+): Promise<UpdateLock> => {
+  if (depth > 8) {
+    throw new Error("pi update lock recovery nesting exceeds the safety limit");
+  }
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      return await createOwnedLock(path, pid, testSeams);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    }
+
+    let raw: string;
+    try {
+      raw = await readFile(path, "utf8");
+    } catch {
+      throw new Error("pi update lock exists but cannot be verified");
+    }
+    const owner = lockOwner(raw);
+    if (!Number.isInteger(owner) || owner <= 0) {
+      throw new Error("pi update lock exists but has no valid owner pid");
+    }
+    if (processAlive(owner)) {
+      throw new Error(`another pi update is active (pid ${owner})`);
+    }
+
+    const generation = createHash("sha256").update(raw).digest("hex").slice(0, 16);
+    const recoveryPath =
+      depth === 0
+        ? `${recoveryRoot}.recovery-${generation}`
+        : `${recoveryRoot}.recovery-${depth + 1}-${generation}`;
+    const recoveryLock = await acquireUpdateLockInternal(
+      recoveryPath,
+      pid,
+      depth + 1,
+      recoveryRoot,
+      testSeams,
+    );
+    try {
+      const current = await readFile(path, "utf8").catch(() => undefined);
+      if (current !== raw) continue;
+      await rm(path);
+    } finally {
+      await recoveryLock.release();
+    }
+  }
+  throw new Error("could not recover stale pi update lock");
+};
+
 export const acquireUpdateLock = async (
   path: string,
   pid = process.pid,
-): Promise<UpdateLock> => {
-  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
-  for (let attempt = 0; attempt < 2; attempt += 1) {
-    try {
-      const handle = await open(path, "wx", 0o600);
-      await handle.writeFile(`${pid}\n`);
-      await handle.close();
-      let released = false;
-      return {
-        async release() {
-          if (released) return;
-          released = true;
-          await rm(path, { force: true });
-        },
-      };
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-      let owner = Number.NaN;
-      try {
-        const raw = await readFile(path, "utf8");
-        owner = Number(raw.trim());
-      } catch {
-        // Treat an unreadable lock as active rather than deleting blindly.
-      }
-      if (!Number.isInteger(owner) || owner <= 0) {
-        throw new Error("pi update lock exists but has no valid owner pid");
-      }
-      if (processAlive(owner)) {
-        throw new Error(`another pi update is active (pid ${owner})`);
-      }
-      if (attempt === 0) {
-        await rm(path, { force: true });
-        continue;
-      }
-      throw new Error("could not recover stale pi update lock");
-    }
-  }
-  throw new Error("could not acquire pi update lock");
+  testSeams?: UpdateLockTestSeams,
+): Promise<UpdateLock> => acquireUpdateLockInternal(path, pid, 0, path, testSeams);
+
+export const defaultUpdateLockPath = (): string =>
+  join(tmpdir(), `pi-harness-update-${process.getuid?.() ?? "user"}.lock`);
+export const defaultUpdateJournalPath = (): string =>
+  join(homedir(), ".cache", "pi-harness", "pi-update-recovery.json");
+
+const packageNamePattern =
+  /^(?:@[a-z0-9][a-z0-9._~-]*\/)?[a-z0-9][a-z0-9._~-]*$/;
+const packageVersionPattern = /^[0-9A-Za-z][0-9A-Za-z.+_-]*$/;
+const validPackageSpec = (value: string): boolean => {
+  const separator = value.lastIndexOf("@");
+  return (
+    separator > 0 &&
+    packageNamePattern.test(value.slice(0, separator)) &&
+    packageVersionPattern.test(value.slice(separator + 1))
+  );
 };
 
-const defaultLockPath = (): string =>
-  join(tmpdir(), `pi-harness-update-${process.getuid?.() ?? "user"}.lock`);
-const defaultJournalPath = (): string =>
-  join(homedir(), ".cache", "pi-harness", "pi-update-recovery.json");
+interface RecordedSignature {
+  packageRoot: string;
+  binaryRealPath: string;
+  packageName: string;
+  packageVersion: string;
+  core: Record<string, { root: string; version: string }>;
+}
+
+const recordValue = (value: unknown): Record<string, unknown> | undefined =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+
+const parseRecordedSignature = (
+  source: string,
+): RecordedSignature | undefined => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(source);
+  } catch {
+    return undefined;
+  }
+  const value = recordValue(parsed);
+  const coreValue = recordValue(value?.core);
+  if (
+    value === undefined ||
+    coreValue === undefined ||
+    typeof value.packageRoot !== "string" ||
+    !isAbsolute(value.packageRoot) ||
+    typeof value.binaryRealPath !== "string" ||
+    !isAbsolute(value.binaryRealPath) ||
+    typeof value.packageName !== "string" ||
+    !packageNamePattern.test(value.packageName) ||
+    typeof value.packageVersion !== "string" ||
+    !packageVersionPattern.test(value.packageVersion)
+  ) {
+    return undefined;
+  }
+  const coreEntries = Object.entries(coreValue);
+  if (coreEntries.length === 0 || coreEntries.length > 64) return undefined;
+  const core: RecordedSignature["core"] = {};
+  for (const [name, rawPackage] of coreEntries) {
+    const pkg = recordValue(rawPackage);
+    if (
+      !packageNamePattern.test(name) ||
+      pkg === undefined ||
+      typeof pkg.root !== "string" ||
+      !isAbsolute(pkg.root) ||
+      typeof pkg.version !== "string" ||
+      !packageVersionPattern.test(pkg.version)
+    ) {
+      return undefined;
+    }
+    core[name] = { root: pkg.root, version: pkg.version };
+  }
+  const top = core[value.packageName];
+  if (
+    top === undefined ||
+    top.root !== value.packageRoot ||
+    top.version !== value.packageVersion
+  ) {
+    return undefined;
+  }
+  return {
+    packageRoot: value.packageRoot,
+    binaryRealPath: value.binaryRealPath,
+    packageName: value.packageName,
+    packageVersion: value.packageVersion,
+    core,
+  };
+};
+
+const packageSpecsFromSignature = (signature: RecordedSignature): string[] => [
+  `${signature.packageName}@${signature.packageVersion}`,
+  ...Object.entries(signature.core)
+    .filter(([name]) => name !== signature.packageName)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([name, pkg]) => `${name}@${pkg.version}`),
+];
+
+const validRollbackCommand = (
+  value: RecoveryJournal,
+  expectedPackages: string[],
+): boolean => {
+  if (
+    !Array.isArray(value.rollbackArgv) ||
+    value.rollbackArgv.some((item) => typeof item !== "string") ||
+    !isAbsolute(value.rollbackArgv[0] ?? "") ||
+    value.rollbackArgv[1] !== "install" ||
+    value.rollbackArgv[2] !== "-g" ||
+    value.rollbackArgv[3] !== "--ignore-scripts"
+  ) {
+    return false;
+  }
+  if (value.rollbackPackages === undefined) {
+    return (
+      value.rollbackArgv.length === 5 &&
+      value.rollbackArgv[4] === expectedPackages[0]
+    );
+  }
+  return (
+    Array.isArray(value.rollbackPackages) &&
+    value.rollbackPackages.length === expectedPackages.length &&
+    value.rollbackPackages.every(
+      (item, index) =>
+        typeof item === "string" &&
+        validPackageSpec(item) &&
+        item === expectedPackages[index],
+    ) &&
+    value.rollbackArgv.length === 5 + expectedPackages.length &&
+    value.rollbackArgv[4] === "--force" &&
+    value.rollbackArgv
+      .slice(5)
+      .every((item, index) => item === expectedPackages[index])
+  );
+};
 
 const writeJournal = async (
   path: string,
@@ -112,27 +339,52 @@ const readJournal = async (
 ): Promise<RecoveryJournal | undefined> => {
   try {
     const value = JSON.parse(await readFile(path, "utf8")) as RecoveryJournal;
+    const signature =
+      typeof value.previousSignature === "string"
+        ? parseRecordedSignature(value.previousSignature)
+        : undefined;
     if (
       value.schema !== "pi-harness/update-recovery" ||
       value.version !== 1 ||
       typeof value.packageName !== "string" ||
       typeof value.previousVersion !== "string" ||
-      typeof value.previousSignature !== "string" ||
-      !Array.isArray(value.rollbackArgv) ||
-      value.rollbackArgv.some((item) => typeof item !== "string") ||
-      value.rollbackArgv.length !== 5 ||
-      !isAbsolute(value.rollbackArgv[0] ?? "") ||
-      value.rollbackArgv[1] !== "install" ||
-      value.rollbackArgv[2] !== "-g" ||
-      value.rollbackArgv[3] !== "--ignore-scripts" ||
-      value.rollbackArgv[4] !== `${value.packageName}@${value.previousVersion}`
+      signature === undefined ||
+      signature.packageName !== value.packageName ||
+      signature.packageVersion !== value.previousVersion ||
+      (value.restorePatches !== undefined &&
+        typeof value.restorePatches !== "boolean")
     ) {
       throw new Error("invalid pi update recovery journal");
     }
-    return value;
+    const rollbackPackages = packageSpecsFromSignature(signature);
+    if (!validRollbackCommand(value, rollbackPackages)) {
+      throw new Error("invalid pi update recovery journal");
+    }
+    return {
+      ...value,
+      rollbackPackages,
+      rollbackArgv: [
+        value.rollbackArgv[0] ?? "",
+        "install",
+        "-g",
+        "--ignore-scripts",
+        "--force",
+        ...rollbackPackages,
+      ],
+    };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
     throw error;
+  }
+};
+
+export const assertNoPendingUpdateRecovery = async (
+  journalPath = defaultUpdateJournalPath(),
+): Promise<void> => {
+  if ((await readJournal(journalPath)) !== undefined) {
+    throw new Error(
+      "pi update recovery is pending; run `bun run update:pi` before applying patches",
+    );
   }
 };
 
@@ -152,6 +404,17 @@ const installationSignature = (installation: PiInstallation): string =>
     ),
   });
 
+const rollbackPackageSpecs = (installation: PiInstallation): string[] => [
+  `${installation.packageName}@${installation.packageVersion}`,
+  ...Object.entries(installation.corePackages)
+    .filter(([name]) => name !== installation.packageName)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([name, pkg]) => `${name}@${pkg.version}`),
+];
+
+const manualRecoveryFollowUp =
+  "recovery remains journaled; rerun `bun run update:pi` when Bun's registry/cache is available so the exact cohort is restored without a shell, required patches are reapplied, and the result is verified";
+
 const rollback = async (
   journal: RecoveryJournal,
   dependencies: UpdatePiDependencies,
@@ -168,16 +431,25 @@ const rollback = async (
       updated: false,
       rolledBack: false,
       previousVersion: journal.previousVersion,
-      message: `automatic rollback failed: ${result.stderr || result.stdout}`,
+      message: `automatic rollback failed: ${result.stderr || result.stdout}; ${manualRecoveryFollowUp}`,
       manualRecoveryArgv: journal.rollbackArgv,
     };
   }
   try {
+    const restoredInstallation = await dependencies.discover();
+    if (journal.restorePatches === true) {
+      await dependencies.applyPatches?.(restoredInstallation, "rollback");
+    }
     const restored = await dependencies.checkCompatibility();
     if (restored.installation.packageVersion !== journal.previousVersion) {
       throw new Error(
         `restored version ${restored.installation.packageVersion} != ${journal.previousVersion}`,
       );
+    }
+    if (
+      installationSignature(restored.installation) !== journal.previousSignature
+    ) {
+      throw new Error("restored pi package cohort does not match preflight");
     }
     await rm(journalPath, { force: true });
     return {
@@ -194,7 +466,7 @@ const rollback = async (
       updated: false,
       rolledBack: false,
       previousVersion: journal.previousVersion,
-      message: `rollback installed but verification failed: ${String(error)}`,
+      message: `rollback installed but verification failed: ${String(error)}; ${manualRecoveryFollowUp}`,
       manualRecoveryArgv: journal.rollbackArgv,
     };
   }
@@ -204,14 +476,24 @@ export const updatePiSafely = async (
   dependencies: UpdatePiDependencies,
 ): Promise<UpdatePiResult> => {
   const run = dependencies.run ?? runCommand;
-  const lockPath = dependencies.lockPath ?? defaultLockPath();
-  const journalPath = dependencies.journalPath ?? defaultJournalPath();
+  const lockPath = dependencies.lockPath ?? defaultUpdateLockPath();
+  const journalPath =
+    dependencies.journalPath ?? defaultUpdateJournalPath();
   const lock = await acquireUpdateLock(lockPath, dependencies.pid);
   try {
     const unfinished = await readJournal(journalPath);
     if (unfinished !== undefined) {
+      // A pristine-state journal can exist while preflight patching is only
+      // partially applied. Paths and versions cannot prove file-level state,
+      // so always reinstall instead of accepting the current cohort.
+      if (unfinished.restorePatches === false) {
+        return rollback(unfinished, dependencies, run, journalPath);
+      }
       try {
         const current = await dependencies.discover();
+        if (unfinished.restorePatches === true) {
+          await dependencies.applyPatches?.(current, "recovery");
+        }
         const verified = await dependencies.checkCompatibility();
         if (
           installationSignature(current) === unfinished.previousSignature &&
@@ -235,17 +517,24 @@ export const updatePiSafely = async (
       return rollback(unfinished, dependencies, run, journalPath);
     }
 
-    // Establish a known-good rollback target before any global mutation.
-    const preflight = await dependencies.checkCompatibility();
-    const previous = preflight.installation;
+    // Establish a known-good rollback target before any updater mutation,
+    // including application of the exact-version sticky patch. A read-only
+    // probe records whether the source cohort is already fully patched; after
+    // preflight patch verification the journal is rewritten with that result.
+    let preflight = await dependencies.checkCompatibility();
+    let previous = preflight.installation;
+    const restoreExistingPatches =
+      (await dependencies.inspectPatches?.(previous)) ?? false;
+    const rollbackPackages = rollbackPackageSpecs(previous);
     const rollbackArgv = [
       previous.bunExecutable,
       "install",
       "-g",
       "--ignore-scripts",
-      `${previous.packageName}@${previous.packageVersion}`,
+      "--force",
+      ...rollbackPackages,
     ];
-    const journal: RecoveryJournal = {
+    let journal: RecoveryJournal = {
       schema: "pi-harness/update-recovery",
       version: 1,
       createdAt: new Date().toISOString(),
@@ -253,8 +542,28 @@ export const updatePiSafely = async (
       previousVersion: previous.packageVersion,
       previousSignature: installationSignature(previous),
       rollbackArgv,
+      rollbackPackages,
+      restorePatches: restoreExistingPatches,
     };
     await writeJournal(journalPath, journal);
+    if (dependencies.applyPatches !== undefined) {
+      try {
+        const hasPatchGeneration = await dependencies.applyPatches(
+          previous,
+          "preflight",
+        );
+        preflight = await dependencies.checkCompatibility();
+        previous = preflight.installation;
+        journal = {
+          ...journal,
+          previousSignature: installationSignature(previous),
+          restorePatches: hasPatchGeneration,
+        };
+        await writeJournal(journalPath, journal);
+      } catch {
+        return rollback(journal, dependencies, run, journalPath);
+      }
+    }
 
     const updateEnv: NodeJS.ProcessEnv = {
       ...process.env,
@@ -281,6 +590,8 @@ export const updatePiSafely = async (
 
     if (!successful(updateResult) && !changed) {
       try {
+        const unchanged = discovered ?? (await dependencies.discover());
+        await dependencies.applyPatches?.(unchanged, "unchanged");
         const verified = await dependencies.checkCompatibility();
         if (
           installationSignature(verified.installation) ===
@@ -304,6 +615,9 @@ export const updatePiSafely = async (
 
     if (successful(updateResult)) {
       try {
+        const candidateInstallation =
+          discovered ?? (await dependencies.discover());
+        await dependencies.applyPatches?.(candidateInstallation, "candidate");
         const candidate = await dependencies.checkCompatibility();
         await rm(journalPath, { force: true });
         return {

--- a/scripts/update-pi.ts
+++ b/scripts/update-pi.ts
@@ -1,7 +1,11 @@
 import { resolve } from "node:path";
 import { checkPiCompatibility } from "./pi-compat/index";
 import { discoverPiInstallation } from "./pi-compat/installation";
-import { updatePiSafely } from "./pi-compat/update-state";
+import { applyPiPatches } from "./pi-compat/patches";
+import {
+  allowsUnsupportedPatchGeneration,
+  updatePiSafely,
+} from "./pi-compat/update-state";
 
 const repoRoot = resolve(import.meta.dir, "..");
 
@@ -9,12 +13,30 @@ try {
   const result = await updatePiSafely({
     checkCompatibility: () => checkPiCompatibility(repoRoot),
     discover: () => discoverPiInstallation(),
+    inspectPatches: async (installation) => {
+      const results = await applyPiPatches(installation, {
+        repoRoot,
+        allowUnsupported: true,
+        checkOnly: true,
+      });
+      return (
+        results.length > 0 &&
+        results.every(({ status }) => status === "already-applied")
+      );
+    },
+    applyPatches: async (installation, phase) => {
+      const results = await applyPiPatches(installation, {
+        repoRoot,
+        allowUnsupported: allowsUnsupportedPatchGeneration(phase),
+      });
+      return results.length > 0;
+    },
   });
   const log = result.ok ? console.log : console.error;
   log(`update-pi: ${result.message}`);
   if (result.manualRecoveryArgv !== undefined) {
     console.error(
-      `Manual recovery: ${result.manualRecoveryArgv.map((part) => JSON.stringify(part)).join(" ")}`,
+      "Recovery remains journaled. Rerun `bun run update:pi` when Bun's registry/cache is available; it executes the recorded exact cohort without a shell, reapplies required patches, and verifies the result.",
     );
   }
   process.exit(result.ok ? 0 : 1);

--- a/tests/hooks/statusline-checks/run.test.ts
+++ b/tests/hooks/statusline-checks/run.test.ts
@@ -94,8 +94,16 @@ describe("runner: TS pnpm typecheck-fail fixture", () => {
     tmps.push(tmp);
     const project = await copyFixture("ts-pnpm-typecheck-fail", tmp);
     const cacheDir = join(tmp, "cache");
+    const bin = join(tmp, "bin");
+    await fs.mkdir(bin);
+    await fs.writeFile(
+      join(bin, "pnpm"),
+      '#!/bin/sh\n[ "$1" = run ] || exit 2\ncase "$2" in\n  typecheck) exit 1 ;;\n  lint|test) exit 0 ;;\n  *) exit 2 ;;\nesac\n',
+      { mode: 0o755 },
+    );
 
     const r = await runRunner(project, {
+      PATH: `${bin}:${process.env.PATH ?? ""}`,
       STATUSLINE_CACHE_DIR: cacheDir,
       STATUSLINE_NOW_OVERRIDE: "2000",
     });

--- a/tests/pi-harness/btw.test.ts
+++ b/tests/pi-harness/btw.test.ts
@@ -3,14 +3,18 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import type { UserMessage } from "@earendil-works/pi-ai/compat";
+import {
+  InMemoryCredentialStore,
+  type UserMessage,
+} from "@earendil-works/pi-ai";
 import {
   buildSessionContext,
   createEventBus,
   type CreateAgentSessionOptions,
   type ExtensionCommandContext,
   type ExtensionContext,
-  type ModelRegistry,
+  ModelRegistry,
+  ModelRuntime,
   type RegisteredCommand,
   type ResourceLoader,
   SessionManager,
@@ -44,6 +48,11 @@ const parentModel = {
   id: "test-model",
   name: "Test model",
 } as NonNullable<ExtensionCommandContext["model"]>;
+const parentModelRuntime = await ModelRuntime.create({
+  credentials: new InMemoryCredentialStore(),
+  modelsPath: null,
+});
+const parentModelRegistry = new ModelRegistry(parentModelRuntime);
 
 const userMessage = (text: string): UserMessage => ({
   role: "user",
@@ -211,7 +220,7 @@ const snapshot = (): BtwSnapshot => ({
   systemPrompt: "parent system prompt",
   messages: [userMessage("parent context")],
   model: parentModel,
-  modelRegistry: {} as ModelRegistry,
+  modelRegistry: parentModelRegistry,
   thinkingLevel: "low",
 });
 
@@ -287,7 +296,7 @@ describe("BTW read-only fork runner", () => {
       ...BTW_DENIED_TOOLS,
     ]);
     expect(harness.createOptions[0].model).toBe(parentModel);
-    expect(harness.createOptions[0].modelRegistry).toBe(parent.modelRegistry);
+    expect(harness.createOptions[0].modelRuntime).toBe(parentModelRuntime);
     expect(harness.createOptions[0].thinkingLevel).toBe("low");
     expect(harness.loaderOptions[0].settingsManager).toBe(
       harness.createOptions[0].settingsManager,
@@ -651,7 +660,7 @@ const commandContext = (
     hasUI: options.hasUI ?? true,
     mode: options.mode ?? "tui",
     model: parentModel,
-    modelRegistry: {} as ModelRegistry,
+    modelRegistry: parentModelRegistry,
     sessionManager,
     signal: undefined,
     ui: {

--- a/tests/pi-harness/fake-pi.ts
+++ b/tests/pi-harness/fake-pi.ts
@@ -185,6 +185,7 @@ export const createFakePi = (
     model?: ModelLike;
     contextUsage?: ContextUsageLike;
     sessionId?: string;
+    sessionFile?: string;
   } = {},
 ): FakePi => {
   const store: HandlerStore = {
@@ -249,6 +250,7 @@ export const createFakePi = (
     sessionManager: {
       getBranch: () => [...sessionBranch],
       getSessionId: () => options.sessionId ?? "fake-session",
+      getSessionFile: () => options.sessionFile,
     },
     getContextUsage: () => contextUsage,
     ui: {

--- a/tests/pi-harness/hearth-tools-native.test.ts
+++ b/tests/pi-harness/hearth-tools-native.test.ts
@@ -34,7 +34,13 @@ const settings: PiToolSettings = {
   shell,
 };
 
-const context = { model: undefined } as never;
+const context = {
+  model: undefined,
+  sessionManager: {
+    getSessionId: () => "hearth-tools-test",
+    getSessionFile: () => undefined,
+  },
+} as never;
 
 interface NativeAbortController {
   readonly signal: AbortSignal;

--- a/tests/pi-harness/permission-skill-policy.test.ts
+++ b/tests/pi-harness/permission-skill-policy.test.ts
@@ -6,15 +6,15 @@ import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 import {
   fauxAssistantMessage,
+  fauxProvider,
   fauxToolCall,
-  registerFauxProvider,
-} from "@earendil-works/pi-ai/compat";
+  InMemoryCredentialStore,
+} from "@earendil-works/pi-ai";
 import {
-  AuthStorage,
   createAgentSession,
   createSyntheticSourceInfo,
   DefaultResourceLoader,
-  ModelRegistry,
+  ModelRuntime,
   SessionManager,
   SettingsManager,
 } from "@earendil-works/pi-coding-agent";
@@ -254,18 +254,17 @@ describe("active skill allowed-tools permission grants", () => {
     const agentDir = join(root, "agent");
     await fs.mkdir(agentDir);
 
-    const faux = registerFauxProvider({
+    const faux = fauxProvider({
       api: `permission-skill-${crypto.randomUUID()}`,
       provider: `permission-skill-${crypto.randomUUID()}`,
       tokensPerSecond: 100_000,
     });
     const model = faux.getModel();
-    const authStorage = AuthStorage.inMemory();
-    authStorage.setRuntimeApiKey(model.provider, "test-key");
-    const modelRegistry = ModelRegistry.create(
-      authStorage,
-      join(agentDir, "models.json"),
-    );
+    const modelRuntime = await ModelRuntime.create({
+      credentials: new InMemoryCredentialStore(),
+      modelsPath: null,
+    });
+    modelRuntime.registerNativeProvider(faux.provider);
     let expandedPrompt: string | undefined;
     const loader = new DefaultResourceLoader({
       cwd: root,
@@ -310,8 +309,7 @@ describe("active skill allowed-tools permission grants", () => {
     const { session } = await createAgentSession({
       cwd: root,
       agentDir,
-      authStorage,
-      modelRegistry,
+      modelRuntime,
       model,
       resourceLoader: loader,
       sessionManager: SessionManager.inMemory(),
@@ -336,7 +334,7 @@ describe("active skill allowed-tools permission grants", () => {
       expect(chatRequests(upstream)).toHaveLength(1);
     } finally {
       session.dispose();
-      faux.unregister();
+      modelRuntime.unregisterProvider(faux.provider.id);
     }
   });
 

--- a/tests/pi-harness/pi-patches.test.ts
+++ b/tests/pi-harness/pi-patches.test.ts
@@ -1,0 +1,303 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  link,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+  PiCorePackage,
+  PiInstallation,
+} from "../../scripts/pi-compat/installation";
+import {
+  applyPiPatches,
+  type PiPatchSpec,
+} from "../../scripts/pi-compat/patches";
+import {
+  runCommand,
+  type CommandResult,
+  type CommandRunner,
+} from "../../scripts/pi-compat/process";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true })),
+  );
+});
+
+const commandFailure = (argv: string[], message: string): CommandResult => ({
+  argv,
+  exitCode: 1,
+  stdout: "",
+  stderr: message,
+  timedOut: false,
+  truncated: false,
+});
+
+const createPackage = async (
+  root: string,
+  packageName: string,
+  version: string,
+  value = "old\n",
+): Promise<PiCorePackage> => {
+  const packageRoot = join(root, "packages", packageName.replaceAll("/", "-"));
+  await mkdir(join(packageRoot, "dist"), { recursive: true });
+  await writeFile(join(packageRoot, "dist", "value.js"), value);
+  return {
+    root: packageRoot,
+    version,
+    manifest: { name: packageName, version },
+  };
+};
+
+const writePatch = async (
+  repoRoot: string,
+  name: string,
+  before = "old",
+  after = "new",
+): Promise<string> => {
+  const relativePath = join("patches", `${name}.patch`);
+  await mkdir(join(repoRoot, "patches"), { recursive: true });
+  await writeFile(
+    join(repoRoot, relativePath),
+    `diff --git a/dist/value.js b/dist/value.js\n--- a/dist/value.js\n+++ b/dist/value.js\n@@ -1 +1 @@\n-${before}\n+${after}\n`,
+  );
+  return relativePath;
+};
+
+const installation = (
+  corePackages: Record<string, PiCorePackage>,
+): PiInstallation => ({
+  bunExecutable: "/tools/bun",
+  globalBin: "/global/bin",
+  binaryPath: "/global/bin/pi",
+  binaryRealPath: "/global/node_modules/pi/dist/cli.js",
+  packageRoot: "/global/node_modules/pi",
+  packageName: "@earendil-works/pi-coding-agent",
+  packageVersion: "0.83.0",
+  corePackages,
+});
+
+const setup = async (): Promise<string> => {
+  const root = await mkdtemp(join(tmpdir(), "pi-patches-test-"));
+  roots.push(root);
+  return root;
+};
+
+describe("global Pi sticky patch application", () => {
+  test("applies an exact-version patch and is idempotent", async () => {
+    const root = await setup();
+    const packageName = "@earendil-works/pi-tui";
+    const pkg = await createPackage(root, packageName, "0.83.0");
+    const file = await writePatch(root, "tui");
+    const specs: PiPatchSpec[] = [
+      { packageName, version: "0.83.0", file },
+      {
+        packageName,
+        version: "0.84.0",
+        file: "patches/future-generation.patch",
+      },
+    ];
+    const discovered = installation({ [packageName]: pkg });
+
+    await expect(
+      applyPiPatches(discovered, {
+        repoRoot: root,
+        specs,
+        checkOnly: true,
+      }),
+    ).resolves.toEqual([
+      { packageName, version: "0.83.0", status: "pending" },
+    ]);
+    expect(await readFile(join(pkg.root, "dist", "value.js"), "utf8")).toBe(
+      "old\n",
+    );
+
+    await expect(
+      applyPiPatches(discovered, { repoRoot: root, specs }),
+    ).resolves.toEqual([{ packageName, version: "0.83.0", status: "applied" }]);
+    expect(await readFile(join(pkg.root, "dist", "value.js"), "utf8")).toBe(
+      "new\n",
+    );
+
+    await expect(
+      applyPiPatches(discovered, {
+        repoRoot: root,
+        specs,
+        checkOnly: true,
+      }),
+    ).resolves.toEqual([
+      { packageName, version: "0.83.0", status: "already-applied" },
+    ]);
+    await expect(
+      applyPiPatches(discovered, { repoRoot: root, specs }),
+    ).resolves.toEqual([
+      { packageName, version: "0.83.0", status: "already-applied" },
+    ]);
+  });
+
+  test("reverses only newly applied patches when post-verification fails", async () => {
+    const root = await setup();
+    const alreadyName = "@earendil-works/pi-tui";
+    const pendingName = "@earendil-works/pi-coding-agent";
+    const already = await createPackage(root, alreadyName, "0.83.0", "new\n");
+    const pending = await createPackage(root, pendingName, "0.83.0");
+    const alreadyPatch = await writePatch(root, "tui");
+    const pendingPatch = await writePatch(root, "coding-agent");
+    const specs: PiPatchSpec[] = [
+      { packageName: alreadyName, version: "0.83.0", file: alreadyPatch },
+      { packageName: pendingName, version: "0.83.0", file: pendingPatch },
+    ];
+
+    await expect(
+      applyPiPatches(
+        installation({ [alreadyName]: already, [pendingName]: pending }),
+        {
+          repoRoot: root,
+          specs,
+          verify: async () => {
+            throw new Error("post-compatibility failed");
+          },
+        },
+      ),
+    ).rejects.toThrow("post-compatibility failed");
+
+    expect(
+      await readFile(join(already.root, "dist", "value.js"), "utf8"),
+    ).toBe("new\n");
+    expect(
+      await readFile(join(pending.root, "dist", "value.js"), "utf8"),
+    ).toBe("old\n");
+  });
+
+  test("detaches package files before patching so Bun cache hardlinks stay clean", async () => {
+    const root = await setup();
+    const packageName = "@earendil-works/pi-tui";
+    const pkg = await createPackage(root, packageName, "0.83.0");
+    const target = join(pkg.root, "dist", "value.js");
+    const cacheFile = join(root, "bun-cache-value.js");
+    await writeFile(cacheFile, "old\n");
+    await rm(target);
+    await link(cacheFile, target);
+    const targetBefore = await stat(target);
+    const cacheBefore = await stat(cacheFile);
+    expect(targetBefore.ino).toBe(cacheBefore.ino);
+    const file = await writePatch(root, "tui");
+    const specs: PiPatchSpec[] = [{ packageName, version: "0.83.0", file }];
+
+    await applyPiPatches(installation({ [packageName]: pkg }), {
+      repoRoot: root,
+      specs,
+    });
+
+    expect(await readFile(target, "utf8")).toBe("new\n");
+    expect(await readFile(cacheFile, "utf8")).toBe("old\n");
+    const targetAfter = await stat(target);
+    const cacheAfter = await stat(cacheFile);
+    expect(targetAfter.ino).not.toBe(cacheAfter.ino);
+  });
+
+  test("rejects unsupported package versions before mutation", async () => {
+    const root = await setup();
+    const packageName = "@earendil-works/pi-tui";
+    const pkg = await createPackage(root, packageName, "0.84.0");
+    const file = await writePatch(root, "tui");
+    const specs: PiPatchSpec[] = [{ packageName, version: "0.83.0", file }];
+
+    await expect(
+      applyPiPatches(installation({ [packageName]: pkg }), {
+        repoRoot: root,
+        specs,
+      }),
+    ).rejects.toThrow("no @earendil-works/pi-tui sticky patch for 0.84.0");
+    expect(await readFile(join(pkg.root, "dist", "value.js"), "utf8")).toBe(
+      "old\n",
+    );
+  });
+
+  test("can leave an unsupported preflight generation untouched", async () => {
+    const root = await setup();
+    const packageName = "@earendil-works/pi-tui";
+    const pkg = await createPackage(root, packageName, "0.82.0");
+    const file = await writePatch(root, "tui");
+    const specs: PiPatchSpec[] = [{ packageName, version: "0.83.0", file }];
+
+    await expect(
+      applyPiPatches(installation({ [packageName]: pkg }), {
+        repoRoot: root,
+        specs,
+        allowUnsupported: true,
+      }),
+    ).resolves.toEqual([]);
+    expect(await readFile(join(pkg.root, "dist", "value.js"), "utf8")).toBe(
+      "old\n",
+    );
+  });
+
+  test("validates the whole patch cohort before changing any package", async () => {
+    const root = await setup();
+    const firstName = "@earendil-works/pi-tui";
+    const secondName = "@earendil-works/pi-coding-agent";
+    const first = await createPackage(root, firstName, "0.83.0");
+    const second = await createPackage(root, secondName, "0.83.0", "drifted\n");
+    const firstPatch = await writePatch(root, "tui");
+    const secondPatch = await writePatch(root, "coding-agent");
+    const specs: PiPatchSpec[] = [
+      { packageName: firstName, version: "0.83.0", file: firstPatch },
+      { packageName: secondName, version: "0.83.0", file: secondPatch },
+    ];
+
+    await expect(
+      applyPiPatches(
+        installation({ [firstName]: first, [secondName]: second }),
+        { repoRoot: root, specs },
+      ),
+    ).rejects.toThrow("does not match either side");
+    expect(await readFile(join(first.root, "dist", "value.js"), "utf8")).toBe(
+      "old\n",
+    );
+  });
+
+  test("rolls back patches from the current invocation if a later apply fails", async () => {
+    const root = await setup();
+    const firstName = "@earendil-works/pi-tui";
+    const secondName = "@earendil-works/pi-coding-agent";
+    const first = await createPackage(root, firstName, "0.83.0");
+    const second = await createPackage(root, secondName, "0.83.0");
+    const firstPatch = await writePatch(root, "tui", "old", "first");
+    const secondPatch = await writePatch(root, "coding-agent", "old", "second");
+    const specs: PiPatchSpec[] = [
+      { packageName: firstName, version: "0.83.0", file: firstPatch },
+      { packageName: secondName, version: "0.83.0", file: secondPatch },
+    ];
+    const run: CommandRunner = async (argv, options) => {
+      const applyingSecond =
+        !argv.includes("--check") &&
+        !argv.includes("--reverse") &&
+        argv.includes(join(root, secondPatch));
+      return applyingSecond
+        ? commandFailure(argv, "simulated write failure")
+        : runCommand(argv, options);
+    };
+
+    await expect(
+      applyPiPatches(
+        installation({ [firstName]: first, [secondName]: second }),
+        { repoRoot: root, specs, run },
+      ),
+    ).rejects.toThrow("simulated write failure");
+    expect(await readFile(join(first.root, "dist", "value.js"), "utf8")).toBe(
+      "old\n",
+    );
+    expect(await readFile(join(second.root, "dist", "value.js"), "utf8")).toBe(
+      "old\n",
+    );
+  });
+});

--- a/tests/pi-harness/tui-fixed-bottom.test.ts
+++ b/tests/pi-harness/tui-fixed-bottom.test.ts
@@ -1,0 +1,535 @@
+import {
+  Container,
+  CURSOR_MARKER,
+  KeybindingsManager,
+  setKeybindings,
+  TUI,
+  TUI_KEYBINDINGS,
+  type Component,
+  type Terminal,
+} from "@earendil-works/pi-tui";
+import { afterEach, describe, expect, test } from "bun:test";
+
+const SEGMENT_RESET = "\u001b[0m\u001b]8;;\u0007";
+
+class FakeTerminal implements Terminal {
+  columns = 20;
+  rows = 6;
+  readonly kittyProtocolActive = false;
+  readonly writes: string[] = [];
+  input?: (data: string) => void;
+  resize?: () => void;
+
+  start(onInput: (data: string) => void, onResize: () => void): void {
+    this.input = onInput;
+    this.resize = onResize;
+  }
+
+  stop(): void {}
+
+  async drainInput(): Promise<void> {}
+
+  write(data: string): void {
+    this.writes.push(data);
+  }
+
+  moveBy(): void {}
+  hideCursor(): void {}
+  showCursor(): void {}
+  clearLine(): void {}
+  clearFromCursor(): void {}
+  clearScreen(): void {}
+  setTitle(): void {}
+  setProgress(): void {}
+}
+
+class MutableLines implements Component {
+  constructor(public lines: string[]) {}
+
+  render(): string[] {
+    return [...this.lines];
+  }
+
+  invalidate(): void {}
+}
+
+class WrappedLines implements Component {
+  constructor(private readonly paragraphs: string[]) {}
+
+  render(width: number): string[] {
+    const chunkWidth = Math.max(1, width);
+    return this.paragraphs.flatMap((paragraph) => {
+      const lines: string[] = [];
+      for (let index = 0; index < paragraph.length; index += chunkWidth) {
+        lines.push(paragraph.slice(index, index + chunkWidth));
+      }
+      return lines;
+    });
+  }
+
+  invalidate(): void {}
+}
+
+class TestTui extends TUI {
+  renderFrame(): string[] {
+    this.doRender();
+    return this.previousLines.map((line) => line.replaceAll(SEGMENT_RESET, ""));
+  }
+
+  sendInput(data: string): void {
+    this.handleInput(data);
+  }
+
+  get observedHardwareCursorRow(): number {
+    return this.hardwareCursorRow;
+  }
+}
+
+const renderLines = (tui: TestTui): string[] => tui.renderFrame();
+
+const numberedLines = (count: number): string[] =>
+  Array.from({ length: count }, (_, index) => `line-${index + 1}`);
+
+afterEach(() => {
+  setKeybindings(new KeybindingsManager(TUI_KEYBINDINGS));
+});
+
+describe("pi-tui fixed bottom viewport", () => {
+  test("keeps the original scrollback rendering when no bottom is fixed", () => {
+    const tui = new TestTui(new FakeTerminal());
+    tui.addChild(new MutableLines(numberedLines(10)));
+
+    expect(renderLines(tui)).toEqual(numberedLines(10));
+  });
+
+  test("pins the editor/footer and pages conversation history with keys and wheel", () => {
+    const terminal = new FakeTerminal();
+    const tui = new TestTui(terminal);
+    const editor = new MutableLines(["EDITOR"]);
+    const bottom = new Container();
+    bottom.addChild(editor);
+    bottom.addChild(new MutableLines(["FOOTER"]));
+    tui.addChild(new MutableLines(numberedLines(10)));
+    tui.setFixedBottom(bottom, editor);
+    tui.setFocus(editor);
+
+    expect(renderLines(tui)).toEqual([
+      "line-7",
+      "line-8",
+      "line-9",
+      "line-10",
+      "EDITOR",
+      "FOOTER",
+    ]);
+    expect(terminal.writes.join("")).not.toContain("\u001b[3J");
+
+    tui.sendInput("\u001b[5~");
+    expect(tui.getViewportOffset()).toBe(4);
+    expect(renderLines(tui).slice(0, 4)).toEqual([
+      "line-3",
+      "line-4",
+      "line-5",
+      "line-6",
+    ]);
+
+    tui.sendInput("\u001b[57421;1:3u");
+    expect(tui.getViewportOffset()).toBe(4);
+
+    tui.sendInput("\u001b[<65;10;3M");
+    expect(tui.getViewportOffset()).toBe(1);
+    expect(renderLines(tui).slice(0, 4)).toEqual([
+      "line-6",
+      "line-7",
+      "line-8",
+      "line-9",
+    ]);
+
+    tui.sendInput("\u001b[<64;10;3M");
+    expect(tui.getViewportOffset()).toBe(4);
+    expect(renderLines(tui).slice(0, 4)).toEqual([
+      "line-3",
+      "line-4",
+      "line-5",
+      "line-6",
+    ]);
+
+    tui.sendInput("\u001b[6~");
+    expect(tui.getViewportOffset()).toBe(0);
+    expect(renderLines(tui).slice(-2)).toEqual(["EDITOR", "FOOTER"]);
+  });
+
+  test("uses configured editor paging keys and respects disabled actions", () => {
+    setKeybindings(
+      new KeybindingsManager(TUI_KEYBINDINGS, {
+        "tui.editor.pageUp": "ctrl+u",
+        "tui.editor.pageDown": [],
+      }),
+    );
+    const tui = new TestTui(new FakeTerminal());
+    let received = "";
+    const editor: Component = {
+      render: () => ["EDITOR"],
+      invalidate: () => {},
+      handleInput: (data) => {
+        received = data;
+      },
+    };
+    const bottom = new Container();
+    bottom.addChild(editor);
+    bottom.addChild(new MutableLines(["FOOTER"]));
+    tui.addChild(new MutableLines(numberedLines(10)));
+    tui.setFixedBottom(bottom, editor);
+    tui.setFocus(editor);
+    renderLines(tui);
+
+    tui.sendInput("\u001b[5~");
+    expect(received).toBe("\u001b[5~");
+    expect(tui.getViewportOffset()).toBe(0);
+
+    received = "";
+    tui.sendInput("\u0015");
+    expect(received).toBe("");
+    expect(tui.getViewportOffset()).toBe(4);
+
+    tui.sendInput("\u001b[6~");
+    expect(received).toBe("\u001b[6~");
+    expect(tui.getViewportOffset()).toBe(4);
+  });
+
+  test("forwards paging keys when history cannot move in that direction", () => {
+    const tui = new TestTui(new FakeTerminal());
+    const received: string[] = [];
+    const editor: Component = {
+      render: () => ["EDITOR"],
+      invalidate: () => {},
+      handleInput: (data) => {
+        received.push(data);
+      },
+    };
+    const bottom = new Container();
+    bottom.addChild(editor);
+    bottom.addChild(new MutableLines(["FOOTER"]));
+    tui.addChild(new MutableLines(numberedLines(10)));
+    tui.setFixedBottom(bottom, editor);
+    tui.setFocus(editor);
+    renderLines(tui);
+
+    tui.sendInput("\u001b[6~");
+    expect(received).toEqual(["\u001b[6~"]);
+
+    tui.sendInput("\u001b[5~");
+    tui.sendInput("\u001b[5~");
+    expect(tui.getViewportOffset()).toBe(6);
+    expect(received).toEqual(["\u001b[6~"]);
+
+    tui.sendInput("\u001b[5~");
+    expect(received).toEqual(["\u001b[6~", "\u001b[5~"]);
+
+    tui.sendInput("\u001b[6~");
+    tui.sendInput("\u001b[6~");
+    expect(tui.getViewportOffset()).toBe(0);
+    tui.sendInput("\u001b[6~");
+    expect(received).toEqual([
+      "\u001b[6~",
+      "\u001b[5~",
+      "\u001b[6~",
+    ]);
+  });
+
+  test("forwards paging keys when no history page is available", () => {
+    const terminal = new FakeTerminal();
+    terminal.rows = 2;
+    const tui = new TestTui(terminal);
+    const received: string[] = [];
+    const editor: Component = {
+      render: () => ["EDITOR-1", "EDITOR-2", "EDITOR-3"],
+      invalidate: () => {},
+      handleInput: (data) => {
+        received.push(data);
+      },
+    };
+    tui.addChild(new MutableLines(numberedLines(10)));
+    tui.setFixedBottom(editor, editor);
+    tui.setFocus(editor);
+    renderLines(tui);
+
+    tui.sendInput("\u001b[5~");
+    tui.sendInput("\u001b[6~");
+
+    expect(tui.getViewportOffset()).toBe(0);
+    expect(received).toEqual(["\u001b[5~", "\u001b[6~"]);
+
+    const fittingTui = new TestTui(new FakeTerminal());
+    const fittingReceived: string[] = [];
+    const fittingEditor: Component = {
+      render: () => ["EDITOR"],
+      invalidate: () => {},
+      handleInput: (data) => {
+        fittingReceived.push(data);
+      },
+    };
+    fittingTui.addChild(new MutableLines(numberedLines(2)));
+    fittingTui.setFixedBottom(fittingEditor, fittingEditor);
+    fittingTui.setFocus(fittingEditor);
+    renderLines(fittingTui);
+    fittingTui.sendInput("\u001b[5~");
+    fittingTui.sendInput("\u001b[6~");
+
+    expect(fittingReceived).toEqual(["\u001b[5~", "\u001b[6~"]);
+  });
+
+  test("preserves a scrolled history anchor during streaming and follows on demand", () => {
+    const terminal = new FakeTerminal();
+    const history = new MutableLines(numberedLines(10));
+    const bottom = new MutableLines(["EDITOR", "FOOTER"]);
+    const tui = new TestTui(terminal);
+    tui.addChild(history);
+    tui.setFixedBottom(bottom);
+    renderLines(tui);
+
+    tui.scrollViewport(4);
+    expect(renderLines(tui).slice(0, 4)).toEqual([
+      "line-3",
+      "line-4",
+      "line-5",
+      "line-6",
+    ]);
+
+    history.lines.push("line-11", "line-12");
+    expect(renderLines(tui).slice(0, 4)).toEqual([
+      "line-3",
+      "line-4",
+      "line-5",
+      "line-6",
+    ]);
+
+    history.lines.pop();
+    history.lines.pop();
+    expect(renderLines(tui).slice(0, 4)).toEqual([
+      "line-3",
+      "line-4",
+      "line-5",
+      "line-6",
+    ]);
+    history.lines.push("line-11", "line-12");
+    renderLines(tui);
+
+    tui.followViewport();
+    expect(renderLines(tui).slice(0, 4)).toEqual([
+      "line-9",
+      "line-10",
+      "line-11",
+      "line-12",
+    ]);
+
+    terminal.rows = 8;
+    expect(renderLines(tui)).toEqual([
+      "line-7",
+      "line-8",
+      "line-9",
+      "line-10",
+      "line-11",
+      "line-12",
+      "EDITOR",
+      "FOOTER",
+    ]);
+
+    bottom.lines = ["EDITOR-1", "EDITOR-2", "EDITOR-3", "FOOTER"];
+    expect(renderLines(tui)).toEqual([
+      "line-9",
+      "line-10",
+      "line-11",
+      "line-12",
+      "EDITOR-1",
+      "EDITOR-2",
+      "EDITOR-3",
+      "FOOTER",
+    ]);
+  });
+
+  test("keeps the same history anchor when the available page height changes", () => {
+    const terminal = new FakeTerminal();
+    const history = new MutableLines(numberedLines(12));
+    const bottom = new MutableLines(["EDITOR", "FOOTER"]);
+    const tui = new TestTui(terminal);
+    tui.addChild(history);
+    tui.setFixedBottom(bottom);
+    renderLines(tui);
+    tui.scrollViewport(4);
+
+    expect(renderLines(tui).slice(0, 4)).toEqual([
+      "line-5",
+      "line-6",
+      "line-7",
+      "line-8",
+    ]);
+
+    terminal.rows = 8;
+    expect(renderLines(tui).slice(0, 6)).toEqual([
+      "line-5",
+      "line-6",
+      "line-7",
+      "line-8",
+      "line-9",
+      "line-10",
+    ]);
+
+    bottom.lines = ["EDITOR-1", "EDITOR-2", "EDITOR-3", "FOOTER"];
+    expect(renderLines(tui).slice(0, 4)).toEqual([
+      "line-5",
+      "line-6",
+      "line-7",
+      "line-8",
+    ]);
+  });
+
+  test("keeps the same history anchor when width changes rewrap content", () => {
+    const terminal = new FakeTerminal();
+    const tui = new TestTui(terminal);
+    const paragraphs = Array.from(
+      { length: 10 },
+      (_, index) => `message-${String(index + 1).padStart(2, "0")}`,
+    );
+    tui.addChild(new WrappedLines(paragraphs));
+    tui.setFixedBottom(new MutableLines(["EDITOR", "FOOTER"]));
+    renderLines(tui);
+    tui.scrollViewport(4);
+
+    expect(renderLines(tui).slice(0, 4)).toEqual([
+      "message-03",
+      "message-04",
+      "message-05",
+      "message-06",
+    ]);
+
+    terminal.columns = 5;
+    expect(renderLines(tui).slice(0, 4)).toEqual([
+      "messa",
+      "ge-03",
+      "messa",
+      "ge-04",
+    ]);
+  });
+
+  test("keeps overlays and embedded selectors in control of paging input", () => {
+    const terminal = new FakeTerminal();
+    const tui = new TestTui(terminal);
+    const editor = new MutableLines(["EDITOR"]);
+    const bottom = new Container();
+    bottom.addChild(editor);
+    bottom.addChild(new MutableLines(["FOOTER"]));
+    tui.addChild(new MutableLines(numberedLines(10)));
+    tui.setFixedBottom(bottom, editor);
+    tui.setFocus(editor);
+    renderLines(tui);
+    tui.scrollViewport(2);
+
+    let received = "";
+    const overlay: Component & { focused: boolean } = {
+      focused: false,
+      render: () => ["OVERLAY"],
+      invalidate: () => {},
+      handleInput: (data) => {
+        received = data;
+      },
+    };
+    const handle = tui.showOverlay(overlay);
+    tui.sendInput("\u001b[5~");
+
+    expect(received).toBe("\u001b[5~");
+    expect(tui.getViewportOffset()).toBe(2);
+    handle.hide();
+
+    received = "";
+    const selector: Component = {
+      render: () => ["SELECTOR"],
+      invalidate: () => {},
+      handleInput: (data) => {
+        received = data;
+      },
+    };
+    bottom.clear();
+    bottom.addChild(selector);
+    tui.setFocus(selector);
+    tui.sendInput("\u001b[5~");
+
+    expect(received).toBe("\u001b[5~");
+    expect(tui.getViewportOffset()).toBe(2);
+  });
+
+  test("retargets paging when an extension installs a custom editor", () => {
+    const terminal = new FakeTerminal();
+    const tui = new TestTui(terminal);
+    const defaultEditor = new MutableLines(["DEFAULT EDITOR"]);
+    const customEditor = new MutableLines(["CUSTOM EDITOR"]);
+    const bottom = new Container();
+    bottom.addChild(defaultEditor);
+    bottom.addChild(new MutableLines(["FOOTER"]));
+    tui.addChild(new MutableLines(numberedLines(10)));
+    tui.setFixedBottom(bottom, defaultEditor);
+    tui.setFocus(defaultEditor);
+    renderLines(tui);
+
+    bottom.clear();
+    bottom.addChild(customEditor);
+    bottom.addChild(new MutableLines(["FOOTER"]));
+    tui.setViewportPagingFocus(customEditor);
+    tui.setFocus(customEditor);
+    tui.sendInput("\u001b[5~");
+
+    expect(tui.getViewportOffset()).toBe(4);
+    expect(renderLines(tui).slice(-2)).toEqual(["CUSTOM EDITOR", "FOOTER"]);
+  });
+
+  test("clips optional fixed rows before removing the focused editor", () => {
+    const terminal = new FakeTerminal();
+    terminal.rows = 3;
+    const tui = new TestTui(terminal, true);
+    tui.setFixedBottom(
+      new MutableLines([
+        "WIDGET ABOVE 1",
+        "WIDGET ABOVE 2",
+        `EDIT${CURSOR_MARKER}OR`,
+        "WIDGET BELOW 1",
+        "WIDGET BELOW 2",
+        "FOOTER",
+      ]),
+    );
+
+    expect(renderLines(tui)).toEqual(["EDITOR", "WIDGET BELOW 2", "FOOTER"]);
+    expect(tui.observedHardwareCursorRow).toBe(0);
+
+    terminal.rows = 0;
+    expect(renderLines(tui)).toEqual([]);
+  });
+
+  test("suppresses a Kitty image split by the conversation boundary", () => {
+    const tui = new TestTui(new FakeTerminal());
+    const image = "\u001b_Gi=42,r=3;AAAA\u001b\\";
+    tui.addChild(
+      new MutableLines(["a", "b", "c", "d", image, "", "", "h", "i", "j"]),
+    );
+    tui.setFixedBottom(new MutableLines(["EDITOR", "FOOTER"]));
+    renderLines(tui);
+    tui.scrollViewport(4);
+
+    const frame = renderLines(tui);
+    expect(frame).toEqual(["c", "d", "", "", "EDITOR", "FOOTER"]);
+    expect(frame.join("")).not.toContain("\u001b_G");
+  });
+
+  test("enables mouse tracking and keeps the hardware cursor in the fixed editor", () => {
+    const terminal = new FakeTerminal();
+    const tui = new TestTui(terminal, true);
+    tui.addChild(new MutableLines(numberedLines(10)));
+    tui.setFixedBottom(new MutableLines([`EDIT${CURSOR_MARKER}OR`, "FOOTER"]));
+
+    expect(renderLines(tui).slice(-2)).toEqual(["EDITOR", "FOOTER"]);
+    expect(tui.observedHardwareCursorRow).toBe(4);
+
+    tui.start();
+    tui.stop();
+    expect(terminal.writes.join("")).toContain("\u001b[?1000h\u001b[?1006h");
+    expect(terminal.writes.join("")).toContain("\u001b[?1006l\u001b[?1000l");
+  });
+});

--- a/tests/pi-harness/update-pi.test.ts
+++ b/tests/pi-harness/update-pi.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -7,6 +8,8 @@ import type { PiInstallation } from "../../scripts/pi-compat/installation";
 import type { CommandResult } from "../../scripts/pi-compat/process";
 import {
   acquireUpdateLock,
+  allowsUnsupportedPatchGeneration,
+  assertNoPendingUpdateRecovery,
   updatePiSafely,
 } from "../../scripts/pi-compat/update-state";
 
@@ -34,6 +37,24 @@ const installation = (version: string): PiInstallation => ({
   },
 });
 
+const installationWithTui = (
+  version: string,
+  tuiVersion: string,
+): PiInstallation => {
+  const value = installation(version);
+  return {
+    ...value,
+    corePackages: {
+      ...value.corePackages,
+      "@earendil-works/pi-tui": {
+        root: "/global/node_modules/pi-tui",
+        version: tuiVersion,
+        manifest: {},
+      },
+    },
+  };
+};
+
 const compatible = (value: PiInstallation): PiCompatibilityResult => ({
   baseline: { ok: true, issues: [], packages: [] },
   installation: value,
@@ -57,7 +78,24 @@ const paths = async () => {
   };
 };
 
+const toLegacyJournal = (source: string): string =>
+  source
+    .replace('    "--force",\n', "")
+    .replace(
+      /\n  "rollbackPackages": \[[\s\S]*?\],(?=\n  "restorePatches")/,
+      "",
+    )
+    .replace(/,\n  "restorePatches": (?:true|false)(?=\n})/, "");
+
 describe("safe pi updater", () => {
+  test("allows unsupported generations only before candidate mutation", () => {
+    expect(allowsUnsupportedPatchGeneration("preflight")).toBe(true);
+    expect(allowsUnsupportedPatchGeneration("candidate")).toBe(false);
+    expect(allowsUnsupportedPatchGeneration("rollback")).toBe(false);
+    expect(allowsUnsupportedPatchGeneration("recovery")).toBe(false);
+    expect(allowsUnsupportedPatchGeneration("unchanged")).toBe(true);
+  });
+
   test("aborts before mutation when preflight is not known-good", async () => {
     const temp = await paths();
     let runs = 0;
@@ -75,6 +113,118 @@ describe("safe pi updater", () => {
       }),
     ).rejects.toThrow("preflight failed");
     expect(runs).toBe(0);
+  });
+
+  test("preserves an already-patched source across an initial-journal interruption", async () => {
+    const temp = await paths();
+    const current = installation("0.80.7");
+    const phases: string[] = [];
+    let runs = 0;
+    const dependencies = {
+      ...temp,
+      checkCompatibility: async () => compatible(current),
+      discover: async () => current,
+      inspectPatches: async () => true,
+      applyPatches: async (_candidate: PiInstallation, phase: string) => {
+        phases.push(phase);
+        if (phase === "preflight") {
+          throw new Error("interrupted before preflight journal rewrite");
+        }
+        return true;
+      },
+      run: async () => {
+        runs += 1;
+        return result(1, "rollback interrupted");
+      },
+    };
+
+    const interrupted = await updatePiSafely(dependencies);
+    expect(interrupted.manualRecoveryArgv).toBeDefined();
+    const recovered = await updatePiSafely(dependencies);
+
+    expect(recovered).toMatchObject({ ok: false, rolledBack: true });
+    expect(recovered.message).toContain("already-restored");
+    expect(phases).toEqual(["preflight", "recovery"]);
+    expect(runs).toBe(1);
+  });
+
+  test("restores pristine packages when patched preflight verification fails", async () => {
+    const temp = await paths();
+    const current = installation("0.80.7");
+    let patched = false;
+    const calls: string[] = [];
+    const phases: string[] = [];
+    const update = await updatePiSafely({
+      ...temp,
+      checkCompatibility: async () => {
+        if (patched) throw new Error("patched preflight is incompatible");
+        return compatible(current);
+      },
+      discover: async () => current,
+      applyPatches: async (_candidate, phase) => {
+        phases.push(phase);
+        if (phase === "preflight") patched = true;
+        return true;
+      },
+      run: async (argv) => {
+        calls.push(argv.includes("update") ? "update" : "rollback");
+        patched = false;
+        return result();
+      },
+    });
+
+    expect(update).toMatchObject({ ok: false, rolledBack: true });
+    expect(calls).toEqual(["rollback"]);
+    expect(phases).toEqual(["preflight"]);
+    expect(patched).toBe(false);
+    await expect(readFile(temp.journalPath, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  test("reinstalls an interrupted partial preflight patch cohort", async () => {
+    const temp = await paths();
+    const current = installation("0.80.7");
+    const packageState: { value: "pristine" | "partial" } = {
+      value: "pristine",
+    };
+    let rejectPartial = true;
+    let rollbackAvailable = false;
+    const calls: string[] = [];
+    const phases: string[] = [];
+    const dependencies = {
+      ...temp,
+      checkCompatibility: async () => {
+        if (packageState.value === "partial" && rejectPartial) {
+          throw new Error("preflight patch cohort is partial");
+        }
+        return compatible(current);
+      },
+      discover: async () => current,
+      applyPatches: async (_candidate: PiInstallation, phase: string) => {
+        phases.push(phase);
+        if (phase === "preflight") packageState.value = "partial";
+        return true;
+      },
+      run: async () => {
+        calls.push("rollback");
+        if (!rollbackAvailable) return result(1, "rollback interrupted");
+        packageState.value = "pristine";
+        return result();
+      },
+    };
+
+    const interrupted = await updatePiSafely(dependencies);
+    expect(interrupted.manualRecoveryArgv).toBeDefined();
+    expect(packageState.value).toBe("partial");
+
+    rejectPartial = false;
+    rollbackAvailable = true;
+    const recovered = await updatePiSafely(dependencies);
+    expect(recovered).toMatchObject({ ok: false, rolledBack: true });
+    expect(packageState.value).toBe("pristine");
+    expect(calls).toEqual(["rollback", "rollback"]);
+    expect(phases).toEqual(["preflight"]);
   });
 
   test("accepts an updated candidate after compatibility verification", async () => {
@@ -100,6 +250,96 @@ describe("safe pi updater", () => {
       currentVersion: "0.81.0",
     });
     expect(calls).toEqual(["update"]);
+  });
+
+  test("applies sticky patches before candidate compatibility verification", async () => {
+    const temp = await paths();
+    let current = installation("0.80.7");
+    const patchedVersions = new Set<string>();
+    const patchCalls: string[] = [];
+    const update = await updatePiSafely({
+      ...temp,
+      checkCompatibility: async () => {
+        if (
+          current.packageVersion === "0.81.0" &&
+          !patchedVersions.has("0.81.0")
+        ) {
+          throw new Error("candidate was checked before patching");
+        }
+        return compatible(current);
+      },
+      discover: async () => current,
+      applyPatches: async (candidate) => {
+        patchCalls.push(candidate.packageVersion);
+        patchedVersions.add(candidate.packageVersion);
+        return true;
+      },
+      run: async () => {
+        current = installation("0.81.0");
+        return result();
+      },
+    });
+
+    expect(update).toMatchObject({ ok: true, currentVersion: "0.81.0" });
+    expect(patchCalls).toEqual(["0.80.7", "0.81.0"]);
+  });
+
+  test("crosses from an unsupported preflight patch generation to a supported candidate", async () => {
+    const temp = await paths();
+    let current = installation("0.80.7");
+    let candidatePatched = false;
+    const phases: string[] = [];
+    const update = await updatePiSafely({
+      ...temp,
+      checkCompatibility: async () => {
+        if (current.packageVersion === "0.81.0" && !candidatePatched) {
+          throw new Error("new generation was not patched");
+        }
+        return compatible(current);
+      },
+      discover: async () => current,
+      applyPatches: async (candidate, phase) => {
+        phases.push(`${phase}:${candidate.packageVersion}`);
+        if (phase === "preflight") return false;
+        if (phase === "candidate") candidatePatched = true;
+        return true;
+      },
+      run: async () => {
+        current = installation("0.81.0");
+        return result();
+      },
+    });
+
+    expect(update).toMatchObject({ ok: true, currentVersion: "0.81.0" });
+    expect(phases).toEqual(["preflight:0.80.7", "candidate:0.81.0"]);
+  });
+
+  test("restores an unsupported source without invoking a nonexistent patch", async () => {
+    const temp = await paths();
+    let current = installation("0.80.7");
+    const phases: string[] = [];
+    const update = await updatePiSafely({
+      ...temp,
+      checkCompatibility: async () => compatible(current),
+      discover: async () => current,
+      applyPatches: async (candidate, phase) => {
+        phases.push(`${phase}:${candidate.packageVersion}`);
+        if (phase === "preflight") return false;
+        if (phase === "candidate") throw new Error("unsupported candidate");
+        throw new Error("unsupported source patch hook must be skipped");
+      },
+      run: async (argv) => {
+        current = installation(argv.includes("update") ? "0.81.0" : "0.80.7");
+        return result();
+      },
+    });
+
+    expect(update).toMatchObject({
+      ok: false,
+      rolledBack: true,
+      currentVersion: "0.80.7",
+    });
+    expect(phases).toEqual(["preflight:0.80.7", "candidate:0.81.0"]);
   });
 
   test("does not reinstall when update fails without changing installation", async () => {
@@ -182,6 +422,74 @@ describe("safe pi updater", () => {
     expect(calls).toEqual(["update", "rollback"]);
   });
 
+  test("reapplies the previous sticky patch after an unsupported candidate rollback", async () => {
+    const temp = await paths();
+    let current = installation("0.80.7");
+    const patchCalls: string[] = [];
+    const update = await updatePiSafely({
+      ...temp,
+      checkCompatibility: async () => compatible(current),
+      discover: async () => current,
+      applyPatches: async (candidate) => {
+        patchCalls.push(candidate.packageVersion);
+        if (candidate.packageVersion === "0.81.0") {
+          throw new Error("no sticky patch for candidate");
+        }
+        return true;
+      },
+      run: async (argv) => {
+        current = installation(argv.includes("update") ? "0.81.0" : "0.80.7");
+        return result();
+      },
+    });
+
+    expect(update).toMatchObject({
+      ok: false,
+      rolledBack: true,
+      currentVersion: "0.80.7",
+    });
+    expect(patchCalls).toEqual(["0.80.7", "0.81.0", "0.80.7"]);
+  });
+
+  test("keeps the journal when a rollback dependency cohort drifts", async () => {
+    const temp = await paths();
+    let current = installationWithTui("0.80.7", "0.80.7");
+    const update = await updatePiSafely({
+      ...temp,
+      checkCompatibility: async () => compatible(current),
+      discover: async () => current,
+      applyPatches: async (_candidate, phase) => {
+        if (phase === "candidate") throw new Error("candidate incompatible");
+        return true;
+      },
+      run: async (argv) => {
+        current = argv.includes("update")
+          ? installationWithTui("0.81.0", "0.81.0")
+          : installationWithTui("0.80.7", "0.80.8");
+        return result();
+      },
+    });
+
+    expect(update).toMatchObject({ ok: false, rolledBack: false });
+    expect(update.message).toContain("package cohort does not match preflight");
+    expect(update.manualRecoveryArgv).toContain("--force");
+    expect(update.manualRecoveryArgv).toContain(
+      "@earendil-works/pi-tui@0.80.7",
+    );
+    const journal = await readFile(temp.journalPath, "utf8");
+    expect(journal).toContain("pi-harness/update-recovery");
+    await writeFile(
+      temp.journalPath,
+      journal.replace(
+        "@earendil-works/pi-tui@0.80.7",
+        "@earendil-works/pi-tui@0.80.8",
+      ),
+    );
+    await expect(
+      assertNoPendingUpdateRecovery(temp.journalPath),
+    ).rejects.toThrow("invalid pi update recovery journal");
+  });
+
   test("preserves a manual recovery journal when rollback fails", async () => {
     const temp = await paths();
     let current = installation("0.80.7");
@@ -204,8 +512,91 @@ describe("safe pi updater", () => {
 
     expect(update).toMatchObject({ ok: false, rolledBack: false });
     expect(update.manualRecoveryArgv?.join(" ")).toContain("0.80.7");
+    expect(update.message).toContain("rerun `bun run update:pi`");
     const journal = await readFile(temp.journalPath, "utf8");
     expect(journal).toContain("pi-harness/update-recovery");
+    await expect(
+      assertNoPendingUpdateRecovery(temp.journalPath),
+    ).rejects.toThrow("run `bun run update:pi`");
+  });
+
+  test("restores a legacy unsupported-source journal without patching", async () => {
+    const temp = await paths();
+    let current = installation("0.80.7");
+    let rollbackAvailable = false;
+    const phases: string[] = [];
+    const dependencies = {
+      ...temp,
+      checkCompatibility: async () => compatible(current),
+      discover: async () => current,
+      applyPatches: async (candidate: PiInstallation, phase: string) => {
+        phases.push(`${phase}:${candidate.packageVersion}`);
+        if (phase === "preflight") return false;
+        if (phase === "candidate") throw new Error("candidate incompatible");
+        throw new Error("legacy unsupported source must not invoke patching");
+      },
+      run: async (argv: string[]) => {
+        if (argv.includes("update")) {
+          current = installation("0.81.0");
+          return result();
+        }
+        if (!rollbackAvailable) return result(1, "rollback interrupted");
+        current = installation("0.80.7");
+        return result();
+      },
+    };
+
+    const failed = await updatePiSafely(dependencies);
+    expect(failed.manualRecoveryArgv).toBeDefined();
+    const journal = await readFile(temp.journalPath, "utf8");
+    const legacyJournal = toLegacyJournal(journal);
+    expect(legacyJournal).not.toBe(journal);
+    await writeFile(temp.journalPath, legacyJournal);
+
+    rollbackAvailable = true;
+    const recovered = await updatePiSafely(dependencies);
+    expect(recovered).toMatchObject({ ok: false, rolledBack: true });
+    expect(current.packageVersion).toBe("0.80.7");
+    expect(phases).toEqual(["preflight:0.80.7", "candidate:0.81.0"]);
+  });
+
+  test("clears an already-restored legacy journal without registry access", async () => {
+    const temp = await paths();
+    let current = installation("0.80.7");
+    let rollbackCalls = 0;
+    const phases: string[] = [];
+    const dependencies = {
+      ...temp,
+      checkCompatibility: async () => compatible(current),
+      discover: async () => current,
+      applyPatches: async (candidate: PiInstallation, phase: string) => {
+        phases.push(`${phase}:${candidate.packageVersion}`);
+        if (phase === "preflight") return false;
+        if (phase === "candidate") throw new Error("candidate incompatible");
+        throw new Error("legacy recovery must not invoke patching");
+      },
+      run: async (argv: string[]) => {
+        if (argv.includes("update")) {
+          current = installation("0.81.0");
+          return result();
+        }
+        rollbackCalls += 1;
+        return result(1, "registry unavailable");
+      },
+    };
+
+    const failed = await updatePiSafely(dependencies);
+    expect(failed.manualRecoveryArgv).toBeDefined();
+    const journal = await readFile(temp.journalPath, "utf8");
+    await writeFile(temp.journalPath, toLegacyJournal(journal));
+    current = installation("0.80.7");
+    const callsBeforeRecovery = rollbackCalls;
+
+    const recovered = await updatePiSafely(dependencies);
+    expect(recovered).toMatchObject({ ok: false, rolledBack: true });
+    expect(recovered.message).toContain("already-restored");
+    expect(rollbackCalls).toBe(callsBeforeRecovery);
+    expect(phases).toEqual(["preflight:0.80.7", "candidate:0.81.0"]);
   });
 
   test("clears an unfinished journal when restoration already completed", async () => {
@@ -220,6 +611,7 @@ describe("safe pi updater", () => {
         return compatible(current);
       },
       discover: async () => current,
+      applyPatches: async () => true,
       run: async (argv: string[]) => {
         calls += 1;
         if (argv.includes("update")) {
@@ -271,6 +663,124 @@ describe("safe pi updater", () => {
     expect(current.packageVersion).toBe("0.80.7");
   });
 
+  test("never releases a replacement lock owned by another generation", async () => {
+    const temp = await paths();
+    const lock = await acquireUpdateLock(temp.lockPath, process.pid);
+    await rm(temp.lockPath);
+    await writeFile(temp.lockPath, `${process.pid}:replacement\n`);
+
+    await expect(lock.release()).rejects.toThrow("ownership changed");
+    expect(await readFile(temp.lockPath, "utf8")).toBe(
+      `${process.pid}:replacement\n`,
+    );
+  });
+
+  test("publishes only a complete owner token after staging succeeds", async () => {
+    const temp = await paths();
+    let publishPath = "";
+    let token = "";
+
+    await expect(
+      acquireUpdateLock(temp.lockPath, 999_999_997, {
+        afterPublishPrepared: ({
+          publishPath: preparedPath,
+          token: preparedToken,
+        }) => {
+          publishPath = preparedPath;
+          token = preparedToken;
+          throw new Error("stop before atomic publication");
+        },
+      }),
+    ).rejects.toThrow("stop before atomic publication");
+
+    await expect(readFile(temp.lockPath, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    expect(await readFile(publishPath, "utf8")).toBe(token);
+
+    const lock = await acquireUpdateLock(temp.lockPath, process.pid);
+    await lock.release();
+  });
+
+  test("keeps the published lock when staging cleanup follows publication", async () => {
+    const temp = await paths();
+    let publishPath = "";
+    let token = "";
+
+    await expect(
+      acquireUpdateLock(temp.lockPath, 999_999_996, {
+        afterPublished: ({
+          publishPath: preparedPath,
+          token: preparedToken,
+        }) => {
+          publishPath = preparedPath;
+          token = preparedToken;
+          throw new Error("stop after atomic publication");
+        },
+      }),
+    ).rejects.toThrow("stop after atomic publication");
+
+    expect(await readFile(temp.lockPath, "utf8")).toBe(token);
+    await expect(readFile(publishPath, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+
+    const recovered = await acquireUpdateLock(temp.lockPath, process.pid);
+    await recovered.release();
+  });
+
+  test("coalesces concurrent releases before another generation can acquire", async () => {
+    const temp = await paths();
+    const lock = await acquireUpdateLock(temp.lockPath, process.pid);
+
+    const firstRelease = lock.release();
+    const secondRelease = lock.release();
+    expect(firstRelease).toBe(secondRelease);
+    await Promise.all([firstRelease, secondRelease]);
+
+    const next = await acquireUpdateLock(temp.lockPath, process.pid);
+    await next.release();
+  });
+
+  test("reclaims an orphaned stale-lock recovery generation", async () => {
+    const temp = await paths();
+    const stale = "999999999:stale-main\n";
+    await writeFile(temp.lockPath, stale);
+    const generation = createHash("sha256")
+      .update(stale)
+      .digest("hex")
+      .slice(0, 16);
+    const recoveryPath = `${temp.lockPath}.recovery-${generation}`;
+    await writeFile(recoveryPath, "999999998:stale-recovery\n");
+
+    const lock = await acquireUpdateLock(temp.lockPath, process.pid);
+    await lock.release();
+    await expect(readFile(recoveryPath, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  test("fails closed when stale-lock recovery exceeds its depth limit", async () => {
+    const temp = await paths();
+    let stalePath = temp.lockPath;
+    for (let depth = 0; depth <= 8; depth += 1) {
+      const raw = `${999_999_900 + depth}:stale-${depth}\n`;
+      await writeFile(stalePath, raw);
+      const generation = createHash("sha256")
+        .update(raw)
+        .digest("hex")
+        .slice(0, 16);
+      stalePath =
+        depth === 0
+          ? `${temp.lockPath}.recovery-${generation}`
+          : `${temp.lockPath}.recovery-${depth + 1}-${generation}`;
+    }
+
+    await expect(
+      acquireUpdateLock(temp.lockPath, process.pid),
+    ).rejects.toThrow("recovery nesting exceeds the safety limit");
+  });
+
   test("rejects a concurrent lock and reclaims a stale lock", async () => {
     const temp = await paths();
     const lock = await acquireUpdateLock(temp.lockPath, process.pid);
@@ -280,7 +790,16 @@ describe("safe pi updater", () => {
     await lock.release();
 
     await writeFile(temp.lockPath, "999999999\n");
-    const stale = await acquireUpdateLock(temp.lockPath, process.pid);
-    await stale.release();
+    const contenders = await Promise.allSettled([
+      acquireUpdateLock(temp.lockPath, process.pid),
+      acquireUpdateLock(temp.lockPath, process.pid),
+    ]);
+    let acquired = 0;
+    for (const contender of contenders) {
+      if (contender.status !== "fulfilled") continue;
+      acquired += 1;
+      await contender.value.release();
+    }
+    expect(acquired).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

- align Pi compatibility dependencies and fixtures with global Pi 0.83.0
- keep conversation history in an internal viewport while pinning the editor, widgets, and footer to the terminal bottom
- honor configured paging keybindings, preserve scroll anchors across streaming and resize, and keep overlays/selectors in control
- ship exact-version Bun patches for pi-tui and pi-coding-agent without committing node_modules
- add transactional global patch application, cache hardlink detachment, exact cohort rollback, recovery journals, and ownership-safe locking

## Validation

- `bun test`: 2036 pass, 2 gated skip, 0 fail
- `bun run tsc`
- `bun run lint`: 0 errors, 9 pre-existing warnings
- `bun run check:pi-baseline`
- `bun run check:pi-compat`
- `bun run check:pi-version`
- `bun run check:pi-schemas`
- `bun run check:pi-rules`
- transactional global patch applicator reports both packages already applied
- Bun versioned package caches remain pristine
- final two-track Codex review found no actionable P1/P2 issues

## Related

- https://github.com/earendil-works/pi/issues/6071